### PR TITLE
Update bin representation.

### DIFF
--- a/pyrad/graphs/mipnerf.py
+++ b/pyrad/graphs/mipnerf.py
@@ -105,7 +105,7 @@ class MipNerfGraph(Graph):
             weights=weights_coarse,
         )
         accumulation_coarse = self.renderer_accumulation(weights_coarse)
-        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform.bins)
+        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform)
 
         # pdf sampling
         ray_samples_pdf = self.sampler_pdf(ray_bundle, ray_samples_uniform, weights_coarse)
@@ -118,7 +118,7 @@ class MipNerfGraph(Graph):
             weights=weights_fine,
         )
         accumulation_fine = self.renderer_accumulation(weights_fine)
-        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf.bins)
+        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf)
 
         outputs = {
             "rgb_coarse": rgb_coarse,

--- a/pyrad/graphs/nerfw.py
+++ b/pyrad/graphs/nerfw.py
@@ -111,7 +111,7 @@ class NerfWGraph(Graph):
             rgb=field_outputs_coarse[FieldHeadNames.RGB],
             weights=weights_coarse,
         )
-        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform.bins)
+        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform)
 
         # pdf sampling
         ray_samples_pdf = self.sampler_pdf(ray_bundle, ray_samples_uniform, weights_coarse)
@@ -145,8 +145,8 @@ class NerfWGraph(Graph):
         density_transient = field_outputs_fine[FieldHeadNames.TRANSIENT_DENSITY]
 
         # depth
-        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf.bins)
-        depth_fine_static = self.renderer_depth(weights_fine_static, ray_samples_pdf.bins)
+        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf)
+        depth_fine_static = self.renderer_depth(weights_fine_static, ray_samples_pdf)
 
         # uncertainty
         uncertainty = self.renderer_uncertainty(field_outputs_fine[FieldHeadNames.UNCERTAINTY], weights_fine_transient)

--- a/pyrad/graphs/semantic_nerf.py
+++ b/pyrad/graphs/semantic_nerf.py
@@ -135,7 +135,7 @@ class SemanticNerfGraph(NeRFGraph):
             weights=weights_coarse,
         )
         accumulation_coarse = self.renderer_accumulation(weights_coarse)
-        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform.bins)
+        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform)
 
         # pdf sampling
         ray_samples_pdf = self.sampler_pdf(ray_bundle, ray_samples_uniform, weights_coarse)
@@ -148,7 +148,7 @@ class SemanticNerfGraph(NeRFGraph):
             weights=weights_fine,
         )
         accumulation_fine = self.renderer_accumulation(weights_fine)
-        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf.bins)
+        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf)
         semantic_fine = self.renderer_semantic(field_outputs_fine[FieldHeadNames.SEMANTICS], weights=weights_fine)
 
         outputs = {

--- a/pyrad/graphs/vanilla_nerf.py
+++ b/pyrad/graphs/vanilla_nerf.py
@@ -114,7 +114,7 @@ class NeRFGraph(Graph):
             weights=weights_coarse,
         )
         accumulation_coarse = self.renderer_accumulation(weights_coarse)
-        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform.bins)
+        depth_coarse = self.renderer_depth(weights_coarse, ray_samples_uniform)
 
         # pdf sampling
         ray_samples_pdf = self.sampler_pdf(ray_bundle, ray_samples_uniform, weights_coarse)
@@ -127,7 +127,7 @@ class NeRFGraph(Graph):
             weights=weights_fine,
         )
         accumulation_fine = self.renderer_accumulation(weights_fine)
-        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf.bins)
+        depth_fine = self.renderer_depth(weights_fine, ray_samples_pdf)
 
         outputs = {
             "rgb_coarse": rgb_coarse,

--- a/tests/renderers/test_renderers.py
+++ b/tests/renderers/test_renderers.py
@@ -3,6 +3,7 @@ Test renderers
 """
 import pytest
 import torch
+from pyrad.cameras.rays import Frustums, RaySamples
 
 from pyrad.renderers import renderers
 
@@ -62,12 +63,18 @@ def test_depth_renderer():
     weights = torch.ones((3, num_samples))
     weights /= torch.sum(weights, axis=-1, keepdim=True)
 
-    bins = torch.linspace(0, 100, num_samples + 1)
-    bins = torch.stack([bins, bins, bins], dim=0)
+    ray_samples = RaySamples(
+        frustums=Frustums.get_mock_frustum(),
+        camera_indices=torch.ones((num_samples)),
+        valid_mask=torch.ones((num_samples)),
+        bin_starts=torch.linspace(0, 100, num_samples),
+        bin_ends=torch.linspace(1, 101, num_samples),
+        deltas=torch.ones((num_samples)),
+    )
 
     depth_renderer = renderers.DepthRenderer()
 
-    depth = depth_renderer(weights=weights, bins=bins)
+    depth = depth_renderer(weights=weights, ray_samples=ray_samples)
     assert torch.min(depth) > 0
 
 


### PR DESCRIPTION
Treat bin start and ends separately. This allows one to treat frustum as a pointwise sample.
Treating frustums as points is a bit hacky.