### PR TITLE
speedup PDFSampler impl.

### DIFF
--- a/pyrad/graphs/modules/ray_sampler.py
+++ b/pyrad/graphs/modules/ray_sampler.py
@@ -17,7 +17,7 @@ Collection of sampling strategies
 """
 
 from abc import abstractmethod
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 
 import torch
 from torch import nn
@@ -304,35 +304,7 @@ class PDFSampler(Sampler):
             # Uniform samples between 0 and 1
             u = torch.linspace(0.0, 1.0, steps=num_bins, device=cdf.device)
             u = u.expand(size=(*cdf.shape[:-1], num_bins))
-
-        # mask = u[..., None, :] >= cdf[..., :, None]  # [num_samples, num_orig_bins, num_bins]
-
-        # # Uses same interval trick as mip-NeRF
-        # def find_interval(
-        #     mask: TensorType[..., "num_orig_bins", "num_bins"], x: TensorType[..., "num_orig_bins"]
-        # ) -> Tuple[TensorType[..., "num_bins"], TensorType[..., "num_bins"]]:
-        #     """Find intervals based on cdf mask.
-
-        #          Mask                x              x_start         x_end
-        #        T T T T F      [x0 x1 x2 x3 x4]   [x0 x2 x3 x3]   [x1 x3 x4 x4]
-        #        T T T T F
-        #        T T T F F
-        #        T F F F F
-
-        #        Where the number of rows correspond to the target number of bins. The number of columns
-        #        correspond to the input number of bins
-
-        #     Args:
-        #         mask (TensorType[..., "num_orig_bins", "num_bins"]): PDF represented as a boolean mask.
-        #         x (TensorType[..., "num_original_bins"]): Probe to calculate intervals for.
-
-        #     Returns:
-        #         Tuple[TensorType[..., "num_bins"], TensorType[..., "num_bins"]]: (x_start, x_end)
-        #     """
-
-        #     x_start = torch.max(torch.where(mask, x[..., None], x[..., :1, None]), -2)[0]
-        #     x_end = torch.min(torch.where(~mask, x[..., None], x[..., -1:, None]), -2)[0]
-        #     return x_start, x_end
+        u = u.contiguous()
 
         # Force bins to not have a gap between them. Kinda hacky, should reconsider.
         existing_bins = torch.cat(
@@ -344,11 +316,6 @@ class PDFSampler(Sampler):
             axis=-1,
         )
 
-        # _bins_g0, _bins_g1 = find_interval(mask, existing_bins)
-        # _cdf_g0, _cdf_g1 = find_interval(mask, cdf)
-
-        # ~7x faster than `find_interval`
-        u = u.contiguous()
         inds = torch.searchsorted(cdf, u, side="right")
         below = torch.clamp(inds - 1, 0, num_bins - 1)
         above = torch.clamp(inds, 0, num_bins - 1)
@@ -356,8 +323,6 @@ class PDFSampler(Sampler):
         bins_g0 = torch.gather(existing_bins, -1, below)
         cdf_g1 = torch.gather(cdf, -1, above)
         bins_g1 = torch.gather(existing_bins, -1, above)
-        # assert torch.isclose(_bins_g0, bins_g0).all()
-        # assert torch.isclose(_cdf_g1, cdf_g1).all()
 
         t = torch.clip(torch.nan_to_num((u - cdf_g0) / (cdf_g1 - cdf_g0), 0), 0, 1)
         bins = bins_g0 + t * (bins_g1 - bins_g0)


### PR DESCRIPTION
The `find_interval` function in `PDFSampler` can be replaced by `torch.searchsorted` (supported from torch 1.6.0), resulting 7x faster for this line in `instant_ngp.py`:
```
 ray_samples_pdf = self.sampler_pdf(ray_bundle, ray_samples_uniform, weights_uniform)
```

Before:
<img width="1386" alt="Screen Shot 2022-07-11 at 10 47 41 PM" src="https://user-images.githubusercontent.com/10151885/178424225-6b36ec4d-3463-4bbb-8ee8-6235a51578c3.png">

After:
<img width="1394" alt="Screen Shot 2022-07-11 at 11 17 26 PM" src="https://user-images.githubusercontent.com/10151885/178424236-af755afb-edb5-4643-9a52-089093e46af9.png">

Numeric check is done on this new impl. to match with the old one. 