### PR TITLE
update tensordataclass to decorator

### DIFF
--- a/pyrad/cameras/rays.py
+++ b/pyrad/cameras/rays.py
@@ -16,7 +16,6 @@
 Some ray datastructures.
 """
 import random
-from dataclasses import dataclass
 from typing import Optional
 
 import torch
@@ -24,11 +23,12 @@ from torchtyping import TensorType
 
 from pyrad.utils.math import Gaussians, conical_frustum_to_gaussian
 from pyrad.utils.misc import is_not_none
-from pyrad.utils.tensor_dataclass import TensorDataclass
+from pyrad.utils.tensor_dataclass import tensordataclass
 
 
-@dataclass
-class Frustums(TensorDataclass):
+# pylint: disable=no-member,not-an-iterable
+@tensordataclass
+class Frustums:
     """Describes region of space as a frustum.
 
     Args:
@@ -85,8 +85,9 @@ class Frustums(TensorDataclass):
         )
 
 
-@dataclass
-class RaySamples(TensorDataclass):
+# pylint: disable=no-member,not-an-iterable
+@tensordataclass
+class RaySamples:
     """Samples along a ray
 
     Args:
@@ -146,8 +147,9 @@ class RaySamples(TensorDataclass):
         return self
 
 
-@dataclass
-class RayBundle(TensorDataclass):
+# pylint: disable=no-member,not-an-iterable
+@tensordataclass
+class RayBundle:
     """A bundle of ray parameters.
 
     Args:

--- a/pyrad/fields/base.py
+++ b/pyrad/fields/base.py
@@ -19,12 +19,12 @@ Base class for the graphs.
 from abc import abstractmethod
 from typing import Dict, Optional, Tuple
 
-from torch import nn
 import torch
+from torch import nn
 from torchtyping import TensorType
-from pyrad.fields.modules.field_heads import FieldHeadNames
 
 from pyrad.cameras.rays import Frustums, RaySamples
+from pyrad.fields.modules.field_heads import FieldHeadNames
 from pyrad.utils.misc import is_not_none
 
 
@@ -82,7 +82,8 @@ class Field(nn.Module):
         if is_not_none(valid_mask):
             # Hacky handling of empty masks. Tests on a single ray but doesn't use results
             if not valid_mask.any():
-                ray_samples = RaySamples(frustums=Frustums.get_mock_frustum().to(valid_mask.device))
+                frustums = Frustums.get_mock_frustum(device=valid_mask.device)
+                ray_samples = RaySamples(frustums)
             else:
                 ray_samples = ray_samples.apply_masks()
             density_masked, density_embedding_masked = self.get_density(ray_samples)

--- a/pyrad/utils/tensor_dataclass.py
+++ b/pyrad/utils/tensor_dataclass.py
@@ -14,80 +14,125 @@
 
 """Tensor dataclass"""
 
-import dataclasses
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import torch
+from torchtyping import TensorType
+
+_IDENTIFER = "__tensordataclass__"
 
 
-class TensorDataclass:
-    """Data class of tensors with the same size batch. Allows indexing and standard tensor ops.
-    Fields that are not Tensors will not be batched unless they are also a TensorDataclass.
+def is_tensordataclass(x):
+    """Checks whether a data is a TensorDataclass."""
+    return hasattr(x.__class__, _IDENTIFER)
+
+
+# pylint: disable=unused-variable,eval-used,too-many-statements
+def tensordataclass(cls):
+    """Decorator that warps a cls into TensorDataclass. In TensorDataclass, all the tensors have the
+    same size batch. Allows indexing and standard tensor ops. Fields that are not Tensors will not
+    be batched unless they are also a TensorDataclass.
 
     Example:
-
     .. code-block:: python
-
-        @dataclass
-        class TestTensorDataclass(TensorDataclass):
+        # pylint: disable=no-member,not-an-iterable
+        @tensordataclass
+        class TestTensorDataclass():
             a: torch.Tensor
             b: torch.Tensor
             c: torch.Tensor = None
-
         # Create a new tensor dataclass with batch size of [2,3,4]
         test = TestTensorDataclass(a=torch.ones((2, 3, 4, 2)), b=torch.ones((4, 3)))
-
         test.shape  # [2, 3, 4]
         test.a.shape  # [2, 3, 4, 2]
         test.b.shape  # [2, 3, 4, 3]
-
         test.reshape((6,4)).shape  # [6, 4]
         test.flatten().shape  # [24,]
-
         test[..., 0].shape  # [2, 3]
         test[:, 0, :].shape  # [2, 4]
     """
 
-    _shape: tuple
+    field_keys = list(cls.__annotations__.keys())
+    # _FIELD_TYPES = list(cls.__annotations__.values())
+
+    def __init__(self, *args, **kwargs) -> None:
+        # Quietly pop out and save these arguments from kwargs.
+        self._shape: Tuple[int] = kwargs.pop("_shape", None)
+        self._packed_info: TensorType["num_chunks", 3] = kwargs.pop("_packed_info", None)
+
+        # check the remaining arguments
+        n_params = len(args) + len(kwargs.values())
+        n_params_max = len(field_keys)
+        assert n_params <= n_params_max, (
+            f"__init__() takes from 1 to {n_params_max + 1} positional arguments" f" but {n_params + 1} were given"
+        )
+
+        # collect attributes
+        init_params = {}
+        for i, value in enumerate(args):
+            key = field_keys[i]
+            init_params.update({key: value})
+        for key, value in kwargs.items():
+            assert key not in init_params, f"__init__() got multiple values for argument '{key}'"
+            assert key in field_keys, f"__init__() got an unexpected keyword argument '{key}'"
+            init_params.update({key: value})
+        for key in field_keys:
+            if key in init_params:
+                continue
+            assert hasattr(self, key), f"__init__() missing 1 required positional argument: '{key}'"
+            value = getattr(self, key)
+            init_params.update({key: value})
+
+        # set attributes
+        for i, (key, value) in enumerate(init_params.items()):
+            # TODO(ruilongli): figure out a way to check type for TensorType
+            # assert value is None or isinstance(value, _FIELD_TYPES[i]), (
+            #     f"__init__() got a wrong type {type(value)} v.s. {_FIELD_TYPES[i]}" f" for argument `{key}`"
+            # )
+            setattr(self, key, value)
+
+        self.__post_init__()
 
     def __post_init__(self) -> None:
-        if not dataclasses.is_dataclass(self):
-            raise TypeError("TensorDataclass must be a dataclass")
+        if self.is_packed():
+            # Do nothing for a packed tensor
+            return
 
-        field_names = [f.name for f in dataclasses.fields(self)]
         batch_shapes = []
-        for f in field_names:
+        for f in field_keys:
             v = self.__getattribute__(f)
             if v is not None:
                 if isinstance(v, torch.Tensor):
                     batch_shapes.append(v.shape[:-1])
-                elif isinstance(v, TensorDataclass):
+                elif is_tensordataclass(v):
                     batch_shapes.append(v.shape)
         if len(batch_shapes) == 0:
             raise ValueError("TensorDataclass must have at least one tensor")
         batch_shape = torch.broadcast_shapes(*batch_shapes)
 
-        for f in field_names:
+        for f in field_keys:
             v = self.__getattribute__(f)
             if v is not None:
                 if isinstance(v, torch.Tensor):
                     self.__setattr__(f, v.broadcast_to((*batch_shape, v.shape[-1])))
-                elif isinstance(v, TensorDataclass):
+                elif is_tensordataclass(v):
                     self.__setattr__(f, v.broadcast_to(batch_shape))
 
         self.__setattr__("_shape", batch_shape)
 
-    def __getitem__(self, indices) -> "TensorDataclass":
+    def __getitem__(self, indices) -> cls:
+        if self.is_packed():
+            raise IndexError("Packed TensorDataClass can not be indexed!")
         if isinstance(indices, torch.Tensor):
-            return self._apply_fn_to_fields(lambda x: x[indices])
+            return self.apply_fn_to_fields(lambda x: x[indices])
         if isinstance(indices, (int, slice)):
             indices = (indices,)
         tensor_fn = lambda x: x[indices + (slice(None),)]
         dataclass_fn = lambda x: x[indices]
-        return self._apply_fn_to_fields(tensor_fn, dataclass_fn)
+        return self.apply_fn_to_fields(tensor_fn, dataclass_fn)
 
-    def __setitem__(self, indices, value) -> "TensorDataclass":
+    def __setitem__(self, indices, value) -> cls:
         raise RuntimeError("Index assignment is not supported for TensorDataclass")
 
     def __len__(self) -> int:
@@ -104,21 +149,24 @@ class TensorDataclass:
     @property
     def shape(self) -> tuple:
         """Returns the batch shape of the tensor dataclass."""
-        return self._shape
+        shape = self.__getattribute__("_shape")
+        if shape is None:
+            raise RuntimeError("Packed TensorDataClass does not have a shape defined!")
+        return shape
 
     @property
     def size(self) -> int:
         """Returns the number of elements in the tensor dataclass batch dimension."""
-        if len(self._shape) == 0:
+        if len(self.shape) == 0:
             return 1
-        return int(np.prod(self._shape))
+        return int(np.prod(self.shape))
 
     @property
     def ndim(self) -> int:
         """Returns the number of dimensions of the tensor dataclass."""
-        return len(self._shape)
+        return len(self.shape)
 
-    def reshape(self, shape: Tuple[int, ...]) -> "TensorDataclass":
+    def reshape(self, shape: Tuple[int, ...]) -> cls:
         """Returns a new TensorDataclass with the same data but with a new shape.
 
         Args:
@@ -127,21 +175,25 @@ class TensorDataclass:
         Returns:
             TensorDataclass: A new TensorDataclass with the same data but with a new shape.
         """
+        if self.is_packed():
+            raise RuntimeError("Packed TensorDataclass can not be reshaped!")
         if isinstance(shape, int):
             shape = (shape,)
         tensor_fn = lambda x: x.reshape((*shape, x.shape[-1]))
         dataclass_fn = lambda x: x.reshape(shape)
-        return self._apply_fn_to_fields(tensor_fn, dataclass_fn)
+        return self.apply_fn_to_fields(tensor_fn, dataclass_fn)
 
-    def flatten(self) -> "TensorDataclass":
+    def flatten(self) -> cls:
         """Returns a new TensorDataclass with flattened batch dimensions
 
         Returns:
             TensorDataclass: A new TensorDataclass with the same data but with a new shape.
         """
+        if self.is_packed():
+            raise RuntimeError("Packed TensorDataclass can not be flatten!")
         return self.reshape((-1,))
 
-    def broadcast_to(self, shape: Union[torch.Size, Tuple[int]]) -> "TensorDataclass":
+    def broadcast_to(self, shape: Union[torch.Size, Tuple[int]]) -> cls:
         """Returns a new TensorDataclass broadcast to new shape.
 
         Args:
@@ -150,9 +202,11 @@ class TensorDataclass:
         Returns:
             TensorDataclass: A new TensorDataclass with the same data but with a new shape.
         """
-        return self._apply_fn_to_fields(lambda x: x.broadcast_to((*shape, x.shape[-1])))
+        if self.is_packed():
+            raise RuntimeError("Packed TensorDataclass can not be broadcasted!")
+        return self.apply_fn_to_fields(lambda x: x.broadcast_to((*shape, x.shape[-1])))
 
-    def to(self, device) -> "TensorDataclass":
+    def to(self, device) -> cls:
         """Returns a new TensorDataclass with the same data but on the specified device.
 
         Args:
@@ -161,27 +215,66 @@ class TensorDataclass:
         Returns:
             TensorDataclass: A new TensorDataclass with the same data but on the specified device.
         """
-        return self._apply_fn_to_fields(lambda x: x.to(device))
+        return self.apply_fn_to_fields(lambda x: x.to(device))
 
-    def _apply_fn_to_fields(self, fn: callable, dataclass_fn: callable = None) -> "TensorDataclass":
+    def apply_fn_to_fields(
+        self,
+        fn: callable,
+        dataclass_fn: callable = None,
+        exclude_fields: List[str] = None,
+        **kwargs,
+    ) -> cls:
         """Applies a function to all fields of the tensor dataclass.
 
         Args:
             fn (callable): The function to apply to tensor fields.
             dataclass_fn (callable): The function to apply to TensorDataclass fields. Else use fn.
+            exclude_fields (List[str]): The fields to be excluded from calling fn and dataclass_fn.
+            **kwargs: Additional arguments to initialize the new TensorDataclass.
 
         Returns:
-            TensorDataclass: A new TensorDataclass with the same data but with a new shape.
+            cls: A new class with the same data but with a new shape.
         """
+        if exclude_fields is None:
+            exclude_fields = []
 
-        field_names = [f.name for f in dataclasses.fields(self)]
+        field_names = [f for f in field_keys if f not in exclude_fields]
         new_fields = {}
         for f in field_names:
             v = self.__getattribute__(f)
             if v is not None:
-                if isinstance(v, TensorDataclass) and dataclass_fn is not None:
+                if is_tensordataclass(v) and dataclass_fn is not None:
                     new_fields[f] = dataclass_fn(v)
-                elif isinstance(v, (torch.Tensor, TensorDataclass)):
+                elif isinstance(v, torch.Tensor) or is_tensordataclass(v):
                     new_fields[f] = fn(v)
+        new_fields.update(kwargs)
 
-        return dataclasses.replace(self, **new_fields)
+        return cls(**new_fields)
+
+    def is_packed(self) -> bool:
+        """Returns whether the data are packed."""
+        return self.__getattribute__("_packed_info") is not None
+
+    setattr(cls, _IDENTIFER, {})
+    setattr(cls, "__init__", __init__)
+    # all those attributes below can be overrided.
+    for attr_name in [
+        "__post_init__",
+        "__getitem__",
+        "__setitem__",
+        "__len__",
+        "__bool__",
+        "shape",
+        "size",
+        "ndim",
+        "reshape",
+        "flatten",
+        "broadcast_to",
+        "to",
+        "apply_fn_to_fields",
+        "is_packed",
+    ]:
+        if hasattr(cls, attr_name):
+            continue
+        setattr(cls, attr_name, eval(attr_name))
+    return cls

--- a/tests/utils/test_tensor_dataclass.py
+++ b/tests/utils/test_tensor_dataclass.py
@@ -1,22 +1,23 @@
 """
 Test tensor dataclass
 """
-from dataclasses import dataclass
 import pytest
 import torch
 
-from pyrad.utils.tensor_dataclass import TensorDataclass
+from pyrad.utils.tensor_dataclass import tensordataclass
 
 
-@dataclass
-class TestNestedClass(TensorDataclass):
+# pylint: disable=no-member,not-an-iterable,too-few-public-methods
+@tensordataclass
+class TestNestedClass:
     """Dummy dataclass"""
 
     x: torch.Tensor
 
 
-@dataclass
-class TestTensorDataclass(TensorDataclass):
+# pylint: disable=no-member,not-an-iterable,too-few-public-methods
+@tensordataclass
+class TestTensorDataclass:
     """Dummy dataclass"""
 
     a: torch.Tensor
@@ -27,8 +28,8 @@ class TestTensorDataclass(TensorDataclass):
 def test_init():
     """Test that dataclass is properly initialized"""
 
-    @dataclass
-    class Dummy(TensorDataclass):
+    @tensordataclass
+    class Dummy:
         """Dummy dataclass"""
 
         dummy_vals: torch.Tensor = None


### PR DESCRIPTION
The `@dataclass` together with the old `TensorDataclass` can be replaced with a single decorator `@tensordataclass`.

The benefit is that it is more flexible now to control the `__init__` method which can (quitely) takes in `_packed_info` or `_shape` depends on whether the data is packed or not.

A known downside is that currently there is no way for pylint to recognize the methods created from the decorator, so it will raise lint errors like `no-member` and  `not-an-iterable`. Currently I'm disabling it for each class decorated by `@tensordataclass`.

So the use case change is:
> Old:
```
@dataclass
class Frustums(TensorDataclass):
    ...
```
> New:
```
# pylint: disable=no-member,not-an-iterable
@tensordataclass
class Frustums:
    ...
```