### PR TITLE
run_actions propegate docs error

### DIFF
--- a/scripts/debugging/run_actions.py
+++ b/scripts/debugging/run_actions.py
@@ -1,5 +1,4 @@
 """Simple yaml debugger"""
-import os
 import subprocess
 import sys
 


### PR DESCRIPTION
Fix bug where `run_actions.py` would report success even if doc compilation fails.