### PR TITLE
Fix race condition in viewer

### DIFF
--- a/nerfactory/graphs/base.py
+++ b/nerfactory/graphs/base.py
@@ -208,7 +208,6 @@ class Graph(AbstractGraph):
                 outputs_lists[output_name].append(output)
         for output_name, outputs_list in outputs_lists.items():
             outputs[output_name] = torch.cat(outputs_list).view(image_height, image_width, -1)
-        self.vis_outputs = outputs
         return outputs
 
     def get_outputs_for_camera(self, camera: Camera):

--- a/nerfactory/viewer/server/viewer_utils.py
+++ b/nerfactory/viewer/server/viewer_utils.py
@@ -78,6 +78,7 @@ class RenderThread(threading.Thread):
         self.graph = graph
         self.camera_ray_bundle = camera_ray_bundle
         self.exc = None
+        self.vis_outputs = None
 
     def run(self):
         """run function that renders out images given the current graph and ray bundles.
@@ -93,6 +94,7 @@ class RenderThread(threading.Thread):
 
         if outputs:
             self.graph.process_outputs_as_images(outputs)
+            self.vis_outputs = outputs
 
         self.state.check_done_render = True
         self.state.check_interrupt_vis = False
@@ -356,7 +358,7 @@ class VisualizerState:
             pass
 
         graph.train()
-        outputs = graph.vis_outputs
+        outputs = render_thread.vis_outputs
         if outputs is not None:
             self._send_output_to_viewer(outputs)
 


### PR DESCRIPTION
Due to a race condition, eval images were sometimes sent to the viewer. This would cause a flicker when viewing rgb and a crash when viewing 1D signals.

Fixes #159 