### PR TITLE
fix so that benchmarking load the latest experiment

### DIFF
--- a/scripts/benchmarking/run_benchmark.py
+++ b/scripts/benchmarking/run_benchmark.py
@@ -52,7 +52,7 @@ def _load_hydra_config(hydra_dir: str) -> DictConfig:
     Returns:
         DictConfig: returns the loaded hydra dictionary config
     """
-    basename = os.listdir(hydra_dir)[0]
+    basename = sorted(os.listdir(hydra_dir))[-1]
     hydra_dir = f"{hydra_dir}/{basename}"
     initialize(version_base="1.2", config_path=os.path.join("../../", hydra_dir, ".hydra/"))
     config = compose("config.yaml")


### PR DESCRIPTION
After this fix the benchmark can load from the latest experiment. Before it was random because `os.listdir` is not sorted.

<img width="369" alt="Screen Shot 2022-07-27 at 2 18 40 PM" src="https://user-images.githubusercontent.com/10151885/181384941-52372ffd-6290-4b27-aa58-74373e899837.png">
