### PR TITLE
updating requirements for windows compatibility

### DIFF
--- a/environment/requirements.txt
+++ b/environment/requirements.txt
@@ -23,7 +23,8 @@ pylint==2.13.4
 pytest
 python-socketio
 tensorboard==2.9.0
-torch==1.12.0
+--extra-index-url https://download.pytorch.org/whl/cu113
+torch==1.12.0 
 torchmetrics[image]==0.8.2
 torchtyping
 torchvision==0.13.0


### PR DESCRIPTION
I think functorch 0.2.0 is the only functorch version with windows support, and I needed to update pytorch and torchvision versions to support functorch 0.2.0. Training models seems to work fine for me with these package versions