### PR TITLE
throttling rendering resolution

### DIFF
--- a/nerfactory/viewer/server/viewer_utils.py
+++ b/nerfactory/viewer/server/viewer_utils.py
@@ -312,8 +312,9 @@ class VisualizerState:
         if min_resolution:
             self.min_resolution = min_resolution
 
+        damped_upsacale_factor = 1 if self.res_upscale_factor < 8 else self.res_upscale_factor
         image_height = min(
-            self.min_resolution * self.res_upscale_factor,
+            self.min_resolution * damped_upsacale_factor,
             self.max_resolution,
         )
         intrinsics_matrix, camera_to_world_h = get_intrinsics_matrix_and_camera_to_world_h(


### PR DESCRIPTION
#214 #213 
Problem of flickering comes from 2 competing time conditions:
1. camera update- even with the dampening, there is some latency in camera updates with micro changes in camera position
2. rendering update- rendering happens fast enough such that the resolution increases by the next time a micro change in camera position is registered; this introduces the flickering between lower to higher resolution images. 

Rather than dampening the camera further, the rendering looks better if we just throttle the rendering resolution until all the changes are more settled. 