### PR TITLE
Fix type errors

### DIFF
--- a/nerfactory/cameras/cameras.py
+++ b/nerfactory/cameras/cameras.py
@@ -26,7 +26,6 @@ from torch.nn.functional import normalize
 from torchtyping import TensorType
 
 from nerfactory.cameras.rays import RayBundle
-from nerfactory.utils.misc import is_not_none
 
 
 class Camera:
@@ -315,7 +314,7 @@ class PinholeCamera(Camera):
             "camera_to_world": self.camera_to_world.tolist(),
             "camera_index": self.camera_index,
         }
-        if is_not_none(image):
+        if image is not None:
             image_uint8 = (image * 255).detach().cpu().numpy().astype(np.uint8)
             if resize_shape:
                 image_uint8 = cv2.resize(image_uint8, resize_shape)

--- a/nerfactory/dataloaders/eval.py
+++ b/nerfactory/dataloaders/eval.py
@@ -20,6 +20,7 @@ import random
 from abc import abstractmethod
 from typing import Dict, List, Optional, Tuple, Union
 
+import torch
 from omegaconf import ListConfig
 
 from nerfactory.cameras.cameras import Camera, get_camera
@@ -32,7 +33,13 @@ class EvalDataloader:  # pylint: disable=too-few-public-methods
     """Evaluation dataloader base class"""
 
     def __init__(
-        self, image_dataset: ImageDataset, intrinsics, camera_to_world, num_rays_per_chunk: int, device="cpu", **kwargs
+        self,
+        image_dataset: ImageDataset,
+        intrinsics,
+        camera_to_world,
+        num_rays_per_chunk: int,
+        device: Union[torch.device, str] = "cpu",
+        **kwargs,
     ):
         super().__init__()
         self.image_dataset = image_dataset
@@ -78,7 +85,7 @@ class FixedIndicesEvalDataloader(EvalDataloader):
         camera_to_world,
         num_rays_per_chunk: int,
         image_indices: Optional[Union[List[int], ListConfig]] = None,
-        device="cpu",
+        device: Union[torch.device, str] = "cpu",
         **kwargs,
     ):
         """
@@ -112,7 +119,13 @@ class RandIndicesEvalDataloader(EvalDataloader):
     """Dataloader that returns random images."""
 
     def __init__(
-        self, image_dataset: ImageDataset, intrinsics, camera_to_world, num_rays_per_chunk: int, device="cpu", **kwargs
+        self,
+        image_dataset: ImageDataset,
+        intrinsics,
+        camera_to_world,
+        num_rays_per_chunk: int,
+        device: Union[torch.device, str] = "cpu",
+        **kwargs,
     ):
         super().__init__(image_dataset, intrinsics, camera_to_world, num_rays_per_chunk, device, **kwargs)
         self.count = 0

--- a/nerfactory/fields/density_fields/density_grid.py
+++ b/nerfactory/fields/density_fields/density_grid.py
@@ -77,7 +77,7 @@ class DensityGrid(nn.Module):
         update_every_num_iters (int): How frequently to update the grid values. Defaults to 16.
     """
 
-    density_grid: TensorType["num_cascades", "resolution**3"]
+    density_grid: TensorType["num_cascades", "resolution_cubed"]
     mean_density: TensorType[1]
 
     def __init__(

--- a/nerfactory/models/nerfw.py
+++ b/nerfactory/models/nerfw.py
@@ -118,7 +118,7 @@ class NerfWModel(Model):
 
     def get_outputs(self, ray_bundle: RayBundle):
 
-        if misc.is_not_none(ray_bundle.camera_indices):
+        if ray_bundle.camera_indices is not None:
             # TODO(ethan): remove this check
             assert (
                 torch.max(ray_bundle.camera_indices) < self.num_images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ defineConstant = { DEBUG = true }
 reportMissingImports = true
 reportMissingTypeStubs = false
 reportPrivateImportUsage = false
+reportUndefinedVariable = false
 
 pythonVersion = "3.8"
 pythonPlatform = "Linux"


### PR DESCRIPTION
The latest version of pyright does not play well with TensorType, it throw `reportUndefinedVariable` errors for tensor sizes, ie `TensorType["batch"]` will throw an error on `"batch"`.

The workaround for now is to disable pyright `reportUndefinedVariable`. Undefined variables in the code will still be caught by pylint. 