### PR TITLE
Remove downscaling from dataloading

### DIFF
--- a/docs/tutorials/data/choosing_dataset.md
+++ b/docs/tutorials/data/choosing_dataset.md
@@ -9,12 +9,10 @@ data:
   dataset_inputs_train:
     data_directory: data/instant_ngp/fox
     dataset_format: instant_ngp
-    downscale_factor: 1
     alpha_color: white
   dataset_inputs_eval:
     data_directory: data/instant_ngp/fox
     dataset_format: instant_ngp
-    downscale_factor: 1
     alpha_color: white
 ```
 

--- a/docs/tutorials/data/custom_dataset_format.md
+++ b/docs/tutorials/data/custom_dataset_format.md
@@ -12,7 +12,6 @@ class DatasetInputs:
     """Dataset inputs are used to initialize datasets and the NeRF graph."""
 
     image_filenames: List[str]
-    downscale_factor: int = 1
     intrinsics: torch.tensor = None
     camera_to_world: torch.tensor = None
     mask_filenames: List[str] = None
@@ -26,7 +25,6 @@ class DatasetInputs:
 # See `nerfactory/data/format/instant_ngp.py` for the code.
 def load_instant_ngp_data(
     basedir: str,
-    downscale_factor: int = 1,
     split: str = "train", camera_translation_scalar=0.33
 ) -> DatasetInputs:
     """Returns a DatasetInputs struct."""
@@ -42,7 +40,6 @@ def get_dataset_inputs(
     data_directory: str,
     dataset_format: str,
     split: str,
-    downscale_factor: int = 1,
     alpha_color: Optional[Union[str, list, ListConfig]] = None,
 ) -> DatasetInputs:
     """Makes a call to `load_<dataset_format>_data` and returns a DatasetInputs struct."""

--- a/nerfactory/configs/base.py
+++ b/nerfactory/configs/base.py
@@ -189,7 +189,6 @@ class BlenderDataParserConfig(DataParserConfig):
     data_directory: Path = Path("data/blender/lego")
     scale_factor: float = 1.0
     alpha_color: str = "white"
-    downscale_factor: int = 1
 
 
 @dataclass
@@ -219,7 +218,6 @@ class InstantNGPDataParserConfig(DataParserConfig):
     _target: Type = InstantNGP
     data_directory: Path = Path("data/ours/posterv2")
     scale_factor: float = 1.0
-    downscale_factor: int = 1
     scene_scale: float = 0.33
 
 
@@ -229,7 +227,6 @@ class Record3DDataParserConfig(DataParserConfig):
 
     _target: Type = Record3D
     data_directory: Path = Path("data/record3d/garden")
-    downscale_factor: int = 1
     val_skip: int = 8
     aabb_scale = 4.0
     max_dataset_size: int = 150

--- a/nerfactory/dataloaders/base.py
+++ b/nerfactory/dataloaders/base.py
@@ -253,7 +253,6 @@ class VanillaDataManager(DataManager):  # pylint: disable=abstract-method
         if self.config.image_dataset_type == "rgb":
             self.train_image_dataset = ImageDataset(
                 image_filenames=self.train_datasetinputs.image_filenames,
-                downscale_factor=self.train_datasetinputs.downscale_factor,
                 alpha_color=self.train_datasetinputs.alpha_color,
             )
         elif self.config.image_dataset_type == "panoptic":
@@ -290,7 +289,6 @@ class VanillaDataManager(DataManager):  # pylint: disable=abstract-method
         if self.config.image_dataset_type == "rgb":
             self.eval_image_dataset = ImageDataset(
                 image_filenames=self.eval_datasetinputs.image_filenames,
-                downscale_factor=self.eval_datasetinputs.downscale_factor,
                 alpha_color=self.eval_datasetinputs.alpha_color,
             )
         elif self.config.image_dataset_type == "panoptic":

--- a/nerfactory/dataloaders/structs.py
+++ b/nerfactory/dataloaders/structs.py
@@ -121,7 +121,6 @@ class DatasetInputs:
 
     image_filenames: List[Path]
     cameras: Cameras
-    downscale_factor: int = 1
     mask_filenames: Optional[List[Path]] = None
     depth_filenames: Optional[List[Path]] = None
     scene_bounds: SceneBounds = SceneBounds()

--- a/tests/test_run_train.py
+++ b/tests/test_run_train.py
@@ -25,13 +25,11 @@ def set_reduced_config(config: cfg.Config):
     config.pipeline.data_manager.image_dataset_type = "rgb"
 
     config.pipeline.data_manager.train_dataset = cfg.BlenderDataParserConfig(
-        data_directory=Path("tests/data/lego_test"), downscale_factor=16
+        data_directory=Path("tests/data/lego_test")
     )
     config.pipeline.data_manager.train_num_images_to_sample_from = 1
     config.pipeline.data_manager.train_num_rays_per_batch = 4
-    config.pipeline.data_manager.eval_dataset = cfg.BlenderDataParserConfig(
-        data_directory=Path("tests/data/lego_test"), downscale_factor=16
-    )
+    config.pipeline.data_manager.eval_dataset = cfg.BlenderDataParserConfig(data_directory=Path("tests/data/lego_test"))
 
     # reduce model factors
     config.pipeline.model.num_coarse_samples = 4


### PR DESCRIPTION
Currently we provide the option for the user to specify a downscale factor during training. This is inefficient as the images are downscaled during training during each batch. If downscaling is desired, this should be done as a preprocessing step.

+ Add downscaling options during data preprocessing
+ Remove downscaling from training