### PR TITLE
Bump `dcargs`, base config simplification

### DIFF
--- a/nerfactory/configs/base.py
+++ b/nerfactory/configs/base.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Type
 
+import dcargs
 import torch
 
 from nerfactory.configs.utils import to_immutable_dict
@@ -241,11 +242,15 @@ class Record3DDataParserConfig(DataParserConfig):
 class VanillaDataManagerConfig(InstantiateConfig):
     """Configuration for data manager instantiation"""
 
+    # Note: eval_dataparser is annotated with Fixed[] to prevent dcargs from trying to
+    # convert Optional[InstantiateConfig] into subcommands for choosing between None and
+    # InstantiateConfig.
+
     _target: Type = VanillaDataManager
     train_dataparser: DataParserConfig = BlenderDataParserConfig()
     train_num_rays_per_batch: int = 1024
     train_num_images_to_sample_from: int = -1
-    eval_dataparser: Optional[InstantiateConfig] = None
+    eval_dataparser: dcargs.conf.Fixed[Optional[InstantiateConfig]] = None
     eval_image_indices: Optional[Tuple[int, ...]] = (0,)
     eval_num_rays_per_chunk: int = 4096
 

--- a/nerfactory/configs/utils.py
+++ b/nerfactory/configs/utils.py
@@ -18,38 +18,8 @@ Some utility code for configs.
 
 from __future__ import annotations
 
-import sys
 from dataclasses import field
-from typing import Any, Dict, TypeVar
-
-import dcargs
-
-T = TypeVar("T")
-
-
-def cli_from_base_configs(base_library: Dict[str, T]) -> T:
-    """Populate an instance of `cls`, where the first positional argument is used to
-    select from a library of named base configs. See
-    https://brentyi.github.io/dcargs/examples/06_base_configs/ for more details."""
-
-    # Get base configuration name from the first positional argument.
-    if len(sys.argv) < 2 or sys.argv[1] not in base_library:
-        valid_usages = map(lambda k: f"{sys.argv[0]} {k} --help", base_library.keys())
-        raise SystemExit("usage:\n  " + "\n  ".join(valid_usages))
-
-    # Get base configuration from our library, and use it for default CLI parameters.
-    default_instance = base_library[sys.argv[1]]
-
-    return dcargs.cli(
-        type(default_instance),
-        prog=" ".join(sys.argv[:2]),
-        args=sys.argv[2:],
-        default_instance=default_instance,
-        # `avoid_subparsers` will avoid making a subparser for unions when a default is
-        # provided; in this case, it simplifies our CLI but makes it less expressive.
-        avoid_subparsers=True,
-    )
-
+from typing import Any, Dict
 
 # pylint: disable=import-outside-toplevel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "aiortc==1.3.2",
     "av==9.2.0",
     "black[jupyter]==22.3.0",
-    "dcargs>=0.2.6",
+    "dcargs>=0.3.1",
     "ninja==1.10.2.3",
     "functorch==0.2.1",
     "h5py>=2.9.0",


### PR DESCRIPTION
Takes advantage of some new features in dcargs v0.3.0; the main change is to remove the manual `argv` manipulation for choosing a base configuration.

Instead all of that logic gets replaced with the standard argparse subcommands and a `SubcommandType` definition, which is just a fancy `typing.Union` over the base configs.

Some advantages:
1. Less code!
2. Some more flexibility: `SubcommandType` can be used as an annotation as well. So we could potentially write scripts that look like:
    ```python
    def train(config: SubcommandType, restore_checkpoint: Optional[Path] = None) -> None:
        ...
    ```
    Which might be nice for slimming down the config objects.
4. Tab completion support. A completion script can be generated by running `python scripts/run_train.py --dcargs-print-completion {bash/zsh}`.
    - Some thought still needs to be put into if/how these scripts are installed or documented for nerfactory, but in the meantime I wrote some general instructions for installing completion scripts in the dcargs documentation ([link](https://brentyi.github.io/dcargs/tab_completion/)).
    - Could use some help testing this!


Misc notes:
- @ethanweber `dcargs.conf.FlagConversionOff[bool]` or `dcargs.conf.FlagConversionOff[SomeNestedType]` can now be used if you want to explicitly pass in `True` or `False` for boolean fields.
- @tancik if you accidentally type `--field-name` as `--field_name` it'll now correct that for you automatically.