### PR TITLE
Shorten dataparser subcommand

### DIFF
--- a/nerfactory/configs/base.py
+++ b/nerfactory/configs/base.py
@@ -308,7 +308,7 @@ class Record3DDataParserConfig(DataParserConfig):
     more, images will be sampled approximately evenly. Defaults to 150."""
 
 
-DataParserSubcommand = dcargs.extras.subcommand_type_from_defaults(
+AnnotatedDataParserUnion = dcargs.extras.subcommand_type_from_defaults(
     {
         "nerfactory-data": NerfactoryDataParserConfig(),
         "blender-data": BlenderDataParserConfig(),
@@ -319,6 +319,8 @@ DataParserSubcommand = dcargs.extras.subcommand_type_from_defaults(
     },
     prefix_names=False,
 )
+"""Union over possible dataparser types, annotated with metadata for dcargs. This is the
+same as the vanilla union, but results in shorter subcommand names."""
 
 
 @dataclass
@@ -334,7 +336,7 @@ class VanillaDataManagerConfig(InstantiateConfig):
 
     _target: Type = VanillaDataManager
     """target class to instantiate"""
-    train_dataparser: DataParserSubcommand = BlenderDataParserConfig()
+    train_dataparser: AnnotatedDataParserUnion = BlenderDataParserConfig()
     """specifies the dataparser used to unpack the data"""
     train_num_rays_per_batch: int = 1024
     """number of rays per batch to use per training iteration"""

--- a/scripts/run_train.py
+++ b/scripts/run_train.py
@@ -215,4 +215,5 @@ if __name__ == "__main__":
     # Create a subcommand for each base config.
     SubcommandType = dcargs.extras.subcommand_type_from_defaults(base_configs)
     instantiated_config = dcargs.cli(SubcommandType)
+
     main(config=instantiated_config)


### PR DESCRIPTION
Needed for some autocomplete stuff so just made the change!

Subcommands now look like:
![image](https://user-images.githubusercontent.com/6992947/189988329-e6b0d8f7-bb60-4cf4-97c4-523ec741e50c.png)

And the type automagically resolves to the correct Union:
![image](https://user-images.githubusercontent.com/6992947/189988565-3fe6711f-287d-4e40-b2a4-8c04e1961c37.png)


Resolves #380