### PR TITLE
Add near plane to NGP sampler

### DIFF
--- a/nerfactory/configs/base.py
+++ b/nerfactory/configs/base.py
@@ -407,6 +407,8 @@ class CompoundModelConfig(ModelConfig):
     field_implementation: Literal["torch", "tcnn"] = "tcnn"  # torch, tcnn, ...
     loss_coefficients: Dict[str, float] = to_immutable_dict({"rgb_loss": 1.0})
     num_samples: int = 1024  # instead of course/fine samples
+    cone_angle: float = 0.0
+    near_plane: float = 0.5
 
 
 @dataclass

--- a/nerfactory/models/compound.py
+++ b/nerfactory/models/compound.py
@@ -115,7 +115,9 @@ class CompoundModel(Model):
 
         if self.field is None:
             raise ValueError("populate_fields() must be called before get_outputs")
-        ray_samples, packed_info, t_min, t_max = self.sampler(ray_bundle, self.field.aabb)
+        ray_samples, packed_info, t_min, t_max = self.sampler(
+            ray_bundle, self.field.aabb, cone_angle=self.config.cone_angle, near_plane=self.config.near_plane
+        )
 
         field_outputs = self.field.forward(ray_samples)
 

--- a/nerfactory/models/instant_ngp.py
+++ b/nerfactory/models/instant_ngp.py
@@ -63,6 +63,8 @@ class InstantNGPModelConfig(cfg.ModelConfig):
     """Number of samples in field evaluation. Defaults to 1024,"""
     cone_angle: float = 0.0
     """Should be set to 0.0 for blender scenes but 1./256 for real scenes."""
+    near_plane: float = 0.05
+    """How far along ray to start sampling."""
     randomize_background: bool = False
     """Whether to randomize the background color. Defaults to False."""
 
@@ -128,7 +130,7 @@ class NGPModel(Model):
         device = ray_bundle.origins.device
 
         ray_samples, packed_info, t_min, t_max = self.sampler(
-            ray_bundle, self.field.aabb, cone_angle=self.config.cone_angle
+            ray_bundle, self.field.aabb, cone_angle=self.config.cone_angle, near_plane=self.config.near_plane
         )
 
         field_outputs = self.field.forward(ray_samples)


### PR DESCRIPTION
Previously when inside the the aabb bounding box the sample start `t_min` was 0. Now you can specify a near plane.