### PR TITLE
more cpus for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "protobuf==3.20.0",
     "pylint==2.13.4",
     "pytest==7.1.2",
+    "pytest-xdist==2.5.0",
     "python-socketio==5.7.1",
     "rich==12.5.1",
     "tensorboard==2.9.0",
@@ -104,7 +105,7 @@ disable = [
 
 #pytest
 [tool.pytest.ini_options]
-addopts = "--typeguard-packages=nerfactory --torchtyping-patch-typeguard --disable-warnings --ignore=tests/cuda"
+addopts = "-n=4 --typeguard-packages=nerfactory --torchtyping-patch-typeguard --disable-warnings --ignore=tests/cuda"
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
Speed-up from more than 1 CPU.  Defaults to 4 CPUs now, but GitHub Actions only has [2 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners).

`pytest` with 1 CPU:
```
real    0m13.159s
user    0m55.000s
sys     0m21.245s
```

`pytest` with 4 CPUs:
```
real    0m10.737s
user    1m18.680s
sys     0m48.123s
```