### PR TITLE
Migrate compound model to nerfacc

### DIFF
--- a/nerfactory/configs/base.py
+++ b/nerfactory/configs/base.py
@@ -38,7 +38,6 @@ from nerfactory.datamanagers.dataparsers.record3d_parser import Record3D
 
 # model instances
 from nerfactory.models.base import Model
-from nerfactory.models.compound import CompoundModel
 from nerfactory.models.nerfw import NerfWModel
 from nerfactory.models.tensorf import TensoRFModel
 from nerfactory.optimizers.schedulers import ExponentialDecaySchedule
@@ -396,22 +395,6 @@ class ModelConfig(InstantiateConfig):
 @dataclass
 class VanillaModelConfig(InstantiateConfig):
     """Vanilla Model Config"""
-
-
-@dataclass
-class CompoundModelConfig(ModelConfig):
-    """Compound Model Config"""
-
-    _target: Type = CompoundModel
-    enable_density_field: bool = True
-    enable_collider: bool = False
-    field_implementation: Literal["torch", "tcnn"] = "tcnn"  # torch, tcnn, ...
-    loss_coefficients: Dict[str, float] = to_immutable_dict({"rgb_loss": 1.0})
-    num_samples: int = 1024  # instead of course/fine samples
-    cone_angle: float = 0.0
-    """Should be set to 0.0 for blender scenes but 1./256 for real scenes."""
-    near_plane: float = 0.05
-    """How far along ray to start sampling."""
 
 
 @dataclass

--- a/nerfactory/configs/base_configs.py
+++ b/nerfactory/configs/base_configs.py
@@ -24,7 +24,6 @@ from typeguard import typeguard_ignore
 
 from nerfactory.configs.base import (
     BlenderDataParserConfig,
-    CompoundModelConfig,
     Config,
     FriendsDataManagerConfig,
     MipNerf360DataParserConfig,
@@ -37,6 +36,7 @@ from nerfactory.configs.base import (
     TrainerConfig,
     VanillaDataManagerConfig,
 )
+from nerfactory.models.compound import CompoundModelConfig
 from nerfactory.models.instant_ngp import InstantNGPModelConfig
 from nerfactory.models.mipnerf import MipNerfModel
 from nerfactory.models.mipnerf_360 import MipNerf360Model

--- a/nerfactory/fields/compound_field.py
+++ b/nerfactory/fields/compound_field.py
@@ -49,24 +49,39 @@ except ImportError:
     pass
 
 
-def get_normalized_directions(directions):
-    """SH encoding must be in the range [0, 1]"""
+def get_normalized_directions(directions: TensorType["bs":..., 3]):
+    """SH encoding must be in the range [0, 1]
+
+    Args:
+        directions: batch of directions
+    """
     return (directions + 1.0) / 2.0
 
 
 class TCNNCompoundField(Field):
-    """Compound Field that uses TCNN"""
+    """Compound Field that uses TCNN
+
+    Args:
+        aabb: parameters of scene aabb bounds
+        num_layers: number of hidden layers
+        hidden_dim: dimension of hidden layers
+        geo_feat_dim: output geo feat dimensions
+        num_layers_color: number of hidden layers for color network
+        hidden_dim_color: dimension of hidden layers for color network
+        appearance_embedding_dim: dimension of appearance embedding
+        spatial_distortion: spatial distortion to apply to the scene
+    """
 
     def __init__(
         self,
         aabb,
         num_images: int,
-        num_layers=2,
-        hidden_dim=64,
-        geo_feat_dim=15,
-        num_layers_color=3,
-        hidden_dim_color=64,
-        appearance_embedding_dim: int = 40,
+        num_layers: int = 2,
+        hidden_dim: int = 64,
+        geo_feat_dim: int = 15,
+        num_layers_color: int = 3,
+        hidden_dim_color: int = 64,
+        appearance_embedding_dim: int = 32,
         spatial_distortion: SpatialDistortion = SceneContraction(),
     ) -> None:
         super().__init__()

--- a/nerfactory/models/modules/ray_sampler.py
+++ b/nerfactory/models/modules/ray_sampler.py
@@ -25,7 +25,6 @@ import torch
 from torch import nn
 from torchtyping import TensorType
 
-import nerfactory.cuda as nerfactory_cuda
 from nerfactory.cameras.rays import Frustums, RayBundle, RaySamples
 from nerfactory.fields.density_fields.density_grid import DensityGrid
 
@@ -342,108 +341,6 @@ class PDFSampler(Sampler):
         ray_samples = ray_bundle.get_ray_samples(bin_starts=bins[..., :-1, None], bin_ends=bins[..., 1:, None])
 
         return ray_samples
-
-
-class NGPSpacedSampler(Sampler):
-    """Sampler that matches Instant-NGP paper.
-
-    This sampler does ray-box AABB test, ray samples generation and density check, all together.
-
-    TODO(ruilongli): check whether fuse AABB test together with `raymarching` can speed things up.
-    Otherwise we can seperate it out and use collision detecoter that already exists in the repo.
-    """
-
-    def generate_ray_samples(self) -> RaySamples:
-        raise RuntimeError("For NGP we fused ray samples and density check together. Please call forward() directly.")
-
-    # pylint: disable=arguments-differ
-    def forward(
-        self,
-        ray_bundle: RayBundle,
-        aabb: TensorType[2, 3],
-        num_samples: Optional[int] = None,
-        cone_angle: float = 0.0,
-        marching_steps: Optional[int] = 128,
-        near_plane: float = 0.0,
-    ) -> Tuple[RaySamples, TensorType["total_samples", 3], TensorType["total_samples"], TensorType["total_samples"]]:
-        """Generate ray samples in a bounding box.
-
-        TODO(ruilongli): write a Packed[Ray_samples] class to ray_samples with packed_info.
-        TODO(ruilongli): maybe move aabb test to the collision detector?
-
-        Args:
-            ray_bundle: Rays to generate samples for
-            aabb: Bounding box of the scene.
-            num_samples: Number of samples per ray
-            cone_angle: 0.0 for nerf-synthetic and 1.0/256 for real scenes
-            marching_steps: Number of marching steps (Note: not currently used)
-            near_plane: Near plane for raymarching
-
-        Returns:
-            First return is ray samples in a packed way where only the valid samples are kept.
-            Second return contains all the information to recover packed samples into unpacked mode for rendering.
-            The last two returns are t_min and t_max from ray-aabb test.
-        """
-
-        if self.density_field is None:
-            raise ValueError("density_field must be set to use NGPSpacedSampler")
-
-        num_samples = num_samples or self.num_samples
-
-        aabb = aabb.flatten().contiguous()
-        rays_o = ray_bundle.origins.contiguous()
-        rays_d = ray_bundle.directions.contiguous()
-        scene_scale = (aabb[3:6] - aabb[0:3]).max()
-
-        t_min, t_max = nerfactory_cuda.ray_aabb_intersect(rays_o, rays_d, aabb)
-        t_min = torch.max(t_min, torch.ones_like(t_min) * near_plane)
-
-        marching_steps = -1  # disable marching mode for now
-        # TODO(ruilongli): * 16 is for original impl for training. Need to run
-        # some profiling test with this choice.
-        max_samples_per_batch = len(rays_o) * num_samples
-
-        # marching
-        packed_info, origins, dirs, starts, ends = nerfactory_cuda.raymarching(
-            # rays
-            rays_o,
-            rays_d,
-            t_min,
-            t_max,
-            # density grid
-            self.density_field.center,
-            self.density_field.base_scale,
-            self.density_field.num_cascades,
-            self.density_field.resolution,
-            self.density_field.density_bitfield,
-            # sampling args
-            marching_steps,
-            max_samples_per_batch,
-            num_samples,
-            cone_angle,
-            scene_scale,
-        )
-
-        # squeeze valid samples
-        total_samples = max(packed_info[:, -1].sum(), 1)
-        origins = origins[:total_samples]
-        dirs = dirs[:total_samples]
-        starts = starts[:total_samples]
-        ends = ends[:total_samples]
-
-        assert ray_bundle.camera_indices is not None
-        indices = torch.zeros_like(origins[:, :1], dtype=torch.long)
-
-        ray_bundle.camera_indices = ray_bundle.camera_indices.to(torch.long).to(packed_info.device)
-
-        indices = nerfactory_cuda.get_camera_indices(packed_info, ray_bundle.camera_indices, indices)
-
-        zeros = torch.zeros_like(origins[:, :1])
-        ray_samples = RaySamples(
-            frustums=Frustums(origins=origins, directions=dirs, starts=starts, ends=ends, pixel_area=zeros),
-            camera_indices=indices,
-        )
-        return ray_samples, packed_info, t_min, t_max
 
 
 class VolumetricSampler(Sampler):


### PR DESCRIPTION
All models now use nerfacc library. Only remaining cuda in nerfactory repo is for the density grid (which we probably want to remove).