### PR TITLE
Bump dcargs to 0.3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "aiortc==1.3.2",
     "av==9.2.0",
     "black[jupyter]==22.3.0",
-    "dcargs>=0.3.6",
+    "dcargs>=0.3.7",
     "gdown==4.5.1",
     "ninja==1.10.2.3",
     "functorch==0.2.1",


### PR DESCRIPTION
Contains some formatting improvements, dropped a dependency on `termcolor`