### PR TITLE
Speedup eval and training with better data management

### DIFF
--- a/nerfactory/cameras/cameras.py
+++ b/nerfactory/cameras/cameras.py
@@ -171,6 +171,9 @@ class Cameras:
             Rays for the given camera indices and coords.
         """
 
+        if isinstance(camera_indices, torch.Tensor):
+            camera_indices = camera_indices.to(self.device)
+
         if coords is None:
             coords = self.get_image_coords().to(self.device)
 
@@ -237,7 +240,7 @@ class Cameras:
         if not isinstance(camera_indices, torch.Tensor):
             ray_bundle_camera_indices = torch.Tensor([camera_indices]).broadcast_to(pixel_area.shape).to(self.device)
         else:
-            ray_bundle_camera_indices = camera_indices
+            ray_bundle_camera_indices = camera_indices.view(pixel_area.shape)
 
         return RayBundle(
             origins=origins,

--- a/nerfactory/cameras/rays.py
+++ b/nerfactory/cameras/rays.py
@@ -113,7 +113,7 @@ class RaySamples(TensorDataclass):
         # mip-nerf version of transmittance calculation:
         transmittance = torch.cumsum(delta_density[..., :-1, :], dim=-2)
         transmittance = torch.cat(
-            [torch.zeros((*transmittance.shape[:1], 1, 1)).to(densities.device), transmittance], dim=-2
+            [torch.zeros((*transmittance.shape[:1], 1, 1), device=densities.device), transmittance], dim=-2
         )
         transmittance = torch.exp(-transmittance)  # [..., "num_samples"]
 

--- a/nerfactory/models/modules/ray_generator.py
+++ b/nerfactory/models/modules/ray_generator.py
@@ -50,5 +50,4 @@ class RayGenerator(nn.Module):
             camera_indices=c,
             coords=coords,
         )
-        ray_bundle.camera_indices = c[..., None]  # ["num_rays",1]
         return ray_bundle

--- a/nerfactory/utils/math.py
+++ b/nerfactory/utils/math.py
@@ -29,7 +29,7 @@ def components_from_spherical_harmonics(levels: int, directions: TensorType[...,
         directions: Spherical hamonic coefficients
     """
     num_components = levels**2
-    components = torch.zeros((*directions.shape[:-1], num_components)).to(directions.device)
+    components = torch.zeros((*directions.shape[:-1], num_components), device=directions.device)
 
     assert 1 <= levels <= 5, f"SH levels must be in [1,4], got {levels}"
     assert directions.shape[-1] == 3, f"Direction input should have three dimensions. Got {directions.shape[-1]}"


### PR DESCRIPTION
We had some Tensors on CPU longer than they should have been.

The following fixes improves:
Instant-NGP Training - 8%
Instant-NGP Eval - negligible
Compound Training - 9%
Compound Eval - 250%

<img width="1410" alt="image" src="https://user-images.githubusercontent.com/3310961/191147648-b41bf535-1d22-495c-b33e-48767b835a09.png">
