### PR TITLE
Record3D Bugfix: Removing Pose OpenGL Conversion

### DIFF
--- a/nerfstudio/data/dataparsers/record3d_dataparser.py
+++ b/nerfstudio/data/dataparsers/record3d_dataparser.py
@@ -52,8 +52,6 @@ class Record3DDataParserConfig(DataParserConfig):
     max_dataset_size: int = 150
     """Max number of images to train on. If the dataset has
     more, images will be sampled approximately evenly."""
-    downscale_factor: int = 1
-    """How much to downscale images."""
 
 
 @dataclass
@@ -142,7 +140,6 @@ class Record3D(DataParser):
             camera_to_worlds=poses,
             camera_type=CameraType.PERSPECTIVE,
         )
-        cameras.rescale_output_resolution(scaling_factor=1.0 / self.config.downscale_factor)
 
         dataparser_outputs = DataparserOutputs(
             image_filenames=image_filenames,


### PR DESCRIPTION
A line added in a previous commit was breaking the record3D training because it was messing up the poses. Fixed with this PR.