### PR TITLE
Bump `dcargs` to 0.3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "aiohttp==3.8.1",
     "aiortc==1.3.2",
     "av==9.2.0",
-    "dcargs>=0.3.7",
+    "dcargs>=0.3.9",
     "gdown==4.5.1",
     "ninja==1.10.2.3",
     "functorch==0.2.1",


### PR DESCRIPTION
Two changes:
- `0.3.8` includes minor improvements for multi-column layouts.
- `0.3.9` detects fields that are paths and marks them for tab completion in bash. (closes #518)