### PR TITLE
Remove occluded samples during training.

### DIFF
--- a/nerfactory/models/modules/ray_sampler.py
+++ b/nerfactory/models/modules/ray_sampler.py
@@ -397,7 +397,7 @@ class VolumetricSampler(Sampler):
         ray_bundle: RayBundle,
         num_samples: Optional[int] = None,
         near_plane: float = 0.0,
-        remove_occluded_samples: bool = False,
+        remove_occluded_samples: bool = True,
     ) -> Tuple[RaySamples, TensorType["total_samples", 3], TensorType["total_samples", 2]]:
         """Generate ray samples in a bounding box.
 
@@ -455,7 +455,7 @@ class VolumetricSampler(Sampler):
         if camera_indices is not None:
             camera_indices = camera_indices[ray_indices]
 
-        if remove_occluded_samples:
+        if remove_occluded_samples and self.training:
             with torch.no_grad():
                 positions = origins + dirs * (starts + ends) / 2.0
                 densities = self.density_fn(positions)


### PR DESCRIPTION
Remove occluded samples during training by first doing a "no grad" forward pass to determine density. This trick is not applied during eval as it hurts eval speed.
Results in better quality
<img width="458" alt="image" src="https://user-images.githubusercontent.com/3310961/192068545-0a35fd9b-0eb8-45a1-8842-d91c12a04943.png">

Uses a bit more memory since the dynamic batch size logic assumes that the average number of samples/ray during training matches the number of samples/ray during eval. Now the number of samples/ray during training is higher.