### PR TITLE
Tune proposal network

### DIFF
--- a/nerfactory/models/proposal.py
+++ b/nerfactory/models/proposal.py
@@ -65,9 +65,9 @@ class ProposalModelConfig(ModelConfig):
     """Whether to randomize the background color."""
     num_proposal_samples_per_ray: int = 64
     """Number of samples per ray for the proposal network."""
-    num_nerf_samples_per_ray: int = 32
+    num_nerf_samples_per_ray: int = 64
     """Number of samples per ray for the nerf network."""
-    num_proposal_network_iterations: int = 2
+    num_proposal_network_iterations: int = 1
     """Number of proposal network iterations."""
     use_same_proposal_network: bool = False
     """Use the same proposal network. Otherwise use different ones."""


### PR DESCRIPTION
After some experimentation I have found that only 1 proposal network is needed (this speeds up training). You can then double the fine samples for a quality improvement.

<img width="457" alt="image" src="https://user-images.githubusercontent.com/3310961/192699794-5956c8fb-4c93-42ef-a04d-589fd3b49142.png">
<img width="699" alt="image" src="https://user-images.githubusercontent.com/3310961/192699836-392c032c-d13a-4808-831b-ff12e8c87137.png">
 