### PR TITLE
Fix package cli auto-completions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nerfstudio"
-version = "0.0.3.1"
+version = "0.0.3.4"
 description = "All-in-one repository for state-of-the-art NeRFs"
 readme = "README.md"
 license = { text="Apache 2.0"}
@@ -49,6 +49,7 @@ dependencies = [
 [project.urls]
 "Documentation" = "https://plenoptix-nerfactory.readthedocs-hosted.com/en/latest/?badge=latest"
 
+
 [project.optional-dependencies]
 # Development packages
 dev = [
@@ -72,6 +73,7 @@ docs = [
 ]
 
 [project.scripts]
+# Note, add entrypoint name to scripts/completions/install.py to include CLI completion
 ns-install-cli = "scripts.completions.install:entrypoint"
 ns-process-data = "scripts.process_data:entrypoint"
 ns-download-data = "scripts.downloads.download_data:entrypoint"
@@ -86,7 +88,10 @@ dependency_links = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["*"]
+include = ["nerfstudio*","scripts*"]
+
+[tool.setuptools.package-data]
+"*" = ["*.json"]
 
 # black
 [tool.black]

--- a/scripts/completions/install.py
+++ b/scripts/completions/install.py
@@ -22,6 +22,15 @@ ShellType = Literal["zsh", "bash"]
 
 CONSOLE = Console(width=120)
 
+ENTRYPOINTS = [
+    "ns-install-cli",
+    "ns-process-data",
+    "ns-download-data",
+    "ns-train",
+    "ns-eval",
+    "ns-dev-test",
+]
+
 
 def _check_dcargs_cli(script_path: pathlib.Path) -> bool:
     """Check if a path points to a script containing a dcargs.cli() call. Also checks
@@ -211,23 +220,6 @@ def main(
 
         # Find dcargs CLIs.
         script_paths = list(filter(_check_dcargs_cli, scripts_dir.glob("**/*.py"))) if include_scripts else []
-        entry_points = (
-            # Read pyproject.toml.
-            (scripts_dir.parent / "pyproject.toml")
-            .read_text()
-            # Get entrypoint lines.
-            .partition("[project.scripts]")[2]
-            .partition("[")[0]
-            # Split into list of strings, which should each be of the format:
-            # `entrypoint = "scripts.something:entrypoint"`
-            .strip()
-            .split("\n")
-        )
-        entry_points = list(
-            # ns-train = "..." ==> ns-train
-            e.partition("=")[0].strip()
-            for e in entry_points
-        )
         script_names = tuple(p.name for p in script_paths)
         assert len(set(script_names)) == len(script_names)
 
@@ -246,7 +238,7 @@ def main(
                     lambda path_or_entrypoint_and_shell: _generate_completion(
                         path_or_entrypoint_and_shell[0], path_or_entrypoint_and_shell[1], completions_dir
                     ),
-                    itertools.product(script_paths + entry_points, shells_found),
+                    itertools.product(script_paths + ENTRYPOINTS, shells_found),
                 )
             )
 


### PR DESCRIPTION
Can't include `pyproject.toml` in pip package, so manually added entrypoints to cli install script. FYI @brentyi 