### PR TITLE
use literal instead of list for --vis

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Type
@@ -205,19 +205,19 @@ class Config(PrintableConfig):
         }
     )
     """optionally specify a pre-defined config to load from"""
-    vis: List[Literal["viewer", "wandb", "tensorboard"]] = field(default_factory=lambda: ["wandb"])
+    vis: Literal["viewer", "wandb", "tensorboard"] = "wandb"
 
     def is_viewer_enabled(self) -> bool:
         """Checks if a viewer is enabled."""
-        return "viewer" in self.vis
+        return "viewer" == self.vis
 
     def is_wandb_enabled(self) -> bool:
         """Checks if wandb is enabled."""
-        return "wandb" in self.vis
+        return "wandb" == self.vis
 
     def is_tensorboard_enabled(self) -> bool:
         """Checks if tensorboard is enabled."""
-        return "tensorboard" in self.vis
+        return "tensorboard" == self.vis
 
     def set_timestamp(self) -> None:
         """Dynamically set the experiment timestamp"""

--- a/nerfstudio/configs/model_configs.py
+++ b/nerfstudio/configs/model_configs.py
@@ -74,7 +74,7 @@ model_configs["nerfacto"] = Config(
         },
     },
     viewer=ViewerConfig(num_rays_per_chunk=1 << 16),
-    vis=["viewer"],
+    vis="viewer",
 )
 
 model_configs["instant-ngp"] = Config(
@@ -91,7 +91,7 @@ model_configs["instant-ngp"] = Config(
         }
     },
     viewer=ViewerConfig(num_rays_per_chunk=64000),
-    vis=["viewer"],
+    vis="viewer",
 )
 
 model_configs["mipnerf-360"] = Config(

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -192,19 +192,11 @@ class Trainer:
     def _check_viewer_warnings(self) -> None:
         """Helper to print out any warnings regarding the way the viewer/loggers are enabled"""
         if self.config.is_viewer_enabled():
-            is_logger_enabled = self.config.is_wandb_enabled() or self.config.is_tensorboard_enabled()
-            if is_logger_enabled:
-                string = (
-                    "[WARNING]: Tensorboard or Wandb enabled with Viewer will slow down Viewer. "
-                    "Please set `--vis viewer` for faster rendering."
-                )
-                CONSOLE.print(f"[bold red]{string}")
-            else:
-                string = (
-                    "[WARNING] Not running eval iterations since only viewer is enabled."
-                    " Please add 'wandb' or 'tensorboard' to the `--vis` list to run evaluations."
-                )
-                CONSOLE.print(f"[bold red]{string}")
+            string = (
+                "[WARNING] Not running eval iterations since only viewer is enabled."
+                " Use `--vis wandb` or `--vis tensorboard` to run with eval instead."
+            )
+            CONSOLE.print(f"[bold red]{string}")
 
     @check_viewer_enabled
     def _init_viewer_scene(self) -> None:

--- a/tests/test_run_train.py
+++ b/tests/test_run_train.py
@@ -27,7 +27,7 @@ def set_reduced_config(config: Config):
     config.pipeline.datamanager.train_num_rays_per_batch = 4
 
     # use tensorboard logging instead of wandb
-    config.vis = ["tensorboard"]
+    config.vis = "tensorboard"
     config.logging.relative_log_dir = Path("/tmp/")
 
     # reduce model factors


### PR DESCRIPTION
- now we can only specify one of viewer, wandb, or tensorboard. we don't think the user will want to use more than one very often. if they do, they can hack around things to change logic or submit a PR fix
- fixes issue #579 because there was no good way around this issue as of now