### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ ns-train nerfacto --vis viewer --viewer.websocket-port=7008
 ssh -L localhost:7008:localhost:7008 {REMOTE HOST}
 ```
 
-For more details on how to interact with the visualizer, please visit our viewer [walk-through]().
+For more details on how to interact with the visualizer, please visit our viewer [walk-through](https://docs.nerf.studio/en/latest/quickstart/viewer_quickstart.html).
 
 ## 4. Rendering a trajectory during inference
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 Nerfstudio provides a simple API that allows for a simplified end-to-end process of creating, training, and testing NeRFs.
 The library supports a **more interpretable implementation of NeRFs by modularizing each component.**
 With more modular NeRFs, we hope to create a more user-friendly experience in exploring the technology.
-Nerfstudio is a contributer friendly repo with the goal of buiding a community where users can more easily build upon each other's contributions.
+Nerfstudio is a contributor-friendly repo with the goal of building a community where users can more easily build upon each other's contributions.
 
 It’s as simple as plug and play with nerfstudio!
 
@@ -68,8 +68,8 @@ We hope nerfstudio enables you to build faster :hammer: learn together :books: a
 
 # Quickstart
 
-The quickstart will help you get started with the default vanilla nerf trained on the classic blender lego scene.
-For more complex changes (e.g. running with your own data/setting up a new NeRF graph, please refer to our [references](#learn-more).
+The quickstart will help you get started with the default vanilla NeRF trained on the classic Blender Lego scene.
+For more complex changes (e.g., running with your own data/setting up a new NeRF graph, please refer to our [references](#learn-more).
 
 ## 1. Installation: Setup the environment
 
@@ -130,7 +130,7 @@ ns-process-data --data FOLDER_OR_VIDEO --output-dir {PROCESSED_DATA_DIR}
 
 ## 3. Training a model
 
-To run with all the defaults, e.g. vanilla nerf method with the blender lego image
+To run with all the defaults, e.g., vanilla NeRF method with the Blender Lego image
 
 ```bash
 # To see what models are available.
@@ -142,7 +142,7 @@ ns-train nerfacto --help
 # Run with nerfacto model.
 ns-train nerfacto
 
-# We provide support for other models. E.g. to run instant-ngp.
+# We provide support for other models. E.g., to run instant-ngp.
 ns-train instant-ngp
 
 # To train on your custom data.
@@ -200,11 +200,11 @@ If you're interested in learning more on how to create your own pipelines, devel
 | 💖 **Community**                                                                                   |
 | [Discord](https://discord.gg/NHGtYRAW)                                                             | Join our community to discuss more. We would love to hear from you!                                |
 | [Twitter](https://twitter.com/nerfstudioteam)                                                      | Follow us on Twitter @nerfstudioteam to see cool updates and announcements                                         |
-| [TikTok](#)                                                                                        | Comming soon! Follow us on TikTok to see some of our fan favorite results                          |
+| [TikTok](#)                                                                                        | Coming soon! Follow us on TikTok to see some of our fan favorite results                          |
 
 # Supported Features
 
-We provide the following support strucutures to make life easier for getting started with NeRFs. For a full description, please refer to our [features page](#).
+We provide the following support structures to make life easier for getting started with NeRFs. For a full description, please refer to our [features page](#).
 
 **If you are looking for a feature that is not currently supported, please do not hesitate to contact the Nerfstudio Team on [Discord](https://discord.gg/NHGtYRAW)!**
 
@@ -231,7 +231,7 @@ We provide the following support strucutures to make life easier for getting sta
 
 # Citation
 
-If you use this library or find the doumentation useful for your research, please consider citing:
+If you use this library or find the documentation useful for your research, please consider citing:
 
 ```
 @misc{nerfstudio,


### PR DESCRIPTION
Everyone's fixing them, but I still see a few. Here you go.

The commas after "e.g." are [the norm in American English](https://jakubmarian.com/comma-after-i-e-and-e-g/#:~:text=Virtually%20all%20American%20style%20guides,motherboards%2C%20graphic%20cards%2C%20CPUs.).

NOTE: on line 169 is "please visit our viewer [walk-through]()" - I could not figure out if there's a place you wanted to point the user. Future work?