### PR TITLE
Reduced `tyro` overhead + helptext formatting

### DIFF
--- a/docs/quickstart/first_nerf.md
+++ b/docs/quickstart/first_nerf.md
@@ -61,9 +61,9 @@ ns-train nerfacto --vis viewer --data data/nerfstudio/poster --viewer.websocket-
   :::
 
 ## Intro to nerfstudio CLI and Configs
-Nerfstudio allows for customizing your training runs, eval runs, configs from the CLI in a powerful way, but there are some things to understand.
+Nerfstudio allows customization of training and eval configs from the CLI in a powerful way, but there are some things to understand.
 
-The most demonstrative and helpful example of this in action is the difference in output between the following commands:
+The most demonstrative and helpful example of the CLI structure is the difference in output between the following commands:
 ```bash
 ns-train -h
 ```
@@ -76,13 +76,13 @@ ns-train nerfacto nerfstudio-data -h
 
 In each of these examples, the -h applies to the previous subcommand (`ns-train`, `nerfacto`, and `nerfstudio-data`). 
 
-In the first example, this shows us the help menu for the `ns-train` script. 
+In the first example, we get the help menu for the `ns-train` script. 
 
-In the second examples, we will get the help menu for the `nerfacto` model. 
+In the second example, we get the help menu for the `nerfacto` model. 
 
-In the third examples, we will get the help menu for the `nerfstudio-data` dataparser.
+In the third example, we get the help menu for the `nerfstudio-data` dataparser.
 
-With our scripts, your arguments will apply to the previous subcommand in your command, and thus where you put your arguments matters! Any optional arguments you discover while doing
+With our scripts, your arguments will apply to the preceding subcommand in your command, and thus where you put your arguments matters! Any optional arguments you discover from running
 ```bash
 ns-train nerfacto -h nerfstudio-data
 ```

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -23,7 +23,6 @@ from typing import Dict
 import tyro
 
 from nerfstudio.configs.base_config import Config, TrainerConfig, ViewerConfig
-from nerfstudio.configs.config_utils import convert_markup_to_ansi
 from nerfstudio.data.datamanagers import VanillaDataManagerConfig
 from nerfstudio.data.dataparsers.blender_dataparser import BlenderDataParserConfig
 from nerfstudio.data.dataparsers.friends_dataparser import FriendsDataParserConfig

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -40,15 +40,12 @@ from nerfstudio.pipelines.dynamic_batch import DynamicBatchPipelineConfig
 
 method_configs: Dict[str, Config] = {}
 descriptions = {
-    "nerfacto": "[bold green]Recommended[/bold green] Real-time model tuned for real captures. "
-    + "This model will be continually updated.",
+    "nerfacto": "Recommended real-time model tuned for real captures. This model will be continually updated.",
     "instant-ngp": "Implementation of Instant-NGP. Recommended real-time model for bounded synthetic data.",
-    "mipnerf": "High quality model for bounded scenes. [red]*slow*",
+    "mipnerf": "High quality model for bounded scenes. (slow)",
     "semantic-nerfw": "Predicts semantic segmentations and filters out transient objects.",
-    "vanilla-nerf": "Original NeRF model. [red]*slow*",
+    "vanilla-nerf": "Original NeRF model. (slow)",
 }
-descriptions = {k: convert_markup_to_ansi(v) for k, v in descriptions.items()}
-
 
 method_configs["nerfacto"] = Config(
     method_name="nerfacto",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "aiortc==1.3.2",
     "appdirs>=1.4",
     "av==9.2.0",
-    "tyro>=0.3.22",
+    "tyro>=0.3.23",
     "gdown==4.5.1",
     "ninja==1.10.2.3",
     "functorch==0.2.1",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,6 +1,32 @@
 #!/usr/bin/env python
-"""
-train.py
+"""Train a radiance field with nerfstudio.
+For real captures, we recommend using the [bright_yellow]nerfacto[/bright_yellow] model.
+
+Nerfstudio allows for customizing your training and eval configs from the CLI in a powerful way, but there are some
+things to understand.
+
+The most demonstrative and helpful example of the CLI structure is the difference in output between the following
+commands:
+
+    ns-train -h
+    ns-train nerfacto -h nerfstudio-data
+    ns-train nerfacto nerfstudio-data -h
+
+In each of these examples, the -h applies to the previous subcommand (ns-train, nerfacto, and nerfstudio-data).
+
+In the first example, we get the help menu for the ns-train script.
+In the second example, we get the help menu for the nerfacto model.
+In the third example, we get the help menu for the nerfstudio-data dataparser.
+
+With our scripts, your arguments will apply to the preceding subcommand in your command, and thus where you put your
+arguments matters! Any optional arguments you discover from running
+
+    ns-train nerfacto -h nerfstudio-data
+
+need to come directly after the nerfacto subcommand, since these optional arguments only belong to the nerfacto
+subcommand:
+
+    ns-train nerfacto {nerfacto optional args} nerfstudio-data
 """
 
 from __future__ import annotations
@@ -20,6 +46,7 @@ import tyro
 import yaml
 
 from nerfstudio.configs import base_config as cfg
+from nerfstudio.configs.config_utils import convert_markup_to_ansi
 from nerfstudio.configs.method_configs import AnnotatedBaseConfigUnion
 from nerfstudio.engine.trainer import train_loop
 from nerfstudio.utils import comms, profiler
@@ -213,7 +240,12 @@ def entrypoint():
     """Entrypoint for use with pyproject scripts."""
     # Choose a base configuration and override values.
     tyro.extras.set_accent_color("bright_yellow")
-    main(tyro.cli(AnnotatedBaseConfigUnion))
+    main(
+        tyro.cli(
+            AnnotatedBaseConfigUnion,
+            description=convert_markup_to_ansi(__doc__),
+        )
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Just released `tyro` 0.3.23, which does some more aggressive caching and reduces the config overhead significantly. On my machine, parsing the full config library now takes ~0.15 seconds each time the `ns-train` script is run (down from ~0.45).
It's dramatically lower for the other scripts. (on the order of 1e-4 seconds)

A few changes:
- Bumped `tyro` dependency.
- Removed ANSI sequences from subcommand helptext. (these are unfortunately no longer supported)
- Copied the install scripts walkthrough from the docs to the help message + made some minor typo fixes and edits.

![image](https://user-images.githubusercontent.com/6992947/194401655-4f01669f-023f-4f23-afba-1b34aba6597b.png)