### PR TITLE
bump nerfacc to 0.2.0. bug fix for depth vis.

### DIFF
--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -477,7 +477,7 @@ class VolumetricSampler(Sampler):
             starts = torch.ones((1, 1), dtype=starts.dtype, device=rays_o.device)
             ends = torch.ones((1, 1), dtype=ends.dtype, device=rays_o.device)
 
-        ray_indices = nerfacc.unpack_to_ray_indices(packed_info).long()
+        ray_indices = nerfacc.unpack_info(packed_info)
         origins = rays_o[ray_indices]
         dirs = rays_d[ray_indices]
         if camera_indices is not None:

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -467,6 +467,7 @@ class VolumetricSampler(Sampler):
             far_plane=far_plane,
             stratified=self.training,
             cone_angle=cone_angle,
+            alpha_thre=1e-2,
         )
 
         num_samples = starts.shape[0]

--- a/nerfstudio/model_components/renderers.py
+++ b/nerfstudio/model_components/renderers.py
@@ -236,7 +236,7 @@ class DepthRenderer(nn.Module):
             else:
                 depth = torch.sum(weights * steps, dim=-2) / (torch.sum(weights, -2) + eps)
 
-            depth = torch.clip(depth, steps[..., 0, :], steps[..., -1, :])
+            depth = torch.clip(depth, steps.min(), steps.max())
 
             return depth
 

--- a/nerfstudio/models/instant_ngp.py
+++ b/nerfstudio/models/instant_ngp.py
@@ -139,6 +139,8 @@ class NGPModel(Model):
         self, training_callback_attributes: TrainingCallbackAttributes
     ) -> List[TrainingCallback]:
         def update_occupancy_grid(step: int):
+            # TODO: needs to get access to the sampler, on how the step size is determinated at each x. See
+            # https://github.com/KAIR-BAIR/nerfacc/blob/127223b11401125a9fce5ce269bb0546ee4de6e8/examples/train_ngp_nerf.py#L190-L213
             self.occupancy_grid.every_n_step(
                 step=step,
                 occ_eval_fn=lambda x: self.field.get_opacity(x, self.config.render_step_size),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "mediapy==1.1.0",
     "msgpack==1.0.4",
     "msgpack_numpy==0.4.8",
-    "nerfacc==0.1.3",
+    "nerfacc==0.2.0",
     "opencv-python==4.6.0.66",
     "plotly==5.7.0",
     "protobuf==3.20.0",


### PR DESCRIPTION
- Bump nerfacc version to 0.2.0
- Fix depth visualization when the samples is packed.

NerfAcc 0.2.0 v.s. 0.1.3: Slight optimization on the library side. More util functions are supported. 

<img width="1431" alt="Screen Shot 2022-10-09 at 11 28 09 AM" src="https://user-images.githubusercontent.com/10151885/194773496-668c4ab7-d248-4717-82f0-0306b74ae76c.png">

![image (6)](https://user-images.githubusercontent.com/10151885/194773871-b4fa1691-c839-499b-aa5b-37cba20be435.png)


The huge performance improvements in NerfAcc 0.2.0 comes mainly from the better logic for occupancy grid updating. Not sure how to incorporate that which seems to need some refactor of the nerfstudio code. Left a comment in the code.