### PR TITLE
Added up vector offset

### DIFF
--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -122,7 +122,7 @@ export function get_scene_tree() {
 
   window.addEventListener('keydown', (event) => {
     if (event.code === 'Space') {
-      camera_controls.setTarget(0, 0, 0);
+      camera_controls.setLookAt(0.7, -0.7, 0.3, 0, 0, 0);
     }
   });
 

--- a/nerfstudio/viewer/app/src/modules/SidePanel/CameraPanel/CameraPanel.jsx
+++ b/nerfstudio/viewer/app/src/modules/SidePanel/CameraPanel/CameraPanel.jsx
@@ -497,8 +497,36 @@ export default function CameraPanel(props) {
     });
   };
 
+  const setUp = () => {
+    const rot = camera_main.rotation;
+    const unitY = new THREE.Vector3(0, 1, 0);
+    const upVec = unitY.applyEuler(rot);
+
+    const grid = sceneTree.find_object_no_create(['Grid']);
+    grid.setRotationFromEuler(rot);
+
+    const pos = new THREE.Vector3();
+    camera_main.getWorldPosition(pos);
+    camera_main.up.set(upVec.x, upVec.y, upVec.z);
+    sceneTree.metadata.camera_controls.updateCameraUp();
+    sceneTree.metadata.camera_controls.setLookAt(pos.x, pos.y, pos.z, 0, 0, 0);
+    const points = [new THREE.Vector3(0, 0, 0), upVec.multiplyScalar(2)];
+    const geometry = new THREE.BufferGeometry().setFromPoints(points);
+    const material = new THREE.LineBasicMaterial({
+      color: 0xaa46fc,
+      linewidth: 1,
+    });
+    const line = new THREE.LineSegments(geometry, material);
+    sceneTree.set_object_from_path(['Viewer Up Vector'], line);
+  };
+
   return (
     <div className="CameraPanel">
+      <div className="CameraPanel-top-button">
+        <Button size="small" variant="outlined" onClick={setUp}>
+          Reset Up Direction
+        </Button>
+      </div>
       <div>
         <div className="CameraPanel-top-button">
           <Button size="small" variant="outlined" onClick={add_camera}>
@@ -624,7 +652,9 @@ export default function CameraPanel(props) {
         <Button
           size="small"
           variant="outlined"
-          onClick={() => set_slider_value(Math.max(0.0, slider_value - step_size))}
+          onClick={() =>
+            set_slider_value(Math.max(0.0, slider_value - step_size))
+          }
         >
           <ArrowBackIosNewIcon />
         </Button>
@@ -665,7 +695,9 @@ export default function CameraPanel(props) {
         <Button
           size="small"
           variant="outlined"
-          onClick={() => set_slider_value(Math.min(slider_max, slider_value + step_size))}
+          onClick={() =>
+            set_slider_value(Math.min(slider_max, slider_value + step_size))
+          }
         >
           <ArrowForwardIosIcon />
         </Button>


### PR DESCRIPTION
Addresses #695 , you can move the camera so that "up" looks correct and then press [Render->Reset Up Direction] and the grid will shift so that up matches the camera. Also adds a vector to display the local up direction once button is pressed.