### PR TITLE
Reduce memory usage of nerfacto model

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -61,7 +61,7 @@ method_configs["nerfacto"] = Config(
                 mode="SO3xR3", optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-3)
             ),
         ),
-        model=NerfactoModelConfig(eval_num_rays_per_chunk=1 << 16),
+        model=NerfactoModelConfig(eval_num_rays_per_chunk=1 << 15),
     ),
     optimizers={
         "proposal_networks": {
@@ -73,7 +73,7 @@ method_configs["nerfacto"] = Config(
             "scheduler": None,
         },
     },
-    viewer=ViewerConfig(num_rays_per_chunk=1 << 16),
+    viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
     vis="viewer",
 )
 

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -61,7 +61,7 @@ method_configs["nerfacto"] = Config(
                 mode="SO3xR3", optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-3)
             ),
         ),
-        model=NerfactoModelConfig(eval_num_rays_per_chunk=1 << 14),
+        model=NerfactoModelConfig(eval_num_rays_per_chunk=1 << 16),
     ),
     optimizers={
         "proposal_networks": {
@@ -73,7 +73,7 @@ method_configs["nerfacto"] = Config(
             "scheduler": None,
         },
     },
-    viewer=ViewerConfig(num_rays_per_chunk=1 << 14),
+    viewer=ViewerConfig(num_rays_per_chunk=1 << 16),
     vis="viewer",
 )
 


### PR DESCRIPTION
Storing all of the eval sample info during eval would cause spikes in memory. By only storing during training this PR is able to reduce memory usage 2x while also increasing the number of eval chunks by 2x.