### PR TITLE
Update custom_dataset.md

### DIFF
--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -127,8 +127,9 @@ At a high level, you can follow these 3 steps:
 2. Then, move the exported capture folder from your iPhone to your computer.
 
 3. Train with nerfstudio!
+
   ```
-  ns-train nerfacto record3d-data --data {RECORD3D_CAPTURE_DIR/EXR_RGBD}
+  ns-train nerfacto --data {RECORD3D_CAPTURE_DIR/EXR_RGBD} record3d-data
   ```
 
 

--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -25,7 +25,7 @@ A full set of arguments can be found {doc}`here</reference/cli/ns_process_data>`
 Simply specify that you are using the `nerfstudio` dataparser and point the data directory to your processed data.
 
 ```bash
-ns-train nerfacto nerfstudio-data --data {PROCESSED_DATA_DIR}
+ns-train nerfacto --data {PROCESSED_DATA_DIR} nerfstudio-data
 ```
 
 ### Installing COLMAP
@@ -131,7 +131,6 @@ At a high level, you can follow these 3 steps:
   ```
   ns-train nerfacto --data {RECORD3D_CAPTURE_DIR/EXR_RGBD} record3d-data
   ```
-
 
 We provide some example recordings for you to try out and to see the correct formatting.
 


### PR DESCRIPTION
Train with the given websocket-port:

```shell
ns-train nerfacto record3d-data --data {RECORD3D_CAPTURE_DIR/EXR_RGBD} --viewer.websocket-port 7007
```

Then I get `ns-train: error: unrecognized arguments: --viewer.websocket-port 7007`.

It is recommended to put `record3d-data` at the end of all arguments.

```shell
ns-train nerfacto --data {RECORD3D_CAPTURE_DIR/EXR_RGBD} --viewer.websocket-port 7007 record3d-data
```