### PR TITLE
Fix tab completion for PyPI installs, add `py.typed`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dependency_links = [
 include = ["nerfstudio*","scripts*"]
 
 [tool.setuptools.package-data]
-"*" = ["*.json"]
+"*" = ["*.json", "py.typed", "setup.bash", "setup.zsh"]
 
 # black
 [tool.black]


### PR DESCRIPTION
1. `ns-install-cli` was formerly breaking on machines where `nerfstudio` was installed via PyPI.
2. Need a `py.typed` for type checking if folks are using `nerfstudio` as a library: https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/