### PR TITLE
Respect custom timestamps passed to `ns-train`

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -229,7 +229,8 @@ class Config(PrintableConfig):
 
     def set_timestamp(self) -> None:
         """Dynamically set the experiment timestamp"""
-        self.timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        if self.timestamp == "{timestamp}":
+            self.timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
 
     def set_experiment_name(self) -> None:
         """Dynamically set the experiment name"""


### PR DESCRIPTION
When using `ns-train` as part of a pipeline, it's convenient for the output directory to be deterministic. This should be achievable by passing the `--timestamp` argument to `ns-train`, but that argument is currently being overwritten. This PR fixes the logic to respect a custom user-provided `--timestamp` value.