### PR TITLE
[VIEWER] Camera Select Bug Fixes

### DIFF
--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -120,10 +120,10 @@ export function get_scene_tree() {
   }
 
   function checkVisibility(camera) {
-    let curr = camera
+    let curr = camera;
     while (curr !== null) {
       if (!curr.visible) return false;
-      curr = curr.parent
+      curr = curr.parent;
     }
     return true;
   }

--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -245,7 +245,10 @@ export function get_scene_tree() {
     mouseVector.y = 1 - 2 * ((e.clientY - BANNER_HEIGHT) / size.y);
 
     if (mouseVector.x > 1 || mouseVector.x < -1 || mouseVector.y > 1 || mouseVector.y < -1) {
-      selectedCam = null;
+      if (selectedCam !== null) {
+        selectedCam.material.color = new THREE.Color(1, 1, 1);
+        selectedCam = null;
+      }
       return;
     }
 

--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -25,6 +25,7 @@ export function get_scene_tree() {
   const sceneTree = new SceneNode(scene);
 
   const dispatch = useDispatch();
+  const BANNER_HEIGHT = 50;
 
   // Main camera
   const main_camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
@@ -241,15 +242,11 @@ export function get_scene_tree() {
 
     sceneTree.metadata.renderer.getSize(size);
     mouseVector.x = 2 * (e.clientX / size.x) - 1;
-    mouseVector.y = 1 - 2 * ((e.clientY - 50) / size.y);
+    mouseVector.y = 1 - 2 * ((e.clientY - BANNER_HEIGHT) / size.y);
 
-    // hacky out of bounds fix
-    if (mouseVector.x > 1 || mouseVector.x < -1) {
-      // some value that won't hit
-      mouseVector.x = -100;
-    }
-    if (mouseVector.y > 1 || mouseVector.y < -1) {
-      mouseVector.y = -100;
+    if (mouseVector.x > 1 || mouseVector.x < -1 || mouseVector.y > 1 || mouseVector.y < -1) {
+      selectedCam = null;
+      return;
     }
 
     raycaster.setFromCamera(mouseVector, sceneTree.metadata.camera);

--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -119,6 +119,14 @@ export function get_scene_tree() {
     keyMap[keyCode] = true;
   }
 
+  function checkVisibility(camera) {
+    while (camera !== null) {
+      if (!camera.visible) return false;
+      camera = camera.parent
+    }
+    return true;
+  }
+
   window.addEventListener('keydown', onKeyDown, true);
   window.addEventListener('keyup', onKeyUp, true);
 
@@ -259,8 +267,9 @@ export function get_scene_tree() {
       selectedCam.material.color = new THREE.Color(1, 1, 1);
       selectedCam = null;
     }
-    if (intersections.length > 0) {
-      selectedCam = intersections[0].object;
+    let filtered_intersections = intersections.filter(isect => checkVisibility(isect.object));
+    if (filtered_intersections.length > 0) {
+      selectedCam = filtered_intersections[0].object;
       selectedCam.material.color = new THREE.Color(0xfab300);
     }
   };

--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -120,9 +120,10 @@ export function get_scene_tree() {
   }
 
   function checkVisibility(camera) {
-    while (camera !== null) {
-      if (!camera.visible) return false;
-      camera = camera.parent
+    let curr = camera
+    while (curr !== null) {
+      if (!curr.visible) return false;
+      curr = curr.parent
     }
     return true;
   }
@@ -267,7 +268,7 @@ export function get_scene_tree() {
       selectedCam.material.color = new THREE.Color(1, 1, 1);
       selectedCam = null;
     }
-    let filtered_intersections = intersections.filter(isect => checkVisibility(isect.object));
+    const filtered_intersections = intersections.filter(isect => checkVisibility(isect.object));
     if (filtered_intersections.length > 0) {
       selectedCam = filtered_intersections[0].object;
       selectedCam.material.color = new THREE.Color(0xfab300);


### PR DESCRIPTION
Fixes for #788 and #789. Visibility updates are shallow, so scene objects often have stale visible booleans. This adds a simple traversal up the parent chain to check visibility