### PR TITLE
Add more controls for orienting poses

### DIFF
--- a/nerfstudio/data/dataparsers/record3d_dataparser.py
+++ b/nerfstudio/data/dataparsers/record3d_dataparser.py
@@ -105,9 +105,9 @@ class Record3D(DataParser):
         # convert to Tensors
         poses = torch.from_numpy(poses[:, :3, :4])
 
-        poses = camera_utils.auto_orient_poses(pose_utils.to4x4(poses), method=self.config.orientation_method)[
-            :, :3, :4
-        ]
+        poses = camera_utils.auto_orient_and_center_poses(
+            pose_utils.to4x4(poses), method=self.config.orientation_method
+        )[:, :3, :4]
 
         # Centering poses
         poses[:, :3, 3] = poses[:, :3, 3] - torch.mean(poses[:, :3, 3], dim=0)


### PR DESCRIPTION
Adding the following three options for the nerfstudio dataset:

`--orientation-method {pca, up, none}` (can now be `none`)
`--center-poses {bool}`
`--auto-scale-poses {bool}`