### PR TITLE
Fix completion install script for bash

### DIFF
--- a/scripts/completions/install.py
+++ b/scripts/completions/install.py
@@ -133,46 +133,52 @@ def _update_rc(
     """
 
     # Install or uninstall `source_line`.
-    source_lines = "\n".join(
-        [
-            "",
-            "# Source nerfstudio autocompletions.",
-            "# From https://unix.stackexchange.com/questions/339954/zsh-command-not-found-compinstall-compinit-compdef",
-            "autoload -Uz compinit",
-            "compinit",
-            f"source {completions_dir / 'setup'}.{shell}",
-        ]
-    )
+    header_line = "# Source nerfstudio autocompletions."
+    if shell == "zsh":
+        source_lines = "\n".join(
+            [
+                "",
+                header_line,
+                "if ! command -v compdef &> /dev/null; then",
+                "    autoload -Uz compinit",
+                "    compinit",
+                "fi",
+                f"source {completions_dir / 'setup'}.zsh",
+            ]
+        )
+    elif shell == "bash":
+        source_lines = "\n".join(
+            [
+                "",
+                header_line,
+                f"source {completions_dir / 'setup'}.bash",
+            ]
+        )
+    else:
+        assert_never(shell)
+
     rc_path = pathlib.Path(os.environ["HOME"]) / f".{shell}rc"
+
+    # Always try to uninstall previous completions.
+    rc_source = rc_path.read_text()
+    while header_line in rc_source:
+        before_install, _, after_install = rc_source.partition(header_line)
+        source_file, _, after_install = after_install.partition("\nsource ")[2].partition("\n")
+        assert source_file.endswith(f"/completions/setup.{shell}")
+        rc_source = before_install + after_install
+        rc_path.write_text(rc_source)
+        CONSOLE.log(f":broom: Existing completions uninstalled from {rc_path}.")
+
+    # Install completions.
     if mode == "install":
-        if source_lines in rc_path.read_text():
-            CONSOLE.log(f":call_me_hand: Completions are already installed in {rc_path}. {_exclamation()}")
-            return
-
-        if not Confirm.ask(f"[bold yellow]Install to {rc_path}?", default=True):
-            CONSOLE.log(f"[bold red]Skipping install for {rc_path.name}.")
-            return
-
-        rc_path.write_text(rc_path.read_text() + source_lines)
+        assert source_lines not in rc_source
+        rc_path.write_text(rc_source.rstrip() + "\n" + source_lines)
         CONSOLE.log(
             f":person_gesturing_ok: Completions installed to {rc_path}. {_exclamation()} Open a new shell to try them"
             " out."
         )
-
-    elif mode == "uninstall":
-        if source_lines not in rc_path.read_text():
-            CONSOLE.log(f":heavy_check_mark: No completions to uninstall from {rc_path.name}.")
-            return
-
-        if not Confirm.ask(f"[bold yellow]Uninstall from {rc_path}?", default=True):
-            CONSOLE.log(f"[dim red]Skipping uninstall for {rc_path.name}.")
-            return
-
-        rc_path.write_text(rc_path.read_text().replace(source_lines, ""))
-        CONSOLE.log(f":broom: Completions uninstalled from {rc_path}.")
-
     else:
-        assert_never(mode)
+        assert mode == "uninstall"
 
 
 def main(mode: ConfigureMode = "install") -> None:

--- a/scripts/completions/install.py
+++ b/scripts/completions/install.py
@@ -143,7 +143,7 @@ def _update_rc(
                 "    autoload -Uz compinit",
                 "    compinit",
                 "fi",
-                f"source {completions_dir / 'setup'}.zsh",
+                f"source {completions_dir / 'setup.zsh'}",
             ]
         )
     elif shell == "bash":
@@ -151,7 +151,7 @@ def _update_rc(
             [
                 "",
                 header_line,
-                f"source {completions_dir / 'setup'}.bash",
+                f"source {completions_dir / 'setup.bash'}",
             ]
         )
     else:


### PR DESCRIPTION
It seems like #747 added a few lines for initializing zsh completions, but these commands will cause errors in bash (`autoload: command not found`, `compinit: command not found`, etc).

I just:
- Removed these lines from the bash install.
- Added a condition to only run `compinit` when needed. `compinit` is quite slow (often 100s of milliseconds), so it's nice to avoid running it if it's not needed.
- Made the completion uninstall process more general.