### PR TITLE
Pathlib Python 3.7 Compatibility Fix

### DIFF
--- a/scripts/downloads/download_data.py
+++ b/scripts/downloads/download_data.py
@@ -32,7 +32,8 @@ def download_blender(save_dir: Path):
     unzip_path = save_dir / Path("nerf_synthetic")
     final_path = save_dir / Path("blender")
     unzip_path.rename(final_path)
-    download_path.unlink(missing_ok=True)
+    if download_path.exists():
+        download_path.unlink()
 
 
 def download_friends(save_dir: Path):
@@ -123,7 +124,8 @@ def download_dnerf(save_dir: Path):
     unzip_path = save_dir / Path("data")
     final_path = save_dir / Path("dnerf")
     unzip_path.rename(final_path)
-    download_path.unlink(missing_ok=True)
+    if download_path.exists():
+        download_path.unlink()
 
 
 def main(

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -345,7 +345,10 @@ def run_colmap(
 
     colmap_version = get_colmap_version()
 
-    (colmap_dir / "database.db").unlink(missing_ok=True)
+    colmap_database_path = colmap_dir / "database.db"
+    if colmap_database_path.exists():
+        # Can't use missing_ok argument because of Python 3.7 compatibility.
+        colmap_database_path.unlink()
 
     # Feature extraction
     feature_extractor_cmd = [


### PR DESCRIPTION
Small fix. the `missing_ok` optional arg in `Path.unlink` is only for Python 3.8+, so this makes it compatible with 3.7.