### PR TITLE
Fix camera interpolation bug

### DIFF
--- a/nerfstudio/viewer/app/src/modules/SidePanel/CameraPanel/curve.js
+++ b/nerfstudio/viewer/app/src/modules/SidePanel/CameraPanel/curve.js
@@ -60,6 +60,9 @@ export function get_curve_object_from_cameras(
 export function get_transform_matrix(position, lookat, up) {
   // normalize the vectors
   lookat.normalize();
+  // make up orthogonal to lookat
+  const up_proj = lookat.clone().multiplyScalar(up.dot(lookat));
+  up.sub(up_proj);
   up.normalize();
 
   // create a copy of the vector up


### PR DESCRIPTION
The rotation matrices for the camera paths were not orthogonal and did not have a det=1. This would cause wierd jumping artifacts.

Before
https://user-images.githubusercontent.com/3310961/198920295-33c78e50-e6b4-406d-95dc-6b2aa766e95d.mov

After
https://user-images.githubusercontent.com/3310961/198920246-1ddeede7-0e33-4ffe-bd49-9d1de4203971.mov

