### PR TITLE
Viewer visualization crashes when using DDP

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -90,7 +90,7 @@ class Trainer:
         # set up viewer if enabled
         viewer_log_path = self.base_dir / config.viewer.relative_log_filename
         self.viewer_state, banner_messages = None, None
-        if self.config.is_viewer_enabled():
+        if self.config.is_viewer_enabled() and local_rank == 0:
             self.viewer_state, banner_messages = viewer_utils.setup_viewer(config.viewer, log_filename=viewer_log_path)
         self._check_viewer_warnings()
         # set up writers/profilers if enabled


### PR DESCRIPTION
`check_main_thread` would return None in non-main processes, causing the script to crash. We now make sure to call that function only on `local_rank==0`