### PR TITLE
Revert change to pure paths

### DIFF
--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PureWindowsPath
 from typing import Optional, Type
 
 import numpy as np
@@ -80,7 +80,10 @@ class Nerfstudio(DataParser):
         num_skipped_image_filenames = 0
 
         for frame in meta["frames"]:
-            filepath = PurePath(frame["file_path"])
+            if "\\" in frame["file_path"]:
+                filepath = PureWindowsPath(frame["file_path"])
+            else:
+                filepath = PurePath(frame["file_path"])
             fname = self._get_fname(filepath)
             if not fname.exists():
                 num_skipped_image_filenames += 1


### PR DESCRIPTION
This reverts a change made in #832 to support `transforms.json` containing relative paths made in Windows. Thanks to @terrancewang for pointing this issue out.

In particular, the `sf_street` dataset contains a filename `images\\frame_00001.png`. This must be converted into `images/frame_00001.png` in POSIX systems.

This resolves #874 .