### PR TITLE
disallow fars <= nears

### DIFF
--- a/nerfstudio/model_components/scene_colliders.py
+++ b/nerfstudio/model_components/scene_colliders.py
@@ -84,6 +84,7 @@ class AABBBoxCollider(SceneBoxCollider):
         # clamp to near plane
         near_plane = self.near_plane if self.training else 0
         nears = torch.clamp(nears, min=near_plane)
+        fars = torch.maximum(fars, nears + 1e-6)
 
         return nears, fars
 


### PR DESCRIPTION
If a camera ray does not intersect the bounding box, `AABBBoxCollider` can return intervals with negative far and/or far < near, which in turn causes trouble downstream.  This is a simple fix to ensure far is always > near.