### PR TITLE
Start viewer with more accurate speed calculation

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -149,12 +149,14 @@ class Trainer:
                     for callback in self.callbacks:
                         callback.run_callback_at_location(step, location=TrainingCallbackLocation.AFTER_TRAIN_ITERATION)
 
-                writer.put_time(
-                    name=EventName.TRAIN_RAYS_PER_SEC,
-                    duration=self.config.pipeline.datamanager.train_num_rays_per_batch / train_t.duration,
-                    step=step,
-                    avg_over_steps=True,
-                )
+                # Skip the first two steps to avoid skewed timings that break the viewer rendering speed estimate.
+                if step > 1:
+                    writer.put_time(
+                        name=EventName.TRAIN_RAYS_PER_SEC,
+                        duration=self.config.pipeline.datamanager.train_num_rays_per_batch / train_t.duration,
+                        step=step,
+                        avg_over_steps=True,
+                    )
 
                 self._update_viewer_state(step)
 


### PR DESCRIPTION
If the viewer is open when rendering starts, the resolution will be very low due to skewed speed calculations. This PR delays these calculations until after a few iterations to avoid this issue.