### PR TITLE
nikhil/nan-training-debug

### DIFF
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -338,7 +338,7 @@ def _compute_residual_and_jacobian(
     return fx, fy, fx_x, fx_y, fy_x, fy_y
 
 
-@torch.jit.script
+# @torch.jit.script
 def radial_and_tangential_undistort(
     coords: torch.Tensor,
     distortion_params: torch.Tensor,

--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -298,7 +298,9 @@ class Cameras:
 
         if distortion_params is not None:
             coord_stack = camera_utils.radial_and_tangential_undistort(coord_stack, distortion_params)
-
+            if torch.isnan(coord_stack).sum():
+                nan_indices = torch.nonzero(torch.isnan(coord_stack), as_tuple=False)
+                import ipdb; ipdb.set_trace()
         if self.camera_type[0] == CameraType.PERSPECTIVE.value:
             directions_stack = torch.stack(
                 [coord_stack[..., 0], coord_stack[..., 1], -torch.ones_like(coord_stack[..., 1])], dim=-1


### PR DESCRIPTION
Got to this function be tracing nans back from model outputs up the stack. Found that before the call to 
`coord_stack = camera_utils.radial_and_tangential_undistort(coord_stack, distortion_params)` the coord_stack param is not nan and is nan after. When debugging within this function, I had to switch of torch scripting to insert a breakpoint. This caused the issue to go away, and none of the downstream breakpoints were hit either. When going to reference function in comment they do not seem to script this function. Not sure what within scripting is causing this to break

To reproduce the old error uncomment the torch.jit.script - and you should hit the breakpoint