### PR TITLE
Add missing activation

### DIFF
--- a/nerfstudio/fields/nerfacto_field.py
+++ b/nerfstudio/fields/nerfacto_field.py
@@ -312,12 +312,14 @@ class TorchNerfactoField(Field):
             num_layers=base_mlp_num_layers,
             layer_width=base_mlp_layer_width,
             skip_connections=skip_connections,
+            out_activation=nn.ReLU(),
         )
 
         self.mlp_head = MLP(
             in_dim=self.mlp_base.get_out_dim() + self.direction_encoding.get_out_dim() + self.appearance_embedding_dim,
             num_layers=head_mlp_num_layers,
             layer_width=head_mlp_layer_width,
+            out_activation=nn.ReLU(),
         )
 
         self.field_output_density = DensityFieldHead(in_dim=self.mlp_base.get_out_dim())

--- a/nerfstudio/fields/nerfw_field.py
+++ b/nerfstudio/fields/nerfw_field.py
@@ -83,6 +83,7 @@ class VanillaNerfWField(Field):
             num_layers=base_mlp_num_layers,
             layer_width=base_mlp_layer_width,
             skip_connections=skip_connections,
+            out_activation=nn.ReLU(),
         )
         self.mlp_transient = MLP(
             in_dim=self.mlp_base.get_out_dim() + self.embedding_transient.get_out_dim(),
@@ -90,6 +91,7 @@ class VanillaNerfWField(Field):
             num_layers=4,
             layer_width=base_mlp_layer_width,
             activation=nn.ReLU(),
+            out_activation=nn.ReLU(),
         )
         self.mlp_head = MLP(
             in_dim=self.mlp_base.get_out_dim()
@@ -97,6 +99,7 @@ class VanillaNerfWField(Field):
             + self.embedding_appearance.get_out_dim(),
             num_layers=head_mlp_num_layers,
             layer_width=head_mlp_layer_width,
+            out_activation=nn.ReLU(),
         )
 
         self.field_head_density = DensityFieldHead(in_dim=self.mlp_base.get_out_dim())

--- a/nerfstudio/fields/semantic_nerf_field.py
+++ b/nerfstudio/fields/semantic_nerf_field.py
@@ -67,17 +67,20 @@ class SemanticNerfField(Field):
             num_layers=base_mlp_num_layers,
             layer_width=base_mlp_layer_width,
             skip_connections=skip_connections,
+            out_activation=nn.ReLU(),
         )
         self.mlp_head = MLP(
             in_dim=self.mlp_base.get_out_dim() + self.direction_encoding.get_out_dim(),
             num_layers=head_mlp_num_layers,
             layer_width=head_mlp_layer_width,
+            out_activation=nn.ReLU(),
         )
         self.mlp_semantic = MLP(
             in_dim=self.mlp_head.get_out_dim(),
             layer_width=self.mlp_head.layer_width // 2,
             num_layers=1,
             activation=nn.ReLU(),
+            out_activation=nn.ReLU(),
         )
         self.field_head_density = DensityFieldHead(in_dim=self.mlp_base.get_out_dim())
         self.field_head_rgb = RGBFieldHead(in_dim=self.mlp_head.get_out_dim())

--- a/nerfstudio/fields/tensorf_field.py
+++ b/nerfstudio/fields/tensorf_field.py
@@ -68,6 +68,7 @@ class TensoRFField(Field):
             num_layers=head_mlp_num_layers,
             layer_width=head_mlp_layer_width,
             activation=nn.ReLU(),
+            out_activation=nn.ReLU(),
         )
 
         self.use_sh = use_sh

--- a/nerfstudio/fields/vanilla_nerf_field.py
+++ b/nerfstudio/fields/vanilla_nerf_field.py
@@ -73,12 +73,14 @@ class NeRFField(Field):
             num_layers=base_mlp_num_layers,
             layer_width=base_mlp_layer_width,
             skip_connections=skip_connections,
+            out_activation=nn.ReLU(),
         )
 
         self.mlp_head = MLP(
             in_dim=self.mlp_base.get_out_dim() + self.direction_encoding.get_out_dim(),
             num_layers=head_mlp_num_layers,
             layer_width=head_mlp_layer_width,
+            out_activation=nn.ReLU(),
         )
 
         self.field_output_density = DensityFieldHead(in_dim=self.mlp_base.get_out_dim())


### PR DESCRIPTION
When using the MLP defaults it does not set the output activation. The current models assume a relu activation has been applied.