### PR TITLE
Add flag to kill training when complete

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -178,6 +178,8 @@ class ViewerConfig(PrintableConfig):
     max_num_display_images: int = 512
     """Maximum number of training images to display in the viewer, to avoid lag. This does not change which images are
     actually used in training/evaluation. If -1, display all."""
+    quit_on_train_completion: bool = False
+    """Whether to kill the training job when it has completed. Note this will stop rendering in the viewer."""
 
 
 from nerfstudio.engine.optimizers import OptimizerConfig

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -131,6 +131,7 @@ class Trainer:
         self._init_viewer_state()
         with TimeWriter(writer, EventName.TOTAL_TRAIN_TIME):
             num_iterations = self.config.trainer.max_num_iterations
+            step = 0
             for step in range(self._start_step, self._start_step + num_iterations):
                 with TimeWriter(writer, EventName.ITER_TRAIN_TIME, step=step) as train_t:
 
@@ -174,10 +175,12 @@ class Trainer:
                 writer.write_out_storage()
             # save checkpoint at the end of training
             self.save_checkpoint(step)
+
             CONSOLE.rule()
             CONSOLE.print("[bold green]:tada: :tada: :tada: Training Finished :tada: :tada: :tada:", justify="center")
-            CONSOLE.print("Use ctrl+c to quit", justify="center")
-            self._always_render(step)
+            if not self.config.viewer.quit_on_train_completion:
+                CONSOLE.print("Use ctrl+c to quit", justify="center")
+                self._always_render(step)
 
     @check_main_thread
     def _always_render(self, step):


### PR DESCRIPTION
Adding the flag `--viewer.quit-on-train-completion True` will kill the training process when it completes. By default it continues to run to allow viewer interactivity.