### PR TITLE
Add 'inference' mode to pipeline

### DIFF
--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -136,9 +136,9 @@ class DataManager(nn.Module):
         super().__init__()
         self.train_count = 0
         self.eval_count = 0
-        if self.train_dataset:
+        if self.train_dataset and self.test_mode != "inference":
             self.setup_train()
-        if self.eval_dataset:
+        if self.eval_dataset and self.test_mode != "inference":
             self.setup_eval()
 
     def forward(self):
@@ -288,7 +288,7 @@ class VanillaDataManager(DataManager):  # pylint: disable=abstract-method
         self,
         config: VanillaDataManagerConfig,
         device: Union[torch.device, str] = "cpu",
-        test_mode: bool = False,
+        test_mode: str = "val",
         world_size: int = 1,
         local_rank: int = 0,
         **kwargs,  # pylint: disable=unused-argument
@@ -310,9 +310,8 @@ class VanillaDataManager(DataManager):  # pylint: disable=abstract-method
 
     def create_eval_dataset(self) -> InputDataset:
         """Sets up the data loaders for evaluation"""
-        return InputDataset(
-            self.config.dataparser.setup().get_dataparser_outputs(split="val" if not self.test_mode else "test")
-        )
+        assert self.test_mode != "inference"
+        return InputDataset(self.config.dataparser.setup().get_dataparser_outputs(split=self.test_mode))
 
     def setup_train(self):
         """Sets up the data loaders for training"""

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -299,6 +299,7 @@ class VanillaDataManager(DataManager):  # pylint: disable=abstract-method
         self.local_rank = local_rank
         self.sampler = None
         self.test_mode = test_mode
+        self.test_split = "test" if test_mode in ["test", "inference"] else "val"
 
         self.train_dataset = self.create_train_dataset()
         self.eval_dataset = self.create_eval_dataset()
@@ -310,8 +311,7 @@ class VanillaDataManager(DataManager):  # pylint: disable=abstract-method
 
     def create_eval_dataset(self) -> InputDataset:
         """Sets up the data loaders for evaluation"""
-        assert self.test_mode != "inference"
-        return InputDataset(self.config.dataparser.setup().get_dataparser_outputs(split=self.test_mode))
+        return InputDataset(self.config.dataparser.setup().get_dataparser_outputs(split=self.test_split))
 
     def setup_train(self):
         """Sets up the data loaders for training"""

--- a/nerfstudio/data/datamanagers/semantic_datamanager.py
+++ b/nerfstudio/data/datamanagers/semantic_datamanager.py
@@ -44,6 +44,4 @@ class SemanticDataManager(VanillaDataManager):  # pylint: disable=abstract-metho
         return SemanticDataset(self.config.dataparser.setup().get_dataparser_outputs(split="train"))
 
     def create_eval_dataset(self) -> SemanticDataset:
-        return SemanticDataset(
-            self.config.dataparser.setup().get_dataparser_outputs(split="val" if not self.test_mode else "test")
-        )
+        return SemanticDataset(self.config.dataparser.setup().get_dataparser_outputs(split=self.test_mode))

--- a/nerfstudio/data/datamanagers/semantic_datamanager.py
+++ b/nerfstudio/data/datamanagers/semantic_datamanager.py
@@ -44,4 +44,4 @@ class SemanticDataManager(VanillaDataManager):  # pylint: disable=abstract-metho
         return SemanticDataset(self.config.dataparser.setup().get_dataparser_outputs(split="train"))
 
     def create_eval_dataset(self) -> SemanticDataset:
-        return SemanticDataset(self.config.dataparser.setup().get_dataparser_outputs(split=self.test_mode))
+        return SemanticDataset(self.config.dataparser.setup().get_dataparser_outputs(split=self.test_split))

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -102,11 +102,14 @@ class Trainer:
         writer.put_config(name="config", config_dict=dataclasses.asdict(config), step=0)
         profiler.setup_profiler(config.logging)
 
-    def setup(self, test_mode=False):
+    def setup(self, test_mode: str = "val"):
         """Setup the Trainer by calling other setup functions.
 
         Args:
-            test_mode: Whether to setup for testing. Defaults to False.
+            test_mode: ['val', 'test', 'inference']
+                'val': loads train/val datasets into memory
+                'test': loads train/test datset into memory
+                'inference': does not load any dataset into memory
         """
         self.pipeline = self.config.pipeline.setup(
             device=self.device, test_mode=test_mode, world_size=self.world_size, local_rank=self.local_rank

--- a/nerfstudio/pipelines/base_pipeline.py
+++ b/nerfstudio/pipelines/base_pipeline.py
@@ -77,7 +77,10 @@ class Pipeline(nn.Module):
     Args:
         config: configuration to instantiate pipeline
         device: location to place model and data
-        test_mode: if True, loads test datset. if False, loads train/eval datasets
+        test_mode: ['val', 'test', 'inference']
+            'train': loads train/eval datasets into memory
+            'test': loads train/test datset into memory
+            'inference': does not load any dataset into memory
         world_size: total number of machines available
         local_rank: rank of current machine
 
@@ -191,7 +194,10 @@ class VanillaPipeline(Pipeline):
 
         config: configuration to instantiate pipeline
         device: location to place model and data
-        test_mode: if True, loads test datset. if False, loads train/eval datasets
+        test_mode: ['val', 'test', 'inference']
+            'val': loads train/val datasets into memory
+            'test': loads train/test datset into memory
+            'inference': does not load any dataset into memory
         world_size: total number of machines available
         local_rank: rank of current machine
 
@@ -204,12 +210,13 @@ class VanillaPipeline(Pipeline):
         self,
         config: VanillaPipelineConfig,
         device: str,
-        test_mode: bool = False,
+        test_mode: str = "val",
         world_size: int = 1,
         local_rank: int = 0,
     ):
         super().__init__()
         self.config = config
+        self.test_mode = test_mode
         self.datamanager: VanillaDataManager = config.datamanager.setup(
             device=device, test_mode=test_mode, world_size=world_size, local_rank=local_rank
         )
@@ -351,6 +358,9 @@ class VanillaPipeline(Pipeline):
             loaded_state: pre-trained model state dict
         """
         state = {key.replace("module.", ""): value for key, value in loaded_state.items()}
+        if self.test_mode == "inference":
+            state.pop("datamanager.train_ray_generator.image_coords")
+            state.pop("datamanager.eval_ray_generator.image_coords")
         self.load_state_dict(state)  # type: ignore
 
     def get_training_callbacks(

--- a/nerfstudio/pipelines/dynamic_batch.py
+++ b/nerfstudio/pipelines/dynamic_batch.py
@@ -49,7 +49,7 @@ class DynamicBatchPipeline(VanillaPipeline):
         self,
         config: DynamicBatchPipelineConfig,
         device: str,
-        test_mode: bool = False,
+        test_mode: str = "val",
         world_size: int = 1,
         local_rank: int = 0,
     ):

--- a/nerfstudio/utils/eval_utils.py
+++ b/nerfstudio/utils/eval_utils.py
@@ -63,11 +63,19 @@ def eval_load_checkpoint(config: cfg.TrainerConfig, pipeline: Pipeline) -> Path:
     return load_path
 
 
-def eval_setup(config_path: Path, eval_num_rays_per_chunk: Optional[int] = None) -> Tuple[cfg.Config, Pipeline, Path]:
+def eval_setup(
+    config_path: Path, eval_num_rays_per_chunk: Optional[int] = None, test_mode: str = "test"
+) -> Tuple[cfg.Config, Pipeline, Path]:
     """Shared setup for loading a saved pipeline for evaluation.
 
     Args:
         config_path: Path to config YAML file.
+        eval_num_rays_per_chunk: Number of rays per forward pass
+        test_mode: ['val', 'test', 'inference']
+            'val': loads train/val datasets into memory
+            'test': loads train/test datset into memory
+            'inference': does not load any dataset into memory
+
 
     Returns:
         Loaded config, pipeline module, and corresponding checkpoint.
@@ -86,7 +94,7 @@ def eval_setup(config_path: Path, eval_num_rays_per_chunk: Optional[int] = None)
 
     # setup pipeline (which includes the DataManager)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    pipeline = config.pipeline.setup(device=device, test_mode=True)
+    pipeline = config.pipeline.setup(device=device, test_mode=test_mode)
     assert isinstance(pipeline, Pipeline)
     pipeline.eval()
 

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -106,7 +106,7 @@ class RenderTrajectory:
     # Path to config YAML file.
     load_config: Path
     # Name of the renderer outputs to use. rgb, depth, etc. concatenates them along y axis
-    rendered_output_names: List[str] = field(default_factory=lambda: ["rgb", "semantics_colormap"])
+    rendered_output_names: List[str] = field(default_factory=lambda: ["rgb"])
     #  Trajectory to render.
     traj: Literal["spiral", "filename"] = "spiral"
     # Scaling factor to apply to the camera image resolution.

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -4,13 +4,14 @@ render.py
 """
 from __future__ import annotations
 
-import dataclasses
 import json
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import mediapy as media
+import numpy as np
 import torch
 import tyro
 from rich.console import Console
@@ -38,7 +39,7 @@ def _render_trajectory_video(
     pipeline: Pipeline,
     cameras: Cameras,
     output_filename: Path,
-    rendered_output_name: str,
+    rendered_output_names: List[str],
     rendered_resolution_scaling_factor: float = 1.0,
     seconds: float = 5.0,
     output_format: Literal["images", "video"] = "video",
@@ -49,7 +50,7 @@ def _render_trajectory_video(
         pipeline: Pipeline to evaluate with.
         cameras: Cameras to render.
         output_filename: Name of the output file.
-        rendered_output_name: Name of the renderer output to use.
+        rendered_output_names: List of outputs to visualise.
         rendered_resolution_scaling_factor: Scaling factor to apply to the camera image resolution.
         seconds: Length of output video.
         output_format: How to save output data.
@@ -73,16 +74,20 @@ def _render_trajectory_video(
             camera_ray_bundle = cameras.generate_rays(camera_indices=camera_idx).to(pipeline.device)
             with torch.no_grad():
                 outputs = pipeline.model.get_outputs_for_camera_ray_bundle(camera_ray_bundle)
-            if rendered_output_name not in outputs:
-                CONSOLE.rule("Error", style="red")
-                CONSOLE.print(f"Could not find {rendered_output_name} in the model outputs", justify="center")
-                CONSOLE.print(f"Please set --rendered_output_name to one of: {outputs.keys()}", justify="center")
-                sys.exit(1)
-            image = outputs[rendered_output_name].cpu().numpy()
+            render_image = []
+            for rendered_output_name in rendered_output_names:
+                if rendered_output_name not in outputs:
+                    CONSOLE.rule("Error", style="red")
+                    CONSOLE.print(f"Could not find {rendered_output_name} in the model outputs", justify="center")
+                    CONSOLE.print(f"Please set --rendered_output_name to one of: {outputs.keys()}", justify="center")
+                    sys.exit(1)
+                output_image = outputs[rendered_output_name].cpu().numpy()
+                render_image.append(output_image)
+            render_image = np.concatenate(render_image, axis=1)
             if output_format == "images":
-                media.write_image(output_image_dir / f"{camera_idx:05d}.png", image)
+                media.write_image(output_image_dir / f"{camera_idx:05d}.png", render_image)
             else:
-                images.append(image)
+                images.append(render_image)
 
     if output_format == "video":
         fps = len(images) / seconds
@@ -94,14 +99,14 @@ def _render_trajectory_video(
     CONSOLE.print(f"[green]Saved video to {output_filename}", justify="center")
 
 
-@dataclasses.dataclass
+@dataclass
 class RenderTrajectory:
     """Load a checkpoint, render a trajectory, and save to a video file."""
 
     # Path to config YAML file.
     load_config: Path
-    # Name of the renderer output to use. rgb, depth, etc.
-    rendered_output_name: str = "rgb"
+    # Name of the renderer outputs to use. rgb, depth, etc. concatenates them along y axis
+    rendered_output_names: List[str] = field(default_factory=lambda: ["rgb", "semantics_colormap"])
     #  Trajectory to render.
     traj: Literal["spiral", "filename"] = "spiral"
     # Scaling factor to apply to the camera image resolution.
@@ -122,6 +127,7 @@ class RenderTrajectory:
         _, pipeline, _ = eval_setup(
             self.load_config,
             eval_num_rays_per_chunk=self.eval_num_rays_per_chunk,
+            test_mode="test" if self.traj == "spiral" else "inference",
         )
 
         install_checks.check_ffmpeg_installed()
@@ -145,7 +151,7 @@ class RenderTrajectory:
             pipeline,
             camera_path,
             output_filename=self.output_path,
-            rendered_output_name=self.rendered_output_name,
+            rendered_output_names=self.rendered_output_names,
             rendered_resolution_scaling_factor=1.0 / self.downscale_factor,
             seconds=seconds,
             output_format=self.output_format,


### PR DESCRIPTION
Add 'inference' mode for rendering and add option to visualise multiple modalities. When loading a trajectory from disk such as using the 'filepath' option - there is no need to load the train and eval images into memory. More generally we do not want to do this when purely running inference through the nerf model. This PR adds an inference option to allow for this usecase.
In addition to this also allow render.py to plot multiple modalities side by side. An example with friends-data is shown

https://user-images.githubusercontent.com/47728081/201646752-c49c5d31-bb69-4be7-8276-a0d49db96d62.mp4

