### PR TITLE
[WIP] Add NR-NeRF method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ data
 # Misc
 old/
 temp*
+*.swp
 !temporal*
 .nfs*
 external/

--- a/nerfstudio/cameras/rays.py
+++ b/nerfstudio/cameras/rays.py
@@ -114,6 +114,19 @@ class RaySamples(TensorDataclass):
     times: Optional[TensorType[..., 1]] = None
     """Times at which rays are sampled"""
 
+    def get_alphas(self, densities: TensorType[..., "num_samples", 1]) -> TensorType[..., "num_samples", 1]:
+        """Return alphas based on predicted densities
+
+        Args:
+            densities: Predicted densities for samples along ray
+
+        Returns:
+            alphas for each sample
+        """
+        delta_density = self.deltas * densities
+        alphas = 1 - torch.exp(-delta_density)
+        return alphas
+
     def get_weights(self, densities: TensorType[..., "num_samples", 1]) -> TensorType[..., "num_samples", 1]:
         """Return weights based on predicted densities
 

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -55,6 +55,7 @@ descriptions = {
     "vanilla-nerf": "Original NeRF model. (slow)",
     "tensorf": "tensorf",
     "dnerf": "Dynamic-NeRF model. (slow)",
+    "nrnerf": "Non-Rigid NeRF model. (slow)",
 }
 
 method_configs["nerfacto"] = Config(
@@ -198,6 +199,28 @@ method_configs["dnerf"] = Config(
             _target=NeRFModel,
             enable_temporal_distortion=True,
             temporal_distortion_params={"kind": TemporalDistortionKind.DNERF},
+        ),
+    ),
+    optimizers={
+        "fields": {
+            "optimizer": RAdamOptimizerConfig(lr=5e-4, eps=1e-08),
+            "scheduler": None,
+        },
+        "temporal_distortion": {
+            "optimizer": RAdamOptimizerConfig(lr=5e-4, eps=1e-08),
+            "scheduler": None,
+        },
+    },
+)
+
+method_configs["nrnerf"] = Config(
+    method_name="nrnerf",
+    pipeline=VanillaPipelineConfig(
+        datamanager=VanillaDataManagerConfig(dataparser=DNeRFDataParserConfig()),
+        model=VanillaModelConfig(
+            _target=NeRFModel,
+            enable_temporal_distortion=True,
+            temporal_distortion_params={"kind": TemporalDistortionKind.NRNERF},
         ),
     ),
     optimizers={

--- a/nerfstudio/field_components/temporal_distortions.py
+++ b/nerfstudio/field_components/temporal_distortions.py
@@ -14,6 +14,7 @@
 
 """Space distortions which occur as a function of time."""
 
+from abc import abstractmethod
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple
 
@@ -23,6 +24,7 @@ from torchtyping import TensorType
 
 from nerfstudio.field_components.encodings import Encoding, NeRFEncoding
 from nerfstudio.field_components.mlp import MLP
+from nerfstudio.utils.math import hutchinson_div_approx
 
 
 class TemporalDistortion(nn.Module):
@@ -38,16 +40,27 @@ class TemporalDistortion(nn.Module):
             Translated positions.
         """
 
+    @abstractmethod
+    def get_loss_dict(self, outputs, batch) -> Dict[str, torch.Tensor]:
+        """
+        Returns:
+          Dict of loss names to relevant losses. May be empty.
+        """
+        return {}
+
 
 class TemporalDistortionKind(Enum):
     """Possible temporal distortion names"""
 
     DNERF = "dnerf"
+    NRNERF = "nrnerf"
 
     def to_temporal_distortion(self, config: Dict[str, Any]) -> TemporalDistortion:
         """Converts this kind to a temporal distortion"""
         if self == TemporalDistortionKind.DNERF:
             return DNeRFDistortion(**config)
+        if self == TemporalDistortionKind.NRNERF:
+            return NRNeRFDistortion(**config)
         raise NotImplementedError(f"Unknown temporal distortion kind {self}")
 
 
@@ -84,9 +97,82 @@ class DNeRFDistortion(TemporalDistortion):
             skip_connections=skip_connections,
         )
 
+    def get_loss_dict(self, outputs, batch) -> Dict[str, torch.Tensor]:
+        return {}
+
     def forward(self, positions, times=None):
         if times is None:
             return None
         p = self.position_encoding(positions)
         t = self.temporal_encoding(times)
         return self.mlp_deform(torch.cat([p, t], dim=-1))
+
+
+class NRNeRFDistortion(TemporalDistortion):
+    """Optimizable temporal deformation using an MLP.
+    Args:
+        position_encoding: An encoding for the XYZ of distortion
+        temporal_encoding: An encoding for the time of distortion
+        mlp_num_layers: Number of layers in distortion MLP
+        mlp_layer_width: Size of hidden layer for the MLP
+        skip_connections: Number of layers for skip connections in the MLP
+    """
+
+    def __init__(
+        self,
+        position_encoding: Encoding = NeRFEncoding(
+            in_dim=3, num_frequencies=10, min_freq_exp=0.0, max_freq_exp=8.0, include_input=True
+        ),
+        temporal_encoding: Encoding = NeRFEncoding(
+            in_dim=1, num_frequencies=10, min_freq_exp=0.0, max_freq_exp=8.0, include_input=True
+        ),
+        mlp_num_layers: int = 4,
+        mlp_layer_width: int = 256,
+        skip_connections: Tuple[int] = (4,),
+    ) -> None:
+        super().__init__()
+        self.position_encoding = position_encoding
+        self.temporal_encoding = temporal_encoding
+        self.mlp_deform = MLP(
+            in_dim=self.position_encoding.get_out_dim() + self.temporal_encoding.get_out_dim(),
+            out_dim=4,
+            num_layers=mlp_num_layers,
+            layer_width=mlp_layer_width,
+            skip_connections=skip_connections,
+        )
+        self.rigidity = None
+        self.p = None
+        self.raw_offset = None
+        self.rigid_offset = None
+
+    def forward(self, positions, times=None):
+        if times is None:
+            return None
+        self.p = positions.requires_grad_()
+        p = self.position_encoding(self.p)
+        t = self.temporal_encoding(times)
+        self.raw_offset, self.rigidity = self.mlp_deform(torch.cat([p, t], dim=-1)).split([3, 1], dim=-1)
+        self.rigidity = self.rigidity.sigmoid()
+
+        self.rigid_offset = self.raw_offset * self.rigidity
+        return self.rigid_offset
+
+    def get_loss_dict(self, outputs, batch) -> Dict[str, torch.Tensor]:
+        if self.p is None:
+            return {}
+        div_loss = hutchinson_div_approx(self.p, self.rigid_offset).square()
+        # div_coarse = (div_loss * outputs["alphas_coarse"]).mean()
+        div_fine = (div_loss * outputs["alphas_fine"].squeeze(-1)).mean()
+
+        norm_dp = torch.linalg.vector_norm(self.raw_offset, dim=-1, keepdim=True)
+        norm_dp = norm_dp.pow(2 - self.rigidity)
+
+        # offset_coarse = outputs["weights_coarse"] * (norm_dp + 3e-3 * self.rigidity)
+        offset_fine = (outputs["weights_fine"] * (norm_dp + 3e-3 * self.rigidity)).mean()
+
+        return {
+            # "divergence_coarse": div_coarse,
+            "divergence_fine": div_fine,
+            # "offset_coarse": offset_coarse,
+            "offset_fine": offset_fine,
+        }


### PR DESCRIPTION
[NR-NeRF](https://arxiv.org/pdf/2012.12247.pdf) is another approach to dynamic NeRF that uses rigidity and additional losses.

I don't know if dedicating a whole set of configs to dynamic approaches is good, maybe it would be good to create a subcommand and have dynamic configs under that?

I can't test it rn because I'm on a machine that has 3 GB and it seems that some tensor is being stored that leads to an eventual OOM even if I only use 50 rays per batch

Edit: turns out eval was causing OOM not mem leaking from somewhere else