### PR TITLE
Fix variable name error in dataloaders.py

### DIFF
--- a/nerfstudio/data/utils/dataloaders.py
+++ b/nerfstudio/data/utils/dataloaders.py
@@ -166,7 +166,7 @@ class EvalDataloader(DataLoader):
             camera_to_worlds=self.cameras.camera_to_worlds[image_idx : image_idx + 1],
             distortion_params=distortion_params,
             camera_type=self.cameras.camera_type[image_idx : image_idx + 1],
-            times=self.cameras.times[image_idx : image_idx + 1] if self.cameras.time else None,
+            times=self.cameras.times[image_idx : image_idx + 1] if self.cameras.times else None,
         )
         return camera
 


### PR DESCRIPTION
AttributeError: 'Cameras' object has no attribute 'time' will occur when ns-render with --traj spiral