### PR TITLE
create rays on device when rendering

### DIFF
--- a/scripts/render.py
+++ b/scripts/render.py
@@ -58,6 +58,7 @@ def _render_trajectory_video(
     CONSOLE.print("[bold green]Creating trajectory video")
     images = []
     cameras.rescale_output_resolution(rendered_resolution_scaling_factor)
+    cameras = cameras.to(pipeline.device)
 
     progress = Progress(
         TextColumn(":movie_camera: Rendering :movie_camera:"),
@@ -71,7 +72,7 @@ def _render_trajectory_video(
         output_image_dir.mkdir(parents=True, exist_ok=True)
     with progress:
         for camera_idx in progress.track(range(cameras.size), description=""):
-            camera_ray_bundle = cameras.generate_rays(camera_indices=camera_idx).to(pipeline.device)
+            camera_ray_bundle = cameras.generate_rays(camera_indices=camera_idx)
             with torch.no_grad():
                 outputs = pipeline.model.get_outputs_for_camera_ray_bundle(camera_ray_bundle)
             render_image = []


### PR DESCRIPTION
When using `traj=="filename"` `camera_ray_bundle` is generated on the cpu and then moved to the gpu which can be slow.