### PR TITLE
TensoRF bugfix: AABB normalized_positions to [-1, 1]

### DIFF
--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -423,6 +423,13 @@ class TensorVMEncoding(Encoding):
         return self.num_components * 3
 
     def forward(self, in_tensor: TensorType["bs":..., "input_dim"]) -> TensorType["bs":..., "output_dim"]:
+        """Compute encoding for each position in in_positions
+
+        Args:
+            in_tensor: position inside bounds in range [-1,1],
+
+        Returns: Encoded position
+        """
         plane_coord = torch.stack([in_tensor[..., [0, 1]], in_tensor[..., [0, 2]], in_tensor[..., [1, 2]]])  # [3,...,2]
         line_coord = torch.stack([in_tensor[..., 2], in_tensor[..., 1], in_tensor[..., 0]])  # [3, ...]
         line_coord = torch.stack([torch.zeros_like(line_coord), line_coord], dim=-1)  # [3, ...., 2]

--- a/nerfstudio/fields/tensorf_field.py
+++ b/nerfstudio/fields/tensorf_field.py
@@ -85,6 +85,7 @@ class TensoRFField(Field):
 
     def get_density(self, ray_samples: RaySamples):
         positions = SceneBox.get_normalized_positions(ray_samples.frustums.get_positions(), self.aabb)
+        positions = positions * 2 - 1
         density = self.density_encoding(positions)
         density_enc = torch.sum(density, dim=-1)[:, :, None]
         relu = torch.nn.ReLU()
@@ -94,6 +95,7 @@ class TensoRFField(Field):
     def get_outputs(self, ray_samples: RaySamples, density_embedding: Optional[TensorType] = None) -> TensorType:
         d = ray_samples.frustums.directions
         positions = SceneBox.get_normalized_positions(ray_samples.frustums.get_positions(), self.aabb)
+        positions = positions * 2 - 1
         rgb_features = self.color_encoding(positions)
         rgb_features = self.B(rgb_features)
 


### PR DESCRIPTION
Previously, SceneBox.get_normalized_positions() returned a value in 0,1. This was fine for InstantNGP and Nerfacto, which use these values directly in an MLP. For TensoRF though, this was an error because grid sample expects values in the range `[-1,1]`. Thus, I think only 1/4th of the encoding planes were actually being used, and half of the encoding lines were.