### PR TITLE
Ignore non-image files in ns-process-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,11 @@ dev = [
 
 # Documentation related packages
 docs = [
-    "furo==2022.4.7",
+    "furo==2022.09.29",
     "readthedocs-sphinx-search==0.1.2",
     "myst-nb==0.16.0",
     "nbformat==5.5.0",
-    "sphinx==4.5.0",
+    "sphinx==5.2.1",
     "sphinxemoji==0.2.0",
     "sphinx-argparse==0.3.1",
     "sphinx-copybutton==0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,11 @@ dev = [
 # Documentation related packages
 docs = [
     "furo==2022.09.29",
+    # Specifying ipython for https://github.com/ipython/ipython/issues/13845
+    "ipython==8.6.0",
     "readthedocs-sphinx-search==0.1.2",
     "myst-nb==0.16.0",
+    "nbconvert==7.2.5",
     "nbformat==5.5.0",
     "sphinx==5.2.1",
     "sphinxemoji==0.2.0",

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -335,7 +335,8 @@ class ProcessRecord3D:
         record3d_image_filenames = []
         for f in record3d_image_dir.iterdir():
             if f.stem.isdigit():  # removes possible duplicate images (for example, 123(3).jpg)
-                record3d_image_filenames.append(f)
+                if f.suffix.lower() in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
+                    record3d_image_filenames.append(f)
 
         record3d_image_filenames = sorted(record3d_image_filenames, key=lambda fn: int(fn.stem))
         num_images = len(record3d_image_filenames)
@@ -436,7 +437,8 @@ class ProcessPolycam:
 
         polycam_image_filenames = []
         for f in polycam_image_dir.iterdir():
-            polycam_image_filenames.append(f)
+            if f.suffix.lower() in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
+                polycam_image_filenames.append(f)
         polycam_image_filenames = sorted(polycam_image_filenames, key=lambda fn: int(fn.stem))
         num_images = len(polycam_image_filenames)
         idx = np.arange(num_images)
@@ -528,7 +530,8 @@ class ProcessMetashape:
         # Copy images to output directory
         image_filenames = []
         for f in self.data.iterdir():
-            image_filenames.append(f)
+            if f.suffix.lower() in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
+                image_filenames.append(f)
         image_filenames = sorted(image_filenames, key=lambda fn: fn.stem)
         num_images = len(image_filenames)
         idx = np.arange(num_images)


### PR DESCRIPTION
When using the metashape data processing, it would fail if other non-image files were included in the directory.