### PR TITLE
fix download command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The following will train a _nerfacto_ model, our recommended model for real worl
 
 ```bash
 # Download some test data:
-ns-download-data nerfstudio --capture-name=poster
+ns-download-data --dataset nerfstudio --capture-name=poster
 # Train model
 ns-train nerfacto --data data/nerfstudio/poster
 ```


### PR DESCRIPTION
FWIW I still get the following error when running the download command:

```
Access denied with the following error:

        Cannot retrieve the public link of the file. You may need to change
        the permission to 'Anyone with the link', or have had many accesses.

You may still be able to access the file from the browser:

         https://drive.google.com/uc?id=1dmjWGXlJnUxwosN6MVooCDQe970PkD-1
```

However manually downloading the file with the link at the bottom and placing the zip into the expected location seems to work.