### PR TITLE
Allow users to skip using openrelay

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -183,6 +183,9 @@ class ViewerConfig(PrintableConfig):
     actually used in training/evaluation. If -1, display all."""
     quit_on_train_completion: bool = False
     """Whether to kill the training job when it has completed. Note this will stop rendering in the viewer."""
+    skip_openrelay: bool = False
+    """Avoid using openrelay to communicate with the viewer. Try disabling if you have trouble
+    connecting to the viewer"""
 
 
 from nerfstudio.engine.optimizers import OptimizerConfig

--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -508,25 +508,28 @@ class ViewerState:
         # returns the description to for WebRTC to the specific websocket connection
         offer = RTCSessionDescription(data["sdp"], data["type"])
 
-        pc = RTCPeerConnection(
-            configuration=RTCConfiguration(
-                iceServers=[
-                    RTCIceServer(urls="stun:stun.l.google.com:19302"),
-                    RTCIceServer(urls="stun:openrelay.metered.ca:80"),
-                    RTCIceServer(
-                        urls="turn:openrelay.metered.ca:80", username="openrelayproject", credential="openrelayproject"
-                    ),
-                    RTCIceServer(
-                        urls="turn:openrelay.metered.ca:443", username="openrelayproject", credential="openrelayproject"
-                    ),
-                    RTCIceServer(
-                        urls="turn:openrelay.metered.ca:443?transport=tcp",
-                        username="openrelayproject",
-                        credential="openrelayproject",
-                    ),
-                ]
-            )
-        )
+        if self.config.skip_openrelay:
+            ice_servers = [
+                RTCIceServer(urls="stun:stun.l.google.com:19302"),
+            ]
+        else:
+            ice_servers = [
+                RTCIceServer(urls="stun:stun.l.google.com:19302"),
+                RTCIceServer(urls="stun:openrelay.metered.ca:80"),
+                RTCIceServer(
+                    urls="turn:openrelay.metered.ca:80", username="openrelayproject", credential="openrelayproject"
+                ),
+                RTCIceServer(
+                    urls="turn:openrelay.metered.ca:443", username="openrelayproject", credential="openrelayproject"
+                ),
+                RTCIceServer(
+                    urls="turn:openrelay.metered.ca:443?transport=tcp",
+                    username="openrelayproject",
+                    credential="openrelayproject",
+                ),
+            ]
+
+        pc = RTCPeerConnection(configuration=RTCConfiguration(iceServers=ice_servers))
         self.pcs.add(pc)
 
         video = SingleFrameStreamTrack()


### PR DESCRIPTION
There seems to be an issue with some users if they are unable to connect to the TURN server. Seems to be related to - https://github.com/aiortc/aioice/issues/16
As a workaround, we now have the option to skip using openrelay servers suing the the command `--viewer.skip-openrelay`. 