### PR TITLE
Interpolation config for tcnn hashgrid

### DIFF
--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -228,6 +228,7 @@ class HashEncoding(Encoding):
         features_per_level: Number of features per level.
         hash_init_scale: Value to initialize hash grid.
         implementation: Implementation of hash encoding. Fallback to torch if tcnn not available.
+        interpolation: Interpolation override for tcnn hashgrid. Not supported for torch unless linear.
     """
 
     def __init__(
@@ -239,6 +240,7 @@ class HashEncoding(Encoding):
         features_per_level: int = 2,
         hash_init_scale: float = 0.001,
         implementation: Literal["tcnn", "torch"] = "tcnn",
+        interpolation: Optional[Literal["Nearest", "Linear", "Smoothstep"]] = None,
     ) -> None:
 
         super().__init__(in_dim=3)
@@ -260,17 +262,25 @@ class HashEncoding(Encoding):
         if not TCNN_EXISTS and implementation == "tcnn":
             print_tcnn_speed_warning("HashEncoding")
         elif implementation == "tcnn":
+            encoding_config = {
+                "otype": "HashGrid",
+                "n_levels": self.num_levels,
+                "n_features_per_level": self.features_per_level,
+                "log2_hashmap_size": self.log2_hashmap_size,
+                "base_resolution": min_res,
+                "per_level_scale": growth_factor,
+            }
+            if interpolation is not None:
+                encoding_config["interpolation"] = interpolation
+
             self.tcnn_encoding = tcnn.Encoding(
                 n_input_dims=3,
-                encoding_config={
-                    "otype": "HashGrid",
-                    "n_levels": self.num_levels,
-                    "n_features_per_level": self.features_per_level,
-                    "log2_hashmap_size": self.log2_hashmap_size,
-                    "base_resolution": min_res,
-                    "per_level_scale": growth_factor,
-                },
+                encoding_config=encoding_config,
             )
+
+        if not TCNN_EXISTS or self.tcnn_encoding is None:
+            assert interpolation is None or interpolation == "Linear", \
+                f"interpolation '{interpolation}' is not supported for torch encoding backend"
 
     def get_out_dim(self) -> int:
         return self.num_levels * self.features_per_level

--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -279,8 +279,9 @@ class HashEncoding(Encoding):
             )
 
         if not TCNN_EXISTS or self.tcnn_encoding is None:
-            assert interpolation is None or interpolation == "Linear", \
-                f"interpolation '{interpolation}' is not supported for torch encoding backend"
+            assert (
+                interpolation is None or interpolation == "Linear"
+            ), f"interpolation '{interpolation}' is not supported for torch encoding backend"
 
     def get_out_dim(self) -> int:
         return self.num_levels * self.features_per_level


### PR DESCRIPTION
Would like to compute the second derivative when using the tcnn hashgrid encoding as described in https://github.com/NVlabs/tiny-cuda-nn/issues/185.