### PR TITLE
Fix device mismatch error when using masks

### DIFF
--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -40,7 +40,7 @@ def collate_image_dataset_batch(batch: Dict, num_rays_per_batch: int, keep_full_
     if "mask" in batch:
         nonzero_indices = torch.nonzero(batch["mask"][..., 0], as_tuple=False)
         chosen_indices = random.sample(range(len(nonzero_indices)), k=num_rays_per_batch)
-        indices = nonzero_indices[chosen_indices]
+        indices = nonzero_indices[chosen_indices].to(device)
     else:
         indices = torch.floor(
             torch.rand((num_rays_per_batch, 3), device=device)

--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -38,9 +38,9 @@ def collate_image_dataset_batch(batch: Dict, num_rays_per_batch: int, keep_full_
 
     # only sample within the mask, if the mask is in the batch
     if "mask" in batch:
-        nonzero_indices = torch.nonzero(batch["mask"][..., 0], as_tuple=False)
+        nonzero_indices = torch.nonzero(batch["mask"][..., 0].to(device), as_tuple=False)
         chosen_indices = random.sample(range(len(nonzero_indices)), k=num_rays_per_batch)
-        indices = nonzero_indices[chosen_indices].to(device)
+        indices = nonzero_indices[chosen_indices]
     else:
         indices = torch.floor(
             torch.rand((num_rays_per_batch, 3), device=device)


### PR DESCRIPTION
When using masks, I get the following error:

```
  File "/home/hturki/miniconda3/envs/my-end/lib/python3.9/site-packages/nerfstudio/data/pixel_samplers.py", line 51, in <dictcomp>
    collated_batch = {key: value[c, y, x] for key, value in batch.items() if key != "image_idx" and value is not None}
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

printing the keys and devices in my batch, I see:

```
image_idx cuda:0
image cpu
mask cuda:0
``` 

Not sure if this fix is the most elegant solution