### PR TITLE
Dnerf viewer and training fix

### DIFF
--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -677,7 +677,7 @@ class Cameras(TensorDataclass):
         pixel_area = (dx * dy)[..., None]  # ("num_rays":..., 1)
         assert pixel_area.shape == num_rays_shape + (1,)
 
-        times = self.times[camera_indices, None] if self.times is not None else None
+        times = self.times[camera_indices, 0] if self.times is not None else None
 
         return RayBundle(
             origins=origins,

--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -757,7 +757,7 @@ class ViewerState:
         )
 
         times = self.vis["renderingState/render_time"].read()
-        if times:
+        if times != None:
             times = torch.tensor([float(times)])
 
         camera = Cameras(

--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -757,7 +757,7 @@ class ViewerState:
         )
 
         times = self.vis["renderingState/render_time"].read()
-        if times != None:
+        if times is not None:
             times = torch.tensor([float(times)])
 
         camera = Cameras(


### PR DESCRIPTION
Hi there!

I realized there are two bugs while working on `dnerf`.
First one is about training, caused by an incorrect shape of times tensor.
Second one is about the viewer. `times` return as zero when first connected to `viewer` and prevent entering the if clause.
Below two changes fixes it.

Thanks