### PR TITLE
More informative completion install error messages

### DIFF
--- a/scripts/completions/install.py
+++ b/scripts/completions/install.py
@@ -95,13 +95,21 @@ def _generate_completion(
     target_path = completions_dir / shell / target_name
 
     # Generate and write the new completion.
-    new = subprocess.run(
-        args=args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        encoding="utf8",
-        check=True,
-    ).stdout
+    try:
+        new = subprocess.run(
+            args=args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf8",
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        CONSOLE.log(f":x: Completion script generation failed: {args}")
+        if e.stdout is not None and len(e.stdout) > 0:
+            CONSOLE.log(e.stdout)
+        if e.stderr is not None and len(e.stderr) > 0:
+            CONSOLE.log(e.stderr)
+        raise e
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
     if not target_path.exists():


### PR DESCRIPTION
I'm curious about the root cause of #1056, but it's difficult to debug without a useful error message.

To test this change, I slid an `assert False` into `scripts/render.py`:
![image](https://user-images.githubusercontent.com/6992947/205003697-7551db77-5d74-41d6-9f8a-a94936661dd5.png)

Old error message just says that the subprocess failed:
![image](https://user-images.githubusercontent.com/6992947/205003087-3a2af6d1-ad1f-4cbb-b51b-75ade45f78c7.png)

New error message tells us why:
![image](https://user-images.githubusercontent.com/6992947/205002952-af7e4cc5-b41d-4bb1-aa21-853fa4eaa20c.png)
