### PR TITLE
Update mipnerf.md

### DIFF
--- a/docs/nerfology/methods/mipnerf.md
+++ b/docs/nerfology/methods/mipnerf.md
@@ -10,8 +10,13 @@ Paper Website
 
 ### Running Model
 
+The model requires requires a fair amount of GPU memory. You can decrease the batch size using the `--pipeline.datamanager.train-num-rays-per-batch` argument to solve CUDA out of memory error (Tested with 4096 rays on 24GB GPU).
+
 ```bash
-ns-train mipnerf
+ns-train mipnerf \
+  --data data/nerfstudio/poster \
+  --pipeline.datamanager.train-num-rays-per-batch 4096 \
+  nerfstudio-data
 ```
 
 ## Overview


### PR DESCRIPTION
1. Add  `--pipeline.datamanager.train-num-rays-per-batch` argument to docs for most of the users have to change the batch size to run this model.
2. Add `nerfstudio-data` argument. It seems like mipnerf set the Blender dataset as default.