### PR TITLE
Bump max res default

### DIFF
--- a/nerfstudio/fields/nerfacto_field.py
+++ b/nerfstudio/fields/nerfacto_field.py
@@ -91,7 +91,7 @@ class TCNNNerfactoField(Field):
         hidden_dim: int = 64,
         geo_feat_dim: int = 15,
         num_levels: int = 16,
-        max_res: int = 1024,
+        max_res: int = 2048,
         log2_hashmap_size: int = 19,
         num_layers_color: int = 3,
         num_layers_transient: int = 2,

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -71,7 +71,7 @@ class NerfactoModelConfig(ModelConfig):
     """Whether to randomize the background color."""
     num_levels: int = 16
     """Number of levels of the hashmap for the base mlp."""
-    max_res: int = 1024
+    max_res: int = 2048
     """Maximum resolution of the hashmap for the base mlp."""
     log2_hashmap_size: int = 19
     """Size of the hashmap for the base mlp"""


### PR DESCRIPTION
Multiple users have reported that bumping the `max_res` value in the nerfacto model improves the quality (without increasing computation or memory). This PR updates the default.