### PR TITLE
Colab working with Python3.8

### DIFF
--- a/colab/demo.ipynb
+++ b/colab/demo.ipynb
@@ -3,11 +3,11 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "view-in-github"
+        "id": "view-in-github",
+        "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/nerfstudio-project/nerfstudio/blob/tancik%2Fpolycam/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/nerfstudio-project/nerfstudio/blob/alex%2Fcolab_38/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -63,7 +63,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "colab": {
@@ -103,7 +103,7 @@
       },
       "outputs": [],
       "source": [
-        "#@markdown <h1>Install Nerfstudio and Dependencies (~10 min)</h1>\n",
+        "#@markdown <h1>Install Nerfstudio and Dependencies (~15 min)</h1>\n",
         "\n",
         "%cd /content/\n",
         "!pip install --upgrade pip\n",
@@ -111,8 +111,9 @@
         "\n",
         "# Installing TinyCuda\n",
         "%cd /content/\n",
-        "!gdown \"https://drive.google.com/u/1/uc?id=1q8fuc-Mqiev5GTBTRA5UPgCaQDzuqKqj\" \n",
-        "!pip install tinycudann-1.6-cp37-cp37m-linux_x86_64.whl\n",
+        "# !gdown \"https://drive.google.com/u/1/uc?id=1wglEFPbI4BjWMFYaKk7gHCNsWCZphKjs\" \n",
+        "# !pip install tinycudann-1.6-cp38-cp38-linux_x86_64.whl\n",
+        "!pip install git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch\n",
         "\n",
         "# Installing COLMAP\n",
         "%cd /content/\n",
@@ -202,7 +203,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "cellView": "form",
         "colab": {
@@ -362,9 +363,8 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
-      "include_colab_link": true,
-      "provenance": []
+      "provenance": [],
+      "include_colab_link": true
     },
     "gpuClass": "standard",
     "kernelspec": {


### PR DESCRIPTION
This is a temporary fix. I couldn't get the wheel to work so installing from the pytorch bindings on git. Slightly slower installation now.