### PR TITLE
Use `torch.where` for faster contract

### DIFF
--- a/nerfstudio/field_components/spatial_distortions.py
+++ b/nerfstudio/field_components/spatial_distortions.py
@@ -65,12 +65,8 @@ class SceneContraction(SpatialDistortion):
 
     def forward(self, positions):
         def contract(x):
-            mag = torch.linalg.norm(x, ord=self.order, dim=-1)
-            mask = mag >= 1
-            x_new = x.clone()
-            x_new[mask] = (2 - (1 / mag[mask][..., None])) * (x[mask] / mag[mask][..., None])
-
-            return x_new
+            mag = torch.linalg.norm(x, ord=self.order, dim=-1)[..., None]
+            return torch.where(mag < 1, x, (2 - (1 / mag)) * (x / mag))
 
         if isinstance(positions, Gaussians):
             means = contract(positions.mean.clone())


### PR DESCRIPTION
I'm finding the `torch.where` version of this function is about 2.5x faster and more readable.

```python
import torch

x = torch.randn(2048, 3, device='cuda')

def contract1(x, order):
    mag = torch.linalg.norm(x, ord=order, dim=-1)
    mask = mag >= 1
    x_new = x.clone()
    x_new[mask] = (2 - (1 / mag[mask][..., None])) * (x[mask] / mag[mask][..., None])

    return x_new

def contract2(x, order):
    mag = torch.linalg.norm(x, ord=order, dim=-1)[..., None]
    return torch.where(mag < 1, x, (2 - (1 / mag)) * (x / mag))

assert torch.allclose(contract1(x, float('inf')), contract2(x, float('inf')))
```
```python
>>> %timeit contract1(x, float('inf')); torch.cuda.synchronize();
249 µs ± 10.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
```python
>>>%timeit contract2(x, float('inf')); torch.cuda.synchronize();
93.1 µs ± 474 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```