### PR TITLE
Support non-pinhole rendering

### DIFF
--- a/nerfstudio/cameras/camera_paths.py
+++ b/nerfstudio/cameras/camera_paths.py
@@ -23,7 +23,7 @@ import torch
 import nerfstudio.utils.poses as pose_utils
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.camera_utils import get_interpolated_poses_many
-from nerfstudio.cameras.cameras import Cameras
+from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.viewer.server.utils import three_js_perspective_camera_focal_length
 
 
@@ -121,6 +121,19 @@ def get_path_from_json(camera_path: Dict[str, Any]) -> Cameras:
 
     image_height = camera_path["render_height"]
     image_width = camera_path["render_width"]
+    if "camera_type" in camera_path:
+        camera_type = camera_path["camera_type"]
+    else:
+        camera_type = "perspective"
+
+    if "camera_type" not in camera_path:
+        camera_type = CameraType.PERSPECTIVE
+    elif camera_path["camera_type"] == "fisheye":
+        camera_type = CameraType.FISHEYE
+    elif camera_path["camera_type"] == "equirectangular":
+        camera_type = CameraType.EQUIRECTANGULAR
+    else:
+        camera_type = CameraType.PERSPECTIVE
 
     c2ws = []
     fxs = []
@@ -129,11 +142,15 @@ def get_path_from_json(camera_path: Dict[str, Any]) -> Cameras:
         # pose
         c2w = torch.tensor(camera["camera_to_world"]).view(4, 4)[:3]
         c2ws.append(c2w)
-        # field of view
-        fov = camera["fov"]
-        focal_length = three_js_perspective_camera_focal_length(fov, image_height)
-        fxs.append(focal_length)
-        fys.append(focal_length)
+        if camera_type == CameraType.EQUIRECTANGULAR:
+            fxs.append(image_width / 2)
+            fys.append(image_height)
+        else:
+            # field of view
+            fov = camera["fov"]
+            focal_length = three_js_perspective_camera_focal_length(fov, image_height)
+            fxs.append(focal_length)
+            fys.append(focal_length)
 
     camera_to_worlds = torch.stack(c2ws, dim=0)
     fx = torch.tensor(fxs)
@@ -144,4 +161,5 @@ def get_path_from_json(camera_path: Dict[str, Any]) -> Cameras:
         cx=image_width / 2,
         cy=image_height / 2,
         camera_to_worlds=camera_to_worlds,
+        camera_type=camera_type,
     )

--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -634,7 +634,7 @@ class Cameras(TensorDataclass):
 
             directions_stack[..., 0][mask] = torch.masked_select(coord_stack[..., 0] * sin_theta / theta, mask).float()
             directions_stack[..., 1][mask] = torch.masked_select(coord_stack[..., 1] * sin_theta / theta, mask).float()
-            directions_stack[..., 2][mask] = -torch.masked_select(torch.cos(theta), mask)
+            directions_stack[..., 2][mask] = -torch.masked_select(torch.cos(theta), mask).float()
 
         if CameraType.EQUIRECTANGULAR.value in cam_types:
             mask = (self.camera_type[true_indices] == CameraType.EQUIRECTANGULAR.value).squeeze(-1)  # (num_rays)

--- a/nerfstudio/viewer/app/package.json
+++ b/nerfstudio/viewer/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "viewer",
   "homepage": ".",
-  "version": "22-12-02-0",
+  "version": "22-12-16-0",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.10.4",

--- a/nerfstudio/viewer/app/src/modules/SidePanel/CameraPanel/CameraPropPanel.jsx
+++ b/nerfstudio/viewer/app/src/modules/SidePanel/CameraPanel/CameraPropPanel.jsx
@@ -18,6 +18,7 @@ export default function CameraPropPanel(props) {
   const render_width = useSelector(
     (state) => state.renderingState.render_width,
   );
+  const camera_type = useSelector((state) => state.renderingState.camera_type);
 
   const setResolution = (value) => {
     dispatch({
@@ -29,6 +30,14 @@ export default function CameraPropPanel(props) {
       type: 'write',
       path: 'renderingState/render_height',
       data: value.height,
+    });
+  };
+
+  const setCameraType = (value) => {
+    dispatch({
+      type: 'write',
+      path: 'renderingState/camera_type',
+      data: value,
     });
   };
 
@@ -59,6 +68,18 @@ export default function CameraPropPanel(props) {
           set_fps(v);
         },
       },
+      camera_type_selector: {
+        label: 'Camera Type',
+        value: camera_type,
+        options: {
+          Perspective: 'perspective',
+          Fisheye: 'fisheye',
+          Equirectangular: 'equirectangular',
+        },
+        onChange: (v) => {
+          setCameraType(v);
+        },
+      },
     }),
     { store },
   );
@@ -68,6 +89,7 @@ export default function CameraPropPanel(props) {
   setControls({
     camera_resolution: { width: render_width, height: render_height },
   });
+  setControls({ camera_type_selector: camera_type });
 
   return null;
 }

--- a/nerfstudio/viewer/app/src/reducer.js
+++ b/nerfstudio/viewer/app/src/reducer.js
@@ -22,6 +22,7 @@ const initialState = {
     render_height: 1080,
     render_width: 1920,
     field_of_view: 50,
+    camera_type: 'perspective',
 
     isTraining: true,
     output_options: ['rgb'], // populated by the possible Graph outputs

--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -37,7 +37,7 @@ from aiortc import (
 from cryptography.utils import CryptographyDeprecationWarning
 from rich.console import Console
 
-from nerfstudio.cameras.cameras import Cameras
+from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.configs import base_config as cfg
 from nerfstudio.data.datasets.base_dataset import InputDataset
@@ -776,11 +776,22 @@ class ViewerState:
         if times is not None:
             times = torch.tensor([float(times)])
 
+        camera_type_msg = camera_object["camera_type"]
+        if camera_type_msg == "perspective":
+            camera_type = CameraType.PERSPECTIVE
+        elif camera_type_msg == "fisheye":
+            camera_type = CameraType.FISHEYE
+        elif camera_type_msg == "equirectangular":
+            camera_type = CameraType.EQUIRECTANGULAR
+        else:
+            camera_type = CameraType.PERSPECTIVE
+
         camera = Cameras(
             fx=intrinsics_matrix[0, 0],
             fy=intrinsics_matrix[1, 1],
             cx=intrinsics_matrix[0, 2],
             cy=intrinsics_matrix[1, 2],
+            camera_type=camera_type,
             camera_to_worlds=camera_to_world[None, ...],
             times=times,
         )


### PR DESCRIPTION
In viewer add support for rendering with a fisheye and equirectangular camera.

Fisheye:
<img width="1753" alt="image" src="https://user-images.githubusercontent.com/3310961/208208592-36edbb96-c2ad-47bd-ae01-325618593911.png">

Equirectangular:
<img width="1768" alt="image" src="https://user-images.githubusercontent.com/3310961/208208731-517cc126-fa91-4400-8213-405f74765d91.png">
