### PR TITLE
Fix Discord link in the docs

### DIFF
--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -2,7 +2,7 @@
 
 **💝 We're excited to have you join the nerfstudio family 💝**
 
-Below, we document the contribution pipeline and good-to-knows for when you're ready to submit a PR. If you have any questions at all, please don't hesitate to reach out to us on [Discord](https://discord.com/invite/NHGtYRAW). We'd love to hear from you!
+Below, we document the contribution pipeline and good-to-knows for when you're ready to submit a PR. If you have any questions at all, please don't hesitate to reach out to us on [Discord](https://discord.gg/uMbNqcraFc). We'd love to hear from you!
 
 The project is set up for development in VSCode, we recommend using it if you plan to contribute.
 
@@ -35,8 +35,8 @@ conda install -c conda-forge pandoc
 
 ## Committing code
 
-1. Make your modifications ✏️ 
-2. Perform local checks ✅ 
+1. Make your modifications ✏️
+2. Perform local checks ✅
 
    To ensure that you will be passing all tests and checks on github, you will need to run the following command:
 
@@ -50,13 +50,13 @@ conda install -c conda-forge pandoc
    - Pytests: Runs pytests locally to make sure added code does not break existing logic.
    - Documentation build: Builds docs locally. Ensures changes do not result in warnings/errors.
    - Licensing: Automatically adds licensing headers to the correct files.
-   
+
    :::{admonition} Attention
    :class: attention
       In order to merge changes to the code base, all of these checks must be passing. If you pass these tests locally, you will likely pass on github servers as well (results in a green checkmark next to your commit).
       :::
 
-3. Open pull request! 💌 
+3. Open pull request! 💌
 
 ## Maintaining documentation
 


### PR DESCRIPTION
In the docs [contributing page](https://docs.nerf.studio/en/latest/reference/contributing.html), the discord link seems to be invalid (as reported by Discord)
<img width="502" alt="image" src="https://user-images.githubusercontent.com/25415255/208302817-8cacfa34-830b-463f-a87e-ecc2131d852a.png">

However, the one in the README.md seems to work. So I copypasted the same link to the docs, too.
