### PR TITLE
Force 8 bit output from ffmpeg

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -94,6 +94,7 @@ def convert_video_to_images(
             ffmpeg_cmd += f" -vf thumbnail={spacing},setpts=N/TB -r 1"
         else:
             CONSOLE.print("[bold red]Can't satify requested number of frames. Extracting all frames.")
+            ffmpeg_cmd += " -pix_fmt bgr8"
 
         ffmpeg_cmd += f" {out_filename}"
 


### PR DESCRIPTION
Sometime ffmpeg would output 16 images when processing video to images. This only occurred when processing every frame. This would cause colmap to fail.
Fixes #1075