### PR TITLE
Camera export

### DIFF
--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -115,3 +115,6 @@ class InputDataset(Dataset):
     def __getitem__(self, image_idx: int) -> Dict:
         data = self.get_data(image_idx)
         return data
+
+    def get_image_filenames(self) -> List[Path]:
+        return self._dataparser_outputs.image_filenames

--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -117,13 +117,11 @@ class InputDataset(Dataset):
         data = self.get_data(image_idx)
         return data
 
-    def get_image_filenames(self) -> List[Path]:
-        """Returns image filenames for this dataset.
+    @property
+    def image_filenames(self) -> List[Path]:
+        """
+        Returns image filenames for this dataset.
         The order of filenames is the same as in the Cameras object for easy mapping.
-
-        Args: None
-        Returns:
-            List of image filenames.
         """
 
         return self._dataparser_outputs.image_filenames

--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -18,7 +18,8 @@ Dataset.
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Dict
+from pathlib import Path
+from typing import Dict, List
 
 import numpy as np
 import numpy.typing as npt
@@ -117,4 +118,12 @@ class InputDataset(Dataset):
         return data
 
     def get_image_filenames(self) -> List[Path]:
+        """Returns image filenames for this dataset.
+        The order of filenames is the same as in the Cameras object for easy mapping.
+
+        Args: None
+        Returns:
+            List of image filenames.
+        """
+
         return self._dataparser_outputs.image_filenames

--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -276,7 +276,7 @@ def collect_camera_poses_for_dataset(dataset: Optional[InputDataset]) -> List[Di
 
     frames: List[Dict[str, Any]] = []
 
-    # new cameras are in cameras, whereas image paths are in dataparser_outputs
+    # new cameras are in cameras, whereas image paths are stored in a private member of the dataset
     for idx in range(len(cameras)):
         image_filename = image_filenames[idx]
         transform = cameras.camera_to_worlds[idx].tolist()

--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import open3d as o3d
@@ -40,7 +40,7 @@ from torchtyping import TensorType
 
 from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.data.datasets.base_dataset import InputDataset
-from nerfstudio.pipelines.base_pipeline import Pipeline
+from nerfstudio.pipelines.base_pipeline import Pipeline, VanillaPipeline
 from nerfstudio.utils.rich_utils import ItersPerSecColumn
 
 CONSOLE = Console(width=120)
@@ -257,12 +257,13 @@ def render_trajectory(
             depths.append(outputs[depth_output_name].cpu().numpy())
     return images, depths
 
+
 def collect_camera_poses_for_dataset(dataset: Optional[InputDataset]) -> List[Dict[str, Any]]:
     if dataset is None:
         return []
 
     cameras = dataset.cameras
-    image_filenames = dataset._dataparser_outputs.image_filenames
+    image_filenames = dataset.get_image_filenames()
 
     frames: List[Dict[str, Any]] = []
 
@@ -270,12 +271,15 @@ def collect_camera_poses_for_dataset(dataset: Optional[InputDataset]) -> List[Di
     for idx in range(len(cameras)):
         image_filename = image_filenames[idx]
         transform = cameras.camera_to_worlds[idx].tolist()
-        frames.append({
-            "file_path": str(image_filename),
-            "transform": transform,
-        })
+        frames.append(
+            {
+                "file_path": str(image_filename),
+                "transform": transform,
+            }
+        )
 
     return frames
+
 
 def collect_camera_poses(pipeline: VanillaPipeline) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Collects camera poses for train and eval datasets.

--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -259,6 +259,15 @@ def render_trajectory(
 
 
 def collect_camera_poses_for_dataset(dataset: Optional[InputDataset]) -> List[Dict[str, Any]]:
+    """Collects rescaled, translated and optimised camera poses for a dataset.
+
+    Args:
+        dataset: Dataset to collect camera poses for.
+
+    Returns:
+        List of dicts containing camera poses.
+    """
+
     if dataset is None:
         return []
 

--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -272,7 +272,7 @@ def collect_camera_poses_for_dataset(dataset: Optional[InputDataset]) -> List[Di
         return []
 
     cameras = dataset.cameras
-    image_filenames = dataset.get_image_filenames()
+    image_filenames = dataset.image_filenames
 
     frames: List[Dict[str, Any]] = []
 

--- a/scripts/exporter.py
+++ b/scripts/exporter.py
@@ -330,11 +330,6 @@ class ExportCameraPoses(Exporter):
             self.output_dir.mkdir(parents=True)
 
         _, pipeline, _ = eval_setup(self.load_config)
-
-        train_dataset = pipeline.datamanager.train_dataset
-        if train_dataset is None:
-            return
-
         assert isinstance(pipeline, VanillaPipeline)
         train_frames, eval_frames = collect_camera_poses(pipeline)
 

--- a/scripts/exporter.py
+++ b/scripts/exporter.py
@@ -4,6 +4,8 @@ Script for exporting NeRF into other formats.
 
 from __future__ import annotations
 
+import json
+import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -17,12 +19,14 @@ from rich.console import Console
 from typing_extensions import Annotated, Literal
 
 from nerfstudio.cameras.rays import RayBundle
+from nerfstudio.data.datasets.base_dataset import InputDataset
 from nerfstudio.exporter import texture_utils, tsdf_utils
 from nerfstudio.exporter.exporter_utils import (
+    collect_camera_poses,
     generate_point_cloud,
     get_mesh_from_filename,
 )
-from nerfstudio.pipelines.base_pipeline import Pipeline
+from nerfstudio.pipelines.base_pipeline import Pipeline, VanillaPipeline
 from nerfstudio.utils.eval_utils import eval_setup
 
 CONSOLE = Console(width=120)
@@ -314,12 +318,46 @@ class ExportMarchingCubesMesh(Exporter):
         raise NotImplementedError("Marching cubes not implemented yet.")
 
 
+@dataclass
+class ExportCameraPoses(Exporter):
+    """
+    Export camera poses to a .json file.
+    """
+
+    def main(self) -> None:
+        """Export camera poses"""
+        if not self.output_dir.exists():
+            self.output_dir.mkdir(parents=True)
+
+        _, pipeline, _ = eval_setup(self.load_config)
+
+        train_dataset = pipeline.datamanager.train_dataset
+        if train_dataset is None:
+            return
+
+        assert isinstance(pipeline, VanillaPipeline)
+        train_frames, eval_frames = collect_camera_poses(pipeline)
+
+        for file_name, frames in [("transforms_train.json", train_frames), ("transforms_eval.json", eval_frames)]:
+            if len(frames) == 0:
+                CONSOLE.print(f"[bold yellow]No frames found for {file_name}. Skipping.")
+                continue
+
+            output_file_path = os.path.join(self.output_dir, file_name)
+
+            with open(output_file_path, "w") as f:
+                json.dump(frames, f, indent=4)
+
+            CONSOLE.print(f"[bold green]:white_check_mark: Saved poses to {output_file_path}")
+
+
 Commands = tyro.conf.FlagConversionOff[
     Union[
         Annotated[ExportPointCloud, tyro.conf.subcommand(name="pointcloud")],
         Annotated[ExportTSDFMesh, tyro.conf.subcommand(name="tsdf")],
         Annotated[ExportPoissonMesh, tyro.conf.subcommand(name="poisson")],
         Annotated[ExportMarchingCubesMesh, tyro.conf.subcommand(name="marching-cubes")],
+        Annotated[ExportCameraPoses, tyro.conf.subcommand(name="cameras")],
     ]
 ]
 

--- a/scripts/exporter.py
+++ b/scripts/exporter.py
@@ -19,7 +19,6 @@ from rich.console import Console
 from typing_extensions import Annotated, Literal
 
 from nerfstudio.cameras.rays import RayBundle
-from nerfstudio.data.datasets.base_dataset import InputDataset
 from nerfstudio.exporter import texture_utils, tsdf_utils
 from nerfstudio.exporter.exporter_utils import (
     collect_camera_poses,
@@ -340,7 +339,7 @@ class ExportCameraPoses(Exporter):
 
             output_file_path = os.path.join(self.output_dir, file_name)
 
-            with open(output_file_path, "w") as f:
+            with open(output_file_path, "w", encoding="UTF-8") as f:
                 json.dump(frames, f, indent=4)
 
             CONSOLE.print(f"[bold green]:white_check_mark: Saved poses to {output_file_path}")


### PR DESCRIPTION
The feature to export camera poses has already been requested by a few people (e.g. [issue-1051](https://github.com/nerfstudio-project/nerfstudio/issues/1051)).

I would also find this feature handy.

In this PR I implemented the exporter for camera poses. Currently, it exports the camera poses as two files: `transforms_train.json` and `transforms_eval.json` for train and eval poses.

the structure of these files is
```
[
  {
    "file_path": {image file path corresponding with this camera as in the original transforms.json},
    "transform": {4x4 List of floats}
  },
  ...
]
```

Even though we can export more information in the .json files, I find the these to be sufficient (at least for my use case). User can use the `file_path` to match the exported camera poses with the input camera poses.

I am happy to add more information to the .json files if there will be need for them, but looks like right now people would like to see mainly the optimised transforms.

I tested this change with
```
$ ns-export cameras --load-config {path to my config} --output_dir cam_poses
```