### PR TITLE
Added missing arg to ns-download-data command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The following will train a _nerfacto_ model, our recommended model for real worl
 
 ```bash
 # Download some test data:
-ns-download-data nerfstudio --capture-name=poster
+ns-download-data --dataset nerfstudio --capture-name=poster
 # Train model
 ns-train nerfacto --data data/nerfstudio/poster
 ```


### PR DESCRIPTION
`ns-download-data nerfstudio --capture-name=vegetation` will give error:

```
usage: ns-download-data [-h] --dataset {blender,friends,nerfstudio,record3d}
                        [--capture-name {None,bww_entrance,campanile,desolation,dozer,library,poster,redwoods2,sf_street,storefront,vegetation}] [--save-dir PATH]

 
ns-download-data: error: the following arguments are required: --dataset
```
Thus adding `--dataset` to the command.

![image](https://user-images.githubusercontent.com/25712145/210401121-65bfbb42-4ee4-48f3-b085-8047683bf38f.png)
