### PR TITLE
save image_coords as non-persistent buffer

### DIFF
--- a/nerfstudio/model_components/ray_generators.py
+++ b/nerfstudio/model_components/ray_generators.py
@@ -36,7 +36,7 @@ class RayGenerator(nn.Module):
         super().__init__()
         self.cameras = cameras
         self.pose_optimizer = pose_optimizer
-        self.image_coords = nn.Parameter(cameras.get_image_coords(), requires_grad=False)
+        self.register_buffer("image_coords", cameras.get_image_coords(), persistent=False)
 
     def forward(self, ray_indices: TensorType["num_rays", 3]) -> RayBundle:
         """Index into the cameras to generate the rays.


### PR DESCRIPTION
Right now image coords are being needlessly serialized as part of the checkpoint state dict