### PR TITLE
Depth data loading for Polycam LiDAR data

### DIFF
--- a/nerfstudio/process_data/polycam_utils.py
+++ b/nerfstudio/process_data/polycam_utils.py
@@ -34,7 +34,7 @@ def polycam_to_json(
     cameras_dir: Path,
     output_dir: Path,
     min_blur_score: float = 0.0,
-    crop_border_pixels: int = 0
+    crop_border_pixels: int = 0,
 ) -> List[str]:
     """Convert Polycam data into a nerfstudio dataset.
 
@@ -98,8 +98,14 @@ def polycam_to_json(
     return summary
 
 
-def process_images(polycam_image_dir: Path, image_dir: Path, crop_border_pixels: int = 15, max_dataset_size: int = 600,
-                   num_downscales: int = 3, verbose: bool = True) -> Tuple[List[str], List[Path]]:
+def process_images(
+    polycam_image_dir: Path,
+    image_dir: Path,
+    crop_border_pixels: int = 15,
+    max_dataset_size: int = 600,
+    num_downscales: int = 3,
+    verbose: bool = True,
+) -> Tuple[List[str], List[Path]]:
     """
     Process RGB images only
 
@@ -153,9 +159,15 @@ def process_images(polycam_image_dir: Path, image_dir: Path, crop_border_pixels:
     return summary_log, polycam_image_filenames
 
 
-def process_depth_maps(polycam_depth_dir: Path, depth_dir: Path,
-                       num_processed_images: int, crop_border_pixels: int = 15, max_dataset_size: int = 600,
-                        num_downscales: int = 3, verbose: bool = True) -> Tuple[List[str], List[Path]]:
+def process_depth_maps(
+    polycam_depth_dir: Path,
+    depth_dir: Path,
+    num_processed_images: int,
+    crop_border_pixels: int = 15,
+    max_dataset_size: int = 600,
+    num_downscales: int = 3,
+    verbose: bool = True,
+) -> Tuple[List[str], List[Path]]:
     """
     Process Depth maps from polycam only
 
@@ -181,18 +193,17 @@ def process_depth_maps(polycam_depth_dir: Path, depth_dir: Path,
 
     # Copy depth images to output directory
     copied_depth_maps_paths = process_data_utils.copy_and_upscale_polycam_depth_maps_list(
-        polycam_depth_maps_filenames,
-        depth_dir=depth_dir,
-        crop_border_pixels=crop_border_pixels,
-        verbose=verbose
+        polycam_depth_maps_filenames, depth_dir=depth_dir, crop_border_pixels=crop_border_pixels, verbose=verbose
     )
 
     num_processed_depth_maps = len(copied_depth_maps_paths)
 
     # assert same number of images as depth maps
     if num_processed_images != num_processed_depth_maps:
-        raise ValueError(f"Expected same amount of depth maps as images. "
-                         f"Instead got {num_processed_images} images and {num_processed_depth_maps} depth maps")
+        raise ValueError(
+            f"Expected same amount of depth maps as images. "
+            f"Instead got {num_processed_images} images and {num_processed_depth_maps} depth maps"
+        )
 
     if crop_border_pixels > 0 and num_processed_depth_maps != num_orig_depth_maps:
         summary_log.append(f"Started with {num_processed_depth_maps} images out of {num_orig_depth_maps} total")
@@ -204,7 +215,8 @@ def process_depth_maps(polycam_depth_dir: Path, depth_dir: Path,
         summary_log.append(f"Started with {num_processed_depth_maps} images")
 
     # Downscale depth maps
-    summary_log.append(process_data_utils.downscale_images(depth_dir, num_downscales, folder_name="depth",
-                                                                verbose=verbose))
+    summary_log.append(
+        process_data_utils.downscale_images(depth_dir, num_downscales, folder_name="depth", verbose=verbose)
+    )
 
     return summary_log, polycam_depth_maps_filenames

--- a/nerfstudio/process_data/polycam_utils.py
+++ b/nerfstudio/process_data/polycam_utils.py
@@ -16,14 +16,13 @@
 
 import json
 import sys
-import numpy as np
 from pathlib import Path
 from typing import List, Tuple
 
 from rich.console import Console
 
 from nerfstudio.process_data import process_data_utils
-from nerfstudio.process_data.process_data_utils import get_image_filenames, CAMERA_MODELS
+from nerfstudio.process_data.process_data_utils import CAMERA_MODELS
 from nerfstudio.utils import io
 
 CONSOLE = Console(width=120)

--- a/nerfstudio/process_data/polycam_utils.py
+++ b/nerfstudio/process_data/polycam_utils.py
@@ -29,15 +29,17 @@ CONSOLE = Console(width=120)
 
 def polycam_to_json(
     image_filenames: List[Path],
+    depth_filenames: List[Path],
     cameras_dir: Path,
     output_dir: Path,
     min_blur_score: float = 0.0,
-    crop_border_pixels: int = 0,
+    crop_border_pixels: int = 0
 ) -> List[str]:
     """Convert Polycam data into a nerfstudio dataset.
 
     Args:
         image_filenames: List of paths to the original images.
+        depth_filenames: List of paths to the original depth maps.
         cameras_dir: Path to the polycam cameras directory.
         output_dir: Path to the output directory.
         min_blur_score: Minimum blur score to use an image. Images below this value will be skipped.
@@ -46,6 +48,7 @@ def polycam_to_json(
     Returns:
         Summary of the conversion.
     """
+    use_depth = True if len(image_filenames) == len(depth_filenames) else False
     data = {}
     data["camera_model"] = CAMERA_MODELS["perspective"].value
     # Needs to be a string for camera_utils.auto_orient_and_center_poses
@@ -67,6 +70,8 @@ def polycam_to_json(
         frame["w"] = frame_json["width"] - crop_border_pixels * 2
         frame["h"] = frame_json["height"] - crop_border_pixels * 2
         frame["file_path"] = f"./images/frame_{i+1:05d}{image_filename.suffix}"
+        if use_depth:
+            frame["depth_map_path"] = f"./depth/frame_{i+1:05d}{depth_filenames[i].suffix}"
         # Transform matrix to nerfstudio format. Please refer to the documentation for coordinate system conventions.
         frame["transform_matrix"] = [
             [frame_json["t_20"], frame_json["t_21"], frame_json["t_22"], frame_json["t_23"]],

--- a/nerfstudio/process_data/polycam_utils.py
+++ b/nerfstudio/process_data/polycam_utils.py
@@ -16,11 +16,13 @@
 
 import json
 import sys
+import numpy as np
 from pathlib import Path
-from typing import List
+from typing import List, Tuple, Any
 
 from rich.console import Console
 
+from nerfstudio.process_data import process_data_utils
 from nerfstudio.process_data.process_data_utils import CAMERA_MODELS
 from nerfstudio.utils import io
 
@@ -95,3 +97,137 @@ def polycam_to_json(
         sys.exit(1)
 
     return summary
+
+
+def process_images(polycam_image_dir: Path, image_dir: Path, crop_border_pixels: int = 15, max_dataset_size: int = 600,
+                   num_downscales: int = 3, verbose: bool = True) -> Tuple[List[str], List[Path]]:
+    """
+    Process RGB images only
+
+    Args:
+        polycam_image_dir: Path to the directory containing RGB Images
+        image_dir: Output directory for processed images
+        crop_border_pixels: Number of pixels to crop from each border of the image. Useful as borders may be
+                            black due to undistortion.
+        max_dataset_size: Max number of images to train on. If the dataset has more, images will be sampled
+                            approximately evenly. If -1, use all images.
+        num_downscales: Number of times to downscale the images. Downscales by 2 each time. For example a value of 3
+                        will downscale the images by 2x, 4x, and 8x.
+        verbose: If True, print extra logging.
+    Returns:
+        summary_log: Summary of the processing.
+        polycam_image_filenames: List of processed images paths
+    """
+    summary_log = []
+    # Copy images to output directory
+
+    polycam_image_filenames = []
+    for f in polycam_image_dir.iterdir():
+        if f.suffix.lower() in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
+            polycam_image_filenames.append(f)
+    polycam_image_filenames = sorted(polycam_image_filenames, key=lambda fn: int(fn.stem))
+    num_images = len(polycam_image_filenames)
+    idx = np.arange(num_images)
+    if max_dataset_size != -1 and num_images > max_dataset_size:
+        idx = np.round(np.linspace(0, num_images - 1, max_dataset_size)).astype(int)
+
+    polycam_image_filenames = list(np.array(polycam_image_filenames)[idx])
+
+    # Copy images to output directory
+    copied_image_paths = process_data_utils.copy_images_list(
+        polycam_image_filenames,
+        image_dir=image_dir,
+        crop_border_pixels=crop_border_pixels,
+        verbose=verbose,
+    )
+    num_frames = len(copied_image_paths)
+
+    copied_image_paths = [Path("images/" + copied_image_path.name) for copied_image_path in copied_image_paths]
+
+    if max_dataset_size > 0 and num_frames != num_images:
+        summary_log.append(f"Started with {num_frames} images out of {num_images} total")
+        summary_log.append(
+            "To change the size of the dataset add the argument --max_dataset_size to larger than the "
+            f"current value ({max_dataset_size}), or -1 to use all images."
+        )
+    else:
+        summary_log.append(f"Started with {num_frames} images")
+
+    # Downscale images
+    summary_log.append(process_data_utils.downscale_images(image_dir, num_downscales, verbose=verbose))
+
+    # Save json
+    if num_frames == 0:
+        CONSOLE.print("[bold red]No images found, exiting")
+        sys.exit(1)
+
+    return summary_log, polycam_image_filenames
+
+
+def process_depth_maps(polycam_depth_dir: Path, depth_dir: Path,
+                       num_processed_images: int, crop_border_pixels: int = 15, max_dataset_size: int = 600,
+                        num_downscales: int = 3, verbose: bool = True) -> Tuple[List[str], List[Path]]:
+    """
+    Process Depth maps from polycam only
+
+    Args:
+        polycam_depth_dir: Path to the directory containing depth maps
+        depth_dir: Output directory for processed depth maps
+        num_processed_images: Number of RGB processed that must match the number of depth maps
+        crop_border_pixels: Number of pixels to crop from each border of the image. Useful as borders may be
+                            black due to undistortion.
+        max_dataset_size: Max number of images to train on. If the dataset has more, images will be sampled
+                         approximately evenly. If -1, use all images.
+        num_downscales: Number of times to downscale the images. Downscales by 2 each time. For example a value of 3
+                        will downscale the images by 2x, 4x, and 8x.
+        verbose: If True, print extra logging.
+    Returns:
+        summary_log: Summary of the processing.
+        polycam_depth_maps_filenames: List of processed depth maps paths
+    """
+    summary_log = []
+    polycam_depth_maps_filenames = []
+    for depth_file in polycam_depth_dir.iterdir():
+        if depth_file.suffix.lower() in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
+            polycam_depth_maps_filenames.append(depth_file)
+
+    # depth maps and images have the same name
+    polycam_depth_maps_filenames = sorted(polycam_depth_maps_filenames, key=lambda fn: int(fn.stem))
+
+    num_depth_maps = len(polycam_depth_maps_filenames)
+
+    idx = np.arange(num_depth_maps)
+    if max_dataset_size != -1 and num_depth_maps > max_dataset_size:
+        idx = np.round(np.linspace(0, num_depth_maps - 1, max_dataset_size)).astype(int)
+
+    polycam_depth_maps_filenames = list(np.array(polycam_depth_maps_filenames)[idx])
+
+    # Copy depth images to output directory
+    copied_depth_maps_paths = process_data_utils.copy_and_upscale_polycam_depth_maps_list(
+        polycam_depth_maps_filenames,
+        depth_dir=depth_dir,
+        crop_border_pixels=crop_border_pixels,
+        verbose=verbose
+    )
+
+    num_processed_depth_maps = len(copied_depth_maps_paths)
+
+    # assert same number of images as depth maps
+    if num_processed_images != num_processed_depth_maps:
+        raise ValueError(f"Expected same amount of depth maps as images. "
+                         f"Instead got {num_processed_images} images and {num_processed_depth_maps} depth maps")
+
+    if crop_border_pixels > 0 and num_processed_depth_maps != num_depth_maps:
+        summary_log.append(f"Started with {num_processed_depth_maps} images out of {num_depth_maps} total")
+        summary_log.append(
+            "To change the size of the dataset add the argument --max_dataset_size to larger than the "
+            f"current value ({crop_border_pixels}), or -1 to use all images."
+        )
+    else:
+        summary_log.append(f"Started with {num_processed_depth_maps} images")
+
+    # Downscale depth maps
+    summary_log.append(process_data_utils.downscale_images(depth_dir, num_downscales, folder_name="depth",
+                                                                verbose=verbose))
+
+    return summary_log, polycam_depth_maps_filenames

--- a/nerfstudio/process_data/polycam_utils.py
+++ b/nerfstudio/process_data/polycam_utils.py
@@ -18,7 +18,7 @@ import json
 import sys
 import numpy as np
 from pathlib import Path
-from typing import List, Tuple, Any
+from typing import List, Tuple
 
 from rich.console import Console
 
@@ -50,7 +50,7 @@ def polycam_to_json(
     Returns:
         Summary of the conversion.
     """
-    use_depth = True if len(image_filenames) == len(depth_filenames) else False
+    use_depth = bool(len(image_filenames) == len(depth_filenames))
     data = {}
     data["camera_model"] = CAMERA_MODELS["perspective"].value
     # Needs to be a string for camera_utils.auto_orient_and_center_poses

--- a/nerfstudio/process_data/polycam_utils.py
+++ b/nerfstudio/process_data/polycam_utils.py
@@ -50,7 +50,7 @@ def polycam_to_json(
     Returns:
         Summary of the conversion.
     """
-    use_depth = bool(len(image_filenames) == len(depth_filenames))
+    use_depth = len(image_filenames) == len(depth_filenames)
     data = {}
     data["camera_model"] = CAMERA_MODELS["perspective"].value
     # Needs to be a string for camera_utils.auto_orient_and_center_poses

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -174,7 +174,7 @@ def copy_and_upscale_polycam_depth_maps_list(polycam_depth_image_filenames: List
     """
     depth_dir.mkdir(parents=True, exist_ok=True)
 
-    # upscale them in place
+    # copy and upscale them to new directory
     with status(msg="[bold yellow] Upscaling depth maps...", spinner="growVertical", verbose=verbose):
         upscale_factor = 2 ** POLYCAM_UPSCALING_TIMES
         assert upscale_factor > 1

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -189,8 +189,8 @@ def copy_and_upscale_polycam_depth_maps_list(polycam_depth_image_filenames: List
 
         for f in copied_depth_map_paths:
             ffmpeg_cmd = [
-                f"ffmpeg -y -i {f} ",
-                f"-q:v 2 -vf scale=iw/{upscale_factor}:ih/{upscale_factor} ",
+                f"ffmpeg -i {f} ",
+                f"-q:v 2 -vf scale=iw/{upscale_factor}:ih/{upscale_factor}:flags=neighbor ",
                 f"{f}",
             ]
             ffmpeg_cmd = " ".join(ffmpeg_cmd)

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -190,7 +190,7 @@ def copy_and_upscale_polycam_depth_maps_list(polycam_depth_image_filenames: List
         for f in copied_depth_map_paths:
             ffmpeg_cmd = [
                 f"ffmpeg -i {f} ",
-                f"-q:v 2 -vf scale=iw/{upscale_factor}:ih/{upscale_factor}:flags=neighbor ",
+                f"-q:v 2 -vf scale=iw*{upscale_factor}:ih*{upscale_factor}:flags=neighbor ",
                 f"{f}",
             ]
             ffmpeg_cmd = " ".join(ffmpeg_cmd)

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -228,7 +228,7 @@ def copy_images(data: Path, image_dir: Path, verbose) -> int:
     return num_frames
 
 
-def downscale_images(image_dir: Path, num_downscales: int, folder_name: int = "images", verbose: bool = False) -> str:
+def downscale_images(image_dir: Path, num_downscales: int, folder_name: str = "images", verbose: bool = False) -> str:
     """Downscales the images in the directory. Uses FFMPEG.
 
     Assumes images are named frame_00001.png, frame_00002.png, etc.

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -29,6 +29,7 @@ from nerfstudio.utils.rich_utils import status
 from nerfstudio.utils.scripts import run_command
 
 CONSOLE = Console(width=120)
+POLYCAM_UPSCALING_TIMES = 2
 
 
 class CameraModel(Enum):
@@ -227,7 +228,7 @@ def copy_images(data: Path, image_dir: Path, verbose) -> int:
     return num_frames
 
 
-def downscale_images(image_dir: Path, num_downscales: int, verbose: bool = False) -> str:
+def downscale_images(image_dir: Path, num_downscales: int, folder_name: int = "images", verbose: bool = False) -> str:
     """Downscales the images in the directory. Uses FFMPEG.
 
     Assumes images are named frame_00001.png, frame_00002.png, etc.
@@ -235,6 +236,7 @@ def downscale_images(image_dir: Path, num_downscales: int, verbose: bool = False
     Args:
         image_dir: Path to the directory containing the images.
         num_downscales: Number of times to downscale the images. Downscales by 2 each time.
+        folder_name: Name of the output folder
         verbose: If True, logs the output of the command.
 
     Returns:
@@ -249,7 +251,7 @@ def downscale_images(image_dir: Path, num_downscales: int, verbose: bool = False
         for downscale_factor in downscale_factors:
             assert downscale_factor > 1
             assert isinstance(downscale_factor, int)
-            downscale_dir = image_dir.parent / f"images_{downscale_factor}"
+            downscale_dir = image_dir.parent / f"{folder_name}_{downscale_factor}"
             downscale_dir.mkdir(parents=True, exist_ok=True)
             file_type = image_dir.glob("frame_*").__next__().suffix
             filename = f"frame_%05d{file_type}"

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -181,10 +181,12 @@ def copy_images_list(
     return copied_image_paths
 
 
-def copy_and_upscale_polycam_depth_maps_list(polycam_depth_image_filenames: List[Path],
-                                             depth_dir: Path,
-                                             crop_border_pixels: Optional[int] = None,
-                                             verbose: bool = False) -> List[Path]:
+def copy_and_upscale_polycam_depth_maps_list(
+    polycam_depth_image_filenames: List[Path],
+    depth_dir: Path,
+    crop_border_pixels: Optional[int] = None,
+    verbose: bool = False,
+) -> List[Path]:
     """
     Copy depth maps to working location and upscale them to match the RGB images dimensions and finally crop them
     equally as RGB Images.
@@ -200,7 +202,7 @@ def copy_and_upscale_polycam_depth_maps_list(polycam_depth_image_filenames: List
 
     # copy and upscale them to new directory
     with status(msg="[bold yellow] Upscaling depth maps...", spinner="growVertical", verbose=verbose):
-        upscale_factor = 2 ** POLYCAM_UPSCALING_TIMES
+        upscale_factor = 2**POLYCAM_UPSCALING_TIMES
         assert upscale_factor > 1
         assert isinstance(upscale_factor, int)
 

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -7,7 +7,7 @@ import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple, Union, List
+from typing import Tuple, Union
 
 import numpy as np
 import tyro

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -562,15 +562,14 @@ class ProcessPolycam:
             depth_dir = self.data / "keyframes" / "depth"
             raise ValueError(f"Depth map directory {depth_dir} doesn't exist")
 
-        (image_processing_log, polycam_image_filenames) = \
-            polycam_utils.process_images(
-                polycam_image_dir,
-                image_dir,
-                crop_border_pixels=self.crop_border_pixels,
-                max_dataset_size=self.max_dataset_size,
-                num_downscales=self.num_downscales,
-                verbose=self.verbose,
-            )
+        (image_processing_log, polycam_image_filenames) = polycam_utils.process_images(
+            polycam_image_dir,
+            image_dir,
+            crop_border_pixels=self.crop_border_pixels,
+            max_dataset_size=self.max_dataset_size,
+            num_downscales=self.num_downscales,
+            verbose=self.verbose,
+        )
 
         summary_log.extend(image_processing_log)
 
@@ -579,16 +578,15 @@ class ProcessPolycam:
             polycam_depth_image_dir = self.data / "keyframes" / "depth"
             depth_dir = self.output_dir / "depth"
             depth_dir.mkdir(parents=True, exist_ok=True)
-            (depth_processing_log, polycam_depth_filenames) = \
-                polycam_utils.process_depth_maps(
-                    polycam_depth_image_dir,
-                    depth_dir,
-                    num_processed_images=len(polycam_image_filenames),
-                    crop_border_pixels=self.crop_border_pixels,
-                    max_dataset_size=self.max_dataset_size,
-                    num_downscales=self.num_downscales,
-                    verbose=self.verbose,
-                )
+            (depth_processing_log, polycam_depth_filenames) = polycam_utils.process_depth_maps(
+                polycam_depth_image_dir,
+                depth_dir,
+                num_processed_images=len(polycam_image_filenames),
+                crop_border_pixels=self.crop_border_pixels,
+                max_dataset_size=self.max_dataset_size,
+                num_downscales=self.num_downscales,
+                verbose=self.verbose,
+            )
             summary_log.extend(depth_processing_log)
 
         summary_log.extend(
@@ -598,10 +596,9 @@ class ProcessPolycam:
                 cameras_dir=polycam_cameras_dir,
                 output_dir=self.output_dir,
                 min_blur_score=self.min_blur_score,
-                crop_border_pixels=self.crop_border_pixels
+                crop_border_pixels=self.crop_border_pixels,
             )
         )
-
 
         CONSOLE.rule("[bold green]:tada: :tada: :tada: All DONE :tada: :tada: :tada:")
 

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -561,7 +561,16 @@ class ProcessPolycam:
             depth_dir = self.data / "keyframes" / "depth"
             raise ValueError(f"Depth map directory {depth_dir} doesn't exist")
 
-        image_processing_log, polycam_image_filenames = self.process_images(polycam_image_dir, image_dir)
+        (image_processing_log, polycam_image_filenames) = \
+            polycam_utils.process_images(
+                polycam_image_dir,
+                image_dir,
+                crop_border_pixels=self.crop_border_pixels,
+                max_dataset_size=self.max_dataset_size,
+                num_downscales=self.num_downscales,
+                verbose=self.verbose,
+            )
+
         summary_log.extend(image_processing_log)
 
         polycam_depth_filenames = []
@@ -569,8 +578,16 @@ class ProcessPolycam:
             polycam_depth_image_dir = self.data / "keyframes" / "depth"
             depth_dir = self.output_dir / "depth"
             depth_dir.mkdir(parents=True, exist_ok=True)
-            depth_processing_log, polycam_depth_filenames = self.process_depth_maps(polycam_depth_image_dir,
-                                                                        depth_dir,len(polycam_image_filenames))
+            (depth_processing_log, polycam_depth_filenames) = \
+                polycam_utils.process_depth_maps(
+                    polycam_depth_image_dir,
+                    depth_dir,
+                    num_processed_images=len(polycam_image_filenames),
+                    crop_border_pixels=self.crop_border_pixels,
+                    max_dataset_size=self.max_dataset_size,
+                    num_downscales=self.num_downscales,
+                    verbose=self.verbose,
+                )
             summary_log.extend(depth_processing_log)
 
         summary_log.extend(
@@ -590,112 +607,6 @@ class ProcessPolycam:
         for summary in summary_log:
             CONSOLE.print(summary, justify="center")
         CONSOLE.rule()
-
-    def process_images(self, polycam_image_dir: Path, image_dir: Path) -> Tuple[List[str], List[Path]]:
-        """
-        Process RGB images only
-
-        Args:
-            polycam_image_dir: Path to the directory containing RGB Images
-            polycam_cameras_dir: Path to the directory of cameras used for processing.
-            image_dir: Output directory for processed images
-        Returns:
-            summary_log: Summary of the processing.
-            polycam_image_filenames: List of processed images paths
-        """
-        summary_log = []
-        # Copy images to output directory
-
-        polycam_image_filenames = []
-        for f in polycam_image_dir.iterdir():
-            if f.suffix.lower() in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
-                polycam_image_filenames.append(f)
-        polycam_image_filenames = sorted(polycam_image_filenames, key=lambda fn: int(fn.stem))
-        num_images = len(polycam_image_filenames)
-        idx = np.arange(num_images)
-        if self.max_dataset_size != -1 and num_images > self.max_dataset_size:
-            idx = np.round(np.linspace(0, num_images - 1, self.max_dataset_size)).astype(int)
-
-        polycam_image_filenames = list(np.array(polycam_image_filenames)[idx])
-
-        # Copy images to output directory
-        copied_image_paths = process_data_utils.copy_images_list(
-            polycam_image_filenames,
-            image_dir=image_dir,
-            crop_border_pixels=self.crop_border_pixels,
-            verbose=self.verbose,
-        )
-        num_frames = len(copied_image_paths)
-
-        copied_image_paths = [Path("images/" + copied_image_path.name) for copied_image_path in copied_image_paths]
-
-        if self.max_dataset_size > 0 and num_frames != num_images:
-            summary_log.append(f"Started with {num_frames} images out of {num_images} total")
-            summary_log.append(
-                "To change the size of the dataset add the argument --max_dataset_size to larger than the "
-                f"current value ({self.max_dataset_size}), or -1 to use all images."
-            )
-        else:
-            summary_log.append(f"Started with {num_frames} images")
-
-        # Downscale images
-        summary_log.append(process_data_utils.downscale_images(image_dir, self.num_downscales, verbose=self.verbose))
-
-        # Save json
-        if num_frames == 0:
-            CONSOLE.print("[bold red]No images found, exiting")
-            sys.exit(1)
-
-        return summary_log, polycam_image_filenames
-
-
-    def process_depth_maps(self, polycam_depth_dir: Path, depth_dir: Path, num_processed_images: int) -> List[str]:
-        summary_log = []
-        polycam_depth_maps_filenames = []
-        for depth_file in polycam_depth_dir.iterdir():
-            if depth_file.suffix.lower() in [".jpg", ".jpeg", ".png", ".tif", ".tiff"]:
-                polycam_depth_maps_filenames.append(depth_file)
-
-        # depth maps and images have the same name
-        polycam_depth_maps_filenames = sorted(polycam_depth_maps_filenames, key=lambda fn: int(fn.stem))
-
-        num_depth_maps = len(polycam_depth_maps_filenames)
-
-        idx = np.arange(num_depth_maps)
-        if self.max_dataset_size != -1 and num_depth_maps > self.max_dataset_size:
-            idx = np.round(np.linspace(0, num_depth_maps - 1, self.max_dataset_size)).astype(int)
-
-        polycam_depth_maps_filenames = list(np.array(polycam_depth_maps_filenames)[idx])
-
-        # Copy depth images to output directory
-        copied_depth_maps_paths = process_data_utils.copy_and_upscale_polycam_depth_maps_list(
-            polycam_depth_maps_filenames,
-            depth_dir=depth_dir,
-            crop_border_pixels=self.crop_border_pixels,
-            verbose=self.verbose
-        )
-
-        num_processed_depth_maps = len(copied_depth_maps_paths)
-
-        # assert same number of images as depth maps
-        if num_processed_images != num_processed_depth_maps:
-            raise ValueError(f"Expected same amount of depth maps as images. "
-                             f"Instead got {num_processed_images} images and {num_processed_depth_maps} depth maps")
-
-        if self.max_dataset_size > 0 and num_processed_depth_maps != num_depth_maps:
-            summary_log.append(f"Started with {num_processed_depth_maps} images out of {num_depth_maps} total")
-            summary_log.append(
-                "To change the size of the dataset add the argument --max_dataset_size to larger than the "
-                f"current value ({self.max_dataset_size}), or -1 to use all images."
-            )
-        else:
-            summary_log.append(f"Started with {num_processed_depth_maps} images")
-
-        # Downscale depth maps
-        summary_log.append(process_data_utils.downscale_images(depth_dir, self.num_downscales, folder_name="depth",
-                                                                    verbose=self.verbose))
-
-        return summary_log, polycam_depth_maps_filenames
 
 
 @dataclass

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -7,7 +7,7 @@ import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 import numpy as np
 import tyro


### PR DESCRIPTION
I was working on loading the LiDAR data from the polycam app by adding an option to the `ns-process-data polycam` interface. The API is as follows:

`ns-process-data polycam --use-depth --data 8ene,6-17p. m.-poly/ --output-dir output_data`

It searches in the keyframes folder for the depth data, scales it to match the RGB dimensions and adds it to the transforms.json. Is this still relevant with the recent [depth supervision pull request](https://github.com/nerfstudio-project/nerfstudio/pull/1173)?