### PR TITLE
Rollback cryptography to fully working version (pre-39; 38 works)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "aiortc>=1.3.2",
     "appdirs>=1.4",
     "av>=9.2.0",
+    "cryptography>=38,<39",
     "tyro>=0.3.31",
     "gdown>=4.6.0",
     "ninja>=1.10",


### PR DESCRIPTION
It appears, based on today's build, that https://github.com/nerfstudio-project/nerfstudio/issues/765#issuecomment-1384792529 is still necessary.  This PR ensures that we do not select too new a version of cryptography, in order to avoid resulting problems.