### PR TITLE
Bug fix for loading cameras with different distortions in nerfstudio_dataparser

### DIFF
--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -136,12 +136,12 @@ class Nerfstudio(DataParser):
             if not distort_fixed:
                 distort.append(
                     camera_utils.get_distortion_params(
-                        k1=float(meta["k1"]) if "k1" in meta else 0.0,
-                        k2=float(meta["k2"]) if "k2" in meta else 0.0,
-                        k3=float(meta["k3"]) if "k3" in meta else 0.0,
-                        k4=float(meta["k4"]) if "k4" in meta else 0.0,
-                        p1=float(meta["p1"]) if "p1" in meta else 0.0,
-                        p2=float(meta["p2"]) if "p2" in meta else 0.0,
+                        k1=float(frame["k1"]) if "k1" in frame else 0.0,
+                        k2=float(frame["k2"]) if "k2" in frame else 0.0,
+                        k3=float(frame["k3"]) if "k3" in frame else 0.0,
+                        k4=float(frame["k4"]) if "k4" in frame else 0.0,
+                        p1=float(frame["p1"]) if "p1" in frame else 0.0,
+                        p2=float(frame["p2"]) if "p2" in frame else 0.0,
                     )
                 )
 


### PR DESCRIPTION
Hi, 

I found the bug in `nerfstudio_dataparser.py` when I was working on multiple cameras with different distortion parameters.

This PR should fix `nerfstudio_dataparser` to load distortion parameters from multiple cameras correctly.

Thanks, 