### PR TITLE
Fix total train time metric logging

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -227,14 +227,18 @@ class Trainer:
                     self.save_checkpoint(step)
 
                 writer.write_out_storage()
-            # save checkpoint at the end of training
-            self.save_checkpoint(step)
 
-            CONSOLE.rule()
-            CONSOLE.print("[bold green]:tada: :tada: :tada: Training Finished :tada: :tada: :tada:", justify="center")
-            if not self.config.viewer.quit_on_train_completion:
-                CONSOLE.print("Use ctrl+c to quit", justify="center")
-                self._always_render(step)
+        # save checkpoint at the end of training
+        self.save_checkpoint(step)
+
+        # write out any remaining events (e.g., total train time)
+        writer.write_out_storage()
+
+        CONSOLE.rule()
+        CONSOLE.print("[bold green]:tada: :tada: :tada: Training Finished :tada: :tada: :tada:", justify="center")
+        if not self.config.viewer.quit_on_train_completion:
+            CONSOLE.print("Use ctrl+c to quit", justify="center")
+            self._always_render(step)
 
     @check_main_thread
     def _always_render(self, step):


### PR DESCRIPTION
The total train time metric was not being logged as `writer.write_out_storage()` was not being called.

It would have included the time the viewer was open until the user killed the process which probably isn't what we want as well.

Metric now logged in wandb
![image](https://user-images.githubusercontent.com/19403859/214376295-d30d472b-6174-46a4-9a60-ecadb388ab72.png)

Thanks for the great project and support on discord by the way!