### PR TITLE
Fix the issue with missing images in the Reality Capture data.

### DIFF
--- a/nerfstudio/process_data/realitycapture_utils.py
+++ b/nerfstudio/process_data/realitycapture_utils.py
@@ -32,6 +32,7 @@ def realitycapture_to_json(
     image_filename_map: List[Path],
     csv_filename: Path,
     output_dir: Path,
+    verbose: bool = False,
 ) -> List[str]:
     """Convert RealityCapture data into a nerfstudio dataset.
 
@@ -58,15 +59,30 @@ def realitycapture_to_json(
             for column, value in row.items():
                 cameras.setdefault(column, []).append(value)
 
-    img = np.array(Image.open(output_dir / image_filename_map[cameras["#name"][0].split(".")[0]]))
+    # check the first exist image with camera data
+    # in camera csv can be more records than source images
+    for i, name in enumerate(cameras["#name"]):
+        camera_label = name.split(".")[0]
+        if camera_label in image_filename_map:
+            img = np.array(Image.open(output_dir / image_filename_map[camera_label]))
+            break
+
     height, width, _ = img.shape
 
     data["h"] = int(height)
     data["w"] = int(width)
 
+    missing_image_data = 0
+
     for i, name in enumerate(cameras["#name"]):
+        basename = name.split(".")[0]
+        if basename not in image_filename_map:
+            if verbose:
+                CONSOLE.print(f"Missing image for camera data {basename}, Skipping")
+            missing_image_data += 1
+            continue
         frame = {}
-        frame["file_path"] = image_filename_map[name.split(".")[0]].as_posix()
+        frame["file_path"] = image_filename_map[basename].as_posix()
         frame["fl_x"] = float(cameras["f"][i]) * max(width, height) / 36
         frame["fl_y"] = float(cameras["f"][i]) * max(width, height) / 36
         # TODO: Unclear how to get the principal point from RealityCapture, here a guess...
@@ -95,6 +111,8 @@ def realitycapture_to_json(
         json.dump(data, f, indent=4)
 
     summary = []
+    if missing_image_data > 0:
+        summary.append(f"Missing image data for {missing_image_data} cameras.")
     if len(frames) < len(image_filename_map):
         summary.append(f"Missing camera data for {len(image_filename_map) - len(frames)} frames.")
     summary.append(f"Final dataset is {len(frames)} frames.")

--- a/nerfstudio/process_data/realitycapture_utils.py
+++ b/nerfstudio/process_data/realitycapture_utils.py
@@ -59,9 +59,7 @@ def realitycapture_to_json(
             for column, value in row.items():
                 cameras.setdefault(column, []).append(value)
 
-    # check the first exist image with camera data
-    # in camera csv can be more records than source images
-    for i, name in enumerate(cameras["#name"]):
+    for name in cameras["#name"]:
         camera_label = name.split(".")[0]
         if camera_label in image_filename_map:
             img = np.array(Image.open(output_dir / image_filename_map[camera_label]))


### PR DESCRIPTION
I had practical situations when exported data from Reality Capture was not consistent. The number of cameras exported in CSV file was higher than the number of images on a very big dataset. This can be related to Reality Capture project settings and export options. CSV file and source images were exported separately. 
This situation gives an error with ns-process-data
These changes fix the issue with missing images in the Reality Capture data.