### PR TITLE
Corrected the order of texture arguments

### DIFF
--- a/scripts/texture.py
+++ b/scripts/texture.py
@@ -56,10 +56,10 @@ class TextureMesh:
         # texture the mesh with NeRF and export to a mesh.obj file
         # and a material and texture file
         texture_utils.export_textured_mesh(
-            mesh,
-            pipeline,
-            self.px_per_uv_triangle,
-            self.output_dir,
+            mesh=mesh,
+            pipeline=pipeline,
+            output_dir=self.output_dir,
+            px_per_uv_triangle=self.px_per_uv_triangle,
             unwrap_method=self.unwrap_method,
             num_pixels_per_side=self.num_pixels_per_side,
         )


### PR DESCRIPTION
@tancik Before this fix, using `scripts/texture.py` to texture an existing mesh will give an error: `TypeError: unsupported operand type(s) for /`.

This is due to the inconsistent argument order when calling `texture_utils.export_textured_mesh` from `scripts/texture.py`. The arguments `self.px_per_uv_triangle` and `self.output_dir` should be swapped.