### PR TITLE
adding check if camera_path_dir exists

### DIFF
--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -395,13 +395,14 @@ class ViewerState:
             trainer.save_checkpoint(step)
             # get all camera paths
             camera_path_dir = os.path.join(self.datapath, "camera_paths")
-            camera_path_files = os.listdir(camera_path_dir)
-            all_path_dict = {}
-            for i in camera_path_files:
-                if i[-4:] == "json":
-                    all_path_dict[i[:-5]] = load_from_json(Path(os.path.join(camera_path_dir, i)))
-            self.vis["renderingState/all_camera_paths"].write(all_path_dict)
-            self.vis["populate_paths_payload"].delete()
+            if os.path.exists(camera_path_dir):
+                camera_path_files = os.listdir(camera_path_dir)
+                all_path_dict = {}
+                for i in camera_path_files:
+                    if i[-4:] == "json":
+                        all_path_dict[i[:-5]] = load_from_json(Path(os.path.join(camera_path_dir, i)))
+                self.vis["renderingState/all_camera_paths"].write(all_path_dict)
+                self.vis["populate_paths_payload"].delete()
 
     def _check_webrtc_offer(self):
         """Check if there is a webrtc offer to respond to."""


### PR DESCRIPTION
currently errors and ends training if datapath/camera_path doesn't exist. should still be able to load a path without erroring with this check.