### PR TITLE
add neus surface rendering method with mono priors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -92,6 +92,25 @@
       "program": "scripts/train.py",
       "console": "integratedTerminal",
       "args": ["semantic_nerf"]
-    }
+    },
+    {
+      "name": "Python: Neus on Replica",
+      "type": "python",
+      "request": "launch",
+      "program": "scripts/train.py",
+      "console": "integratedTerminal",
+      "justMyCode": false,
+      "env": {"CUDA_VISIBLE_DEVICES":"0"},
+      "args": [
+        "neus",
+        "--pipeline.model.sdf-field.inside-outside=True",
+        "--pipeline.model.mono-depth-loss-mult=0.1",
+        "--pipeline.model.mono-normal-loss-mult=0.05",
+        "--viewer.websocket-port=7007",
+        "sdfstudio-data",
+        "--data=data/sdfstudio-demo-data/replica-room0",
+        "--include_mono_prior=True"
+      ]
+    },
   ]
 }

--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -722,6 +722,7 @@ class Cameras(TensorDataclass):
             directions=directions,
             pixel_area=pixel_area,
             camera_indices=camera_indices,
+            directions_norm=directions_norm[0],
             times=times,
             metadata={"directions_norm": directions_norm[0].detach()},
         )

--- a/nerfstudio/cameras/rays.py
+++ b/nerfstudio/cameras/rays.py
@@ -54,6 +54,19 @@ class Frustums(TensorDataclass):
             pos = pos + self.offsets
         return pos
 
+    def get_start_positions(self) -> TensorType[..., 3]:
+        """Calulates "start" position of frustum. We use start positions for MonoSDF
+        because when we use error bounded sampling, we need to upsample many times.
+        It's hard to merge two set of ray samples while keeping the mid points fixed.
+        Every time we up sample the points the mid points will change and
+        therefore we need to evaluate all points again which is 3 times slower.
+        But we can skip the evaluation of sdf value if we use start position instead of mid position
+        because after we merge the points, the starting point is the same and only the delta is changed.
+        Returns:
+            xyz positions.
+        """
+        return self.origins + self.directions * self.starts
+
     def set_offsets(self, offsets):
         """Sets offsets for this frustum for computing positions"""
         self.offsets = offsets
@@ -138,6 +151,40 @@ class RaySamples(TensorDataclass):
 
         return weights
 
+    def get_weights_from_alphas(self, alphas: TensorType[..., "num_samples", 1]) -> TensorType[..., "num_samples", 1]:
+        """Return weights based on predicted alphas
+        Args:
+            alphas: Predicted alphas (maybe from sdf) for samples along ray
+        Returns:
+            Weights for each sample
+        """
+
+        transmittance = torch.cumprod(
+            torch.cat([torch.ones((*alphas.shape[:1], 1, 1), device=alphas.device), 1.0 - alphas + 1e-7], 1), 1
+        )  # [..., "num_samples"]
+
+        weights = alphas * transmittance[:, :-1, :]  # [..., "num_samples"]
+
+        return weights
+
+    def get_weights_and_transmittance_from_alphas(
+        self, alphas: TensorType[..., "num_samples", 1]
+    ) -> TensorType[..., "num_samples", 1]:
+        """Return weights based on predicted alphas
+        Args:
+            alphas: Predicted alphas (maybe from sdf) for samples along ray
+        Returns:
+            Weights for each sample
+        """
+
+        transmittance = torch.cumprod(
+            torch.cat([torch.ones((*alphas.shape[:1], 1, 1), device=alphas.device), 1.0 - alphas + 1e-7], 1), 1
+        )  # [..., "num_samples"]
+
+        weights = alphas * transmittance[:, :-1, :]  # [..., "num_samples"]
+
+        return weights, transmittance
+
 
 @dataclass
 class RayBundle(TensorDataclass):
@@ -150,6 +197,8 @@ class RayBundle(TensorDataclass):
     """Unit ray direction vector"""
     pixel_area: TensorType[..., 1]
     """Projected area of pixel a distance 1 away from origin"""
+    directions_norm: Optional[TensorType[..., 1]] = None
+    """Norm of ray direction vector before normalization"""
     camera_indices: Optional[TensorType[..., 1]] = None
     """Camera indices"""
     nears: Optional[TensorType[..., 1]] = None

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -49,6 +49,7 @@ from nerfstudio.data.dataparsers.nuscenes_dataparser import NuScenesDataParserCo
 from nerfstudio.data.dataparsers.phototourism_dataparser import (
     PhototourismDataParserConfig,
 )
+from nerfstudio.data.dataparsers.sdfstudio_dataparser import SDFStudioDataParserConfig
 from nerfstudio.data.datasets.base_dataset import InputDataset
 from nerfstudio.data.pixel_samplers import EquirectangularPixelSampler, PixelSampler
 from nerfstudio.data.utils.dataloaders import (
@@ -75,6 +76,7 @@ AnnotatedDataParserUnion = tyro.conf.OmitSubcommandPrefixes[  # Omit prefixes of
             "dnerf-data": DNeRFDataParserConfig(),
             "phototourism-data": PhototourismDataParserConfig(),
             "dycheck-data": DycheckDataParserConfig(),
+            "sdfstudio-data": SDFStudioDataParserConfig(),
         },
         prefix_names=False,  # Omit prefixes in subcommands themselves.
     )

--- a/nerfstudio/data/dataparsers/base_dataparser.py
+++ b/nerfstudio/data/dataparsers/base_dataparser.py
@@ -60,6 +60,17 @@ class DataparserOutputs:
     """Scene box of dataset. Used to bound the scene or provide the scene scale depending on model."""
     mask_filenames: Optional[List[Path]] = None
     """Filenames for any masks that are required"""
+    depths: Optional[List[torch.Tensor]] = None
+    """Monocular depth."""
+    normals: Optional[List[torch.Tensor]] = None
+    """Monocular normal."""
+    additional_inputs: Dict[str, Any] = to_immutable_dict({})
+    """Dictionary of additional dataset information (e.g. semantics/point clouds/masks).
+    {input_name:
+    ... {"func": function to process additional dataparser outputs,
+    ... "kwargs": dictionary of data to pass into "func"}
+    }
+    """
     metadata: Dict[str, Any] = to_immutable_dict({})
     """Dictionary of any metadata that be required for the given experiment.
     Will be processed by the InputDataset to create any additional tensors that may be required.

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional, Type
+
+import numpy as np
+import torch
+from PIL import Image
+from rich.console import Console
+from torchtyping import TensorType
+
+from nerfstudio.cameras import camera_utils
+from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.data.dataparsers.base_dataparser import (
+    DataParser,
+    DataParserConfig,
+    DataparserOutputs,
+)
+from nerfstudio.data.scene_box import SceneBox
+from nerfstudio.utils.io import load_from_json
+
+CONSOLE = Console()
+
+
+def get_src_from_pairs(
+    ref_idx, all_imgs, pairs_srcs, neighbors_num=None, neighbors_shuffle=False
+) -> Dict[str, TensorType]:
+    # src_idx[0] is ref img
+    src_idx = pairs_srcs[ref_idx]
+    # randomly sample neighbors
+    if neighbors_num and neighbors_num > -1 and neighbors_num < len(src_idx) - 1:
+        if neighbors_shuffle:
+            perm_idx = torch.randperm(len(src_idx) - 1) + 1
+            src_idx = torch.cat([src_idx[[0]], src_idx[perm_idx[:neighbors_num]]])
+        else:
+            src_idx = src_idx[: neighbors_num + 1]
+    src_idx = src_idx.to(all_imgs.device)
+    return {"src_imgs": all_imgs[src_idx], "src_idxs": src_idx}
+
+
+def get_image(image_filename, alpha_color=None) -> TensorType["image_height", "image_width", "num_channels"]:
+    """Returns a 3 channel image.
+    Args:
+        image_idx: The image index in the dataset.
+    """
+    pil_image = Image.open(image_filename)
+    np_image = np.array(pil_image, dtype="uint8")  # shape is (h, w, 3 or 4)
+    assert len(np_image.shape) == 3
+    assert np_image.dtype == np.uint8
+    assert np_image.shape[2] in [3, 4], f"Image shape of {np_image.shape} is in correct."
+    image = torch.from_numpy(np_image.astype("float32") / 255.0)
+    if alpha_color is not None and image.shape[-1] == 4:
+        assert image.shape[-1] == 4
+        image = image[:, :, :3] * image[:, :, -1:] + alpha_color * (1.0 - image[:, :, -1:])
+    else:
+        image = image[:, :, :3]
+    return image
+
+
+def get_depths_and_normals(image_idx: int, depths, normals):
+    """function to process additional depths and normal information
+    Args:
+        image_idx: specific image index to work with
+        semantics: semantics data
+    """
+
+    # depth
+    depth = depths[image_idx]
+    # normal
+    normal = normals[image_idx]
+
+    return {"depth": depth, "normal": normal}
+
+
+def get_foreground_masks(image_idx: int, fg_masks):
+    """function to process additional foreground_masks
+    Args:
+        image_idx: specific image index to work with
+        fg_masks: foreground_masks
+    """
+
+    # sensor depth
+    fg_mask = fg_masks[image_idx]
+
+    return {"fg_mask": fg_mask}
+
+
+@dataclass
+class SDFStudioDataParserConfig(DataParserConfig):
+    """Scene dataset parser config"""
+
+    _target: Type = field(default_factory=lambda: SDFStudio)
+    """target class to instantiate"""
+    data: Path = Path("data/DTU/scan65")
+    """Directory specifying location of data."""
+    include_mono_prior: bool = False
+    """whether or not to load monocular depth and normal """
+    include_foreground_mask: bool = False
+    """whether or not to load foreground mask"""
+    downscale_factor: int = 1
+    scene_scale: float = 2.0
+    """
+    Sets the bounding cube to have edge length of this size.
+    The longest dimension of the Friends axis-aligned bbox will be scaled to this value.
+    """
+    skip_every_for_val_split: int = 1
+    """sub sampling validation images"""
+    auto_orient: bool = False
+
+
+@dataclass
+class SDFStudio(DataParser):
+    """SDFStudio Dataset"""
+
+    config: SDFStudioDataParserConfig
+
+    def _generate_dataparser_outputs(self, split="train"):  # pylint: disable=unused-argument,too-many-statements
+        # load meta data
+        meta = load_from_json(self.config.data / "meta_data.json")
+
+        indices = list(range(len(meta["frames"])))
+        # subsample to avoid out-of-memory for validation set
+        if split != "train" and self.config.skip_every_for_val_split >= 1:
+            indices = indices[:: self.config.skip_every_for_val_split]
+
+        image_filenames = []
+        depth_images = []
+        normal_images = []
+        foreground_mask_images = []
+        fx = []
+        fy = []
+        cx = []
+        cy = []
+        camera_to_worlds = []
+        for i, frame in enumerate(meta["frames"]):
+            if i not in indices:
+                continue
+
+            image_filename = self.config.data / frame["rgb_path"]
+
+            intrinsics = torch.tensor(frame["intrinsics"])
+            camtoworld = torch.tensor(frame["camtoworld"])
+
+            # append data
+            image_filenames.append(image_filename)
+            fx.append(intrinsics[0, 0])
+            fy.append(intrinsics[1, 1])
+            cx.append(intrinsics[0, 2])
+            cy.append(intrinsics[1, 2])
+            camera_to_worlds.append(camtoworld)
+
+            if self.config.include_mono_prior:
+                assert meta["has_mono_prior"]
+                # load mono depth
+                depth = np.load(self.config.data / frame["mono_depth_path"])
+                depth_images.append(torch.from_numpy(depth).float())
+
+                # load mono normal
+                normal = np.load(self.config.data / frame["mono_normal_path"])
+
+                # transform normal to world coordinate system
+                normal = normal * 2.0 - 1.0  # omnidata output is normalized so we convert it back to normal here
+                normal = torch.from_numpy(normal).float()
+
+                rot = camtoworld[:3, :3]
+
+                normal_map = normal.reshape(3, -1)
+                normal_map = torch.nn.functional.normalize(normal_map, p=2, dim=0)
+
+                normal_map = rot @ normal_map
+                normal_map = normal_map.permute(1, 0).reshape(*normal.shape[1:], 3)
+                normal_images.append(normal_map)
+
+            if self.config.include_foreground_mask:
+                assert meta["has_foreground_mask"]
+                # load foreground mask
+                foreground_mask = np.array(Image.open(self.config.data / frame["foreground_mask"]), dtype="uint8")
+                foreground_mask = foreground_mask[..., :1]
+                foreground_mask_images.append(torch.from_numpy(foreground_mask).float() / 255.0)
+
+        fx = torch.stack(fx)
+        fy = torch.stack(fy)
+        cx = torch.stack(cx)
+        cy = torch.stack(cy)
+        camera_to_worlds = torch.stack(camera_to_worlds)
+
+        # Convert from COLMAP's/OPENCV's camera coordinate system to nerfstudio
+        camera_to_worlds[:, 0:3, 1:3] *= -1
+
+        if self.config.auto_orient:
+            camera_to_worlds, transform = camera_utils.auto_orient_and_center_poses(
+                camera_to_worlds,
+                method="up",
+                center_poses=False,
+            )
+
+            # we should also transform normal accordingly
+            normal_images_aligned = []
+            for normal_image in normal_images:
+                h, w, _ = normal_image.shape
+                normal_image = transform[:3, :3] @ normal_image.reshape(-1, 3).permute(1, 0)
+                normal_image = normal_image.permute(1, 0).reshape(h, w, 3)
+                normal_images_aligned.append(normal_image)
+            normal_images = normal_images_aligned
+
+        # scene box from meta data
+        meta_scene_box = meta["scene_box"]
+        aabb = torch.tensor(meta_scene_box["aabb"], dtype=torch.float32)
+        scene_box = SceneBox(
+            aabb=aabb,
+            near=meta_scene_box["near"],
+            far=meta_scene_box["far"],
+            radius=meta_scene_box["radius"],
+            collider_type=meta_scene_box["collider_type"],
+        )
+
+        height, width = meta["height"], meta["width"]
+        cameras = Cameras(
+            fx=fx,
+            fy=fy,
+            cx=cx,
+            cy=cy,
+            height=height,
+            width=width,
+            camera_to_worlds=camera_to_worlds[:, :3, :4],
+            camera_type=CameraType.PERSPECTIVE,
+        )
+
+        # TODO supports downsample
+        # cameras.rescale_output_resolution(scaling_factor=1.0 / self.config.downscale_factor)
+
+        if self.config.include_mono_prior:
+            additional_inputs_dict = {
+                "cues": {"func": get_depths_and_normals, "kwargs": {"depths": depth_images, "normals": normal_images}}
+            }
+        else:
+            additional_inputs_dict = {}
+
+        if self.config.include_foreground_mask:
+            additional_inputs_dict["foreground_masks"] = {
+                "func": get_foreground_masks,
+                "kwargs": {"fg_masks": foreground_mask_images},
+            }
+
+        dataparser_outputs = DataparserOutputs(
+            image_filenames=image_filenames,
+            cameras=cameras,
+            scene_box=scene_box,
+            additional_inputs=additional_inputs_dict,
+            depths=depth_images,
+            normals=normal_images,
+        )
+        return dataparser_outputs

--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -96,6 +96,11 @@ class InputDataset(Dataset):
         image = self.get_image(image_idx)
         data = {"image_idx": image_idx}
         data["image"] = image
+        for _, data_func_dict in self._dataparser_outputs.additional_inputs.items():
+            assert "func" in data_func_dict, "Missing function to process data: specify `func` in `additional_inputs`"
+            func = data_func_dict["func"]
+            assert "kwargs" in data_func_dict, "No data to process: specify `kwargs` in `additional_inputs`"
+            data.update(func(image_idx, **data_func_dict["kwargs"]))
         if self.has_masks:
             mask_filepath = self._dataparser_outputs.mask_filenames[image_idx]
             data["mask"] = get_image_mask_tensor_from_path(filepath=mask_filepath, scale_factor=self.scale_factor)

--- a/nerfstudio/data/scene_box.py
+++ b/nerfstudio/data/scene_box.py
@@ -32,6 +32,8 @@ class SceneBox:
     """aabb: axis-aligned bounding box.
     aabb[0] is the minimum (x,y,z) point.
     aabb[1] is the maximum (x,y,z) point."""
+    coarse_binary_gird: Optional[torch.Tensor] = None
+    """coarse binary grid computed from sparse colmap point cloud, currently only used in neuralrecon in the wild"""
     near: Optional[float] = 0.1
     """near plane for each image"""
     far: Optional[float] = 6.0

--- a/nerfstudio/data/scene_box.py
+++ b/nerfstudio/data/scene_box.py
@@ -17,10 +17,11 @@ Dataset input structures.
 """
 
 from dataclasses import dataclass
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 import torch
 from torchtyping import TensorType
+from typing_extensions import Literal
 
 
 @dataclass
@@ -31,6 +32,14 @@ class SceneBox:
     """aabb: axis-aligned bounding box.
     aabb[0] is the minimum (x,y,z) point.
     aabb[1] is the maximum (x,y,z) point."""
+    near: Optional[float] = 0.1
+    """near plane for each image"""
+    far: Optional[float] = 6.0
+    """far plane for each image"""
+    radius: Optional[float] = 1.0
+    """radius of sphere"""
+    collider_type: Literal["box", "near_far", "sphere"] = "box"
+    """collider type for each ray, default is box"""
 
     def get_diagonal_length(self):
         """Returns the longest diagonal length."""

--- a/nerfstudio/engine/schedulers.py
+++ b/nerfstudio/engine/schedulers.py
@@ -114,3 +114,38 @@ class DelayedExponentialScheduler(DelayerScheduler):
             max_steps,
         )
         super().__init__(optimizer, lr_init, lr_final, max_steps, delay_epochs, after_scheduler=after_scheduler)
+
+
+@dataclass
+class NeuSSchedulerConfig(InstantiateConfig):
+    """Basic scheduler config with self-defined exponential decay schedule"""
+
+    _target: Type = field(default_factory=lambda: NeuSScheduler)
+    warm_up_end: int = 5000
+    learning_rate_alpha: float = 0.05
+    max_steps: int = 300000
+
+    def setup(self, optimizer=None, lr_init=None, **kwargs) -> Any:
+        """Returns the instantiated object using the config."""
+        return self._target(
+            optimizer,
+            self.warm_up_end,
+            self.learning_rate_alpha,
+            self.max_steps,
+        )
+
+
+class NeuSScheduler(lr_scheduler.LambdaLR):
+    """Starts with a flat lr schedule until it reaches N epochs then applies a given scheduler"""
+
+    def __init__(self, optimizer, warm_up_end, learning_rate_alpha, max_steps) -> None:
+        def func(step):
+            if step < warm_up_end:
+                learning_factor = step / warm_up_end
+            else:
+                alpha = learning_rate_alpha
+                progress = (step - warm_up_end) / (max_steps - warm_up_end)
+                learning_factor = (np.cos(np.pi * progress) + 1.0) * 0.5 * (1 - alpha) + alpha
+            return learning_factor
+
+        super().__init__(optimizer, lr_lambda=func)

--- a/nerfstudio/exporter/texture_utils.py
+++ b/nerfstudio/exporter/texture_utils.py
@@ -393,11 +393,13 @@ def export_textured_mesh(
     camera_indices = torch.zeros_like(origins[..., 0:1])
     nears = torch.zeros_like(origins[..., 0:1])
     fars = torch.ones_like(origins[..., 0:1]) * raylen
+    directions_norm = torch.ones_like(origins[..., 0:1])  # for surface model
     camera_ray_bundle = RayBundle(
         origins=origins,
         directions=directions,
         pixel_area=pixel_area,
         camera_indices=camera_indices,
+        directions_norm=directions_norm,
         nears=nears,
         fars=fars,
     )

--- a/nerfstudio/field_components/field_heads.py
+++ b/nerfstudio/field_components/field_heads.py
@@ -37,6 +37,11 @@ class FieldHeadNames(Enum):
     TRANSIENT_RGB = "transient_rgb"
     TRANSIENT_DENSITY = "transient_density"
     SEMANTICS = "semantics"
+    # probably a better way to do this
+    NORMAL = "normal"
+    SDF = "sdf"
+    ALPHA = "alpha"
+    GRADIENT = "gradient"
 
 
 class FieldHead(FieldComponent):

--- a/nerfstudio/fields/base_field.py
+++ b/nerfstudio/fields/base_field.py
@@ -17,14 +17,25 @@ Base class for the graphs.
 """
 
 from abc import abstractmethod
-from typing import Dict, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple, Type
 
 import torch
 from torch import nn
 from torchtyping import TensorType
 
 from nerfstudio.cameras.rays import Frustums, RaySamples
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.field_components.field_heads import FieldHeadNames
+
+
+# Field related configs for NeuS
+@dataclass
+class FieldConfig(InstantiateConfig):
+    """Configuration for model instantiation"""
+
+    _target: Type = field(default_factory=lambda: Field)
+    """target class to instantiate"""
 
 
 class Field(nn.Module):

--- a/nerfstudio/fields/sdf_field.py
+++ b/nerfstudio/fields/sdf_field.py
@@ -1,0 +1,466 @@
+# Copyright 2022 The Nerfstudio Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Field for compound nerf model, adds scene contraction and image embeddings to instant ngp
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, Type, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.nn.parameter import Parameter
+from torchtyping import TensorType
+from typing_extensions import Literal
+
+from nerfstudio.cameras.rays import RaySamples
+from nerfstudio.field_components.embedding import Embedding
+from nerfstudio.field_components.encodings import NeRFEncoding
+from nerfstudio.field_components.field_heads import FieldHeadNames
+from nerfstudio.field_components.spatial_distortions import SpatialDistortion
+from nerfstudio.fields.base_field import Field, FieldConfig
+
+try:
+    import tinycudann as tcnn
+except ImportError:
+    # tinycudann module doesn't exist
+    pass
+
+
+class SingleVarianceNetwork(nn.Module):
+    """Variance network in NeuS
+
+    Args:
+        nn (_type_): init value in NeuS variance network
+    """
+
+    def __init__(self, init_val):
+        super(SingleVarianceNetwork, self).__init__()
+        self.register_parameter("variance", nn.Parameter(init_val * torch.ones(1), requires_grad=True))
+
+    def forward(self, x):
+        """Returns current variance value"""
+        return torch.ones([len(x), 1], device=x.device) * torch.exp(self.variance * 10.0)
+
+    def get_variance(self):
+        """return current variance value"""
+        return torch.exp(self.variance * 10.0).clip(1e-6, 1e6)
+
+
+@dataclass
+class SDFFieldConfig(FieldConfig):
+    """Nerfacto Model Config"""
+
+    _target: Type = field(default_factory=lambda: SDFField)
+    num_layers: int = 8
+    """Number of layers for geometric network"""
+    hidden_dim: int = 256
+    """Number of hidden dimension of geometric network"""
+    geo_feat_dim: int = 256
+    """Dimension of geometric feature"""
+    num_layers_color: int = 4
+    """Number of layers for color network"""
+    hidden_dim_color: int = 256
+    """Number of hidden dimension of color network"""
+    appearance_embedding_dim: int = 32
+    """Dimension of appearance embedding"""
+    use_appearance_embedding: bool = False
+    """Dimension of appearance embedding"""
+    bias: float = 0.8
+    """sphere size of geometric initializaion"""
+    geometric_init: bool = True
+    """Whether to use geometric initialization"""
+    inside_outside: bool = True
+    """whether to revert signed distance value, set to True for indoor scene"""
+    weight_norm: bool = True
+    """Whether to use weight norm for linear laer"""
+    use_grid_feature: bool = False
+    """Whether to use multi-resolution feature grids"""
+    divide_factor: float = 2.0
+    """Normalization factor for multi-resolution grids"""
+    beta_init: float = 0.1
+    """Init learnable beta value for transformation of sdf to density"""
+    encoding_type: Literal["hash", "periodic", "tensorf_vm"] = "hash"
+
+
+class SDFField(Field):
+    """_summary_
+
+    Args:
+        Field (_type_): _description_
+    """
+
+    config: SDFFieldConfig
+
+    def __init__(
+        self,
+        config: SDFFieldConfig,
+        aabb,
+        num_images: int,
+        use_average_appearance_embedding: bool = False,
+        spatial_distortion: Optional[SpatialDistortion] = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+
+        # TODO do we need aabb here?
+        self.aabb = Parameter(aabb, requires_grad=False)
+
+        self.spatial_distortion = spatial_distortion
+        self.num_images = num_images
+
+        self.embedding_appearance = Embedding(self.num_images, self.config.appearance_embedding_dim)
+        self.use_average_appearance_embedding = use_average_appearance_embedding
+        self.use_grid_feature = self.config.use_grid_feature
+        self.divide_factor = self.config.divide_factor
+
+        num_levels = 16
+        max_res = 2048
+        base_res = 16
+        log2_hashmap_size = 19
+        features_per_level = 2
+        use_hash = True
+        smoothstep = True
+        growth_factor = np.exp((np.log(max_res) - np.log(base_res)) / (num_levels - 1))
+
+        if self.config.encoding_type == "hash":
+            # feature encoding
+            self.encoding = tcnn.Encoding(
+                n_input_dims=3,
+                encoding_config={
+                    "otype": "HashGrid" if use_hash else "DenseGrid",
+                    "n_levels": num_levels,
+                    "n_features_per_level": features_per_level,
+                    "log2_hashmap_size": log2_hashmap_size,
+                    "base_resolution": base_res,
+                    "per_level_scale": growth_factor,
+                    "interpolation": "Smoothstep" if smoothstep else "Linear",
+                },
+            )
+
+        # TODO make this configurable
+        # we concat inputs position ourselves
+        self.position_encoding = NeRFEncoding(
+            in_dim=3, num_frequencies=6, min_freq_exp=0.0, max_freq_exp=5.0, include_input=False
+        )
+
+        self.direction_encoding = NeRFEncoding(
+            in_dim=3, num_frequencies=4, min_freq_exp=0.0, max_freq_exp=3.0, include_input=True
+        )
+
+        # TODO move it to field components
+        # MLP with geometric initialization
+        dims = [self.config.hidden_dim for _ in range(self.config.num_layers)]
+        in_dim = 3 + self.position_encoding.get_out_dim() + self.encoding.n_output_dims
+        dims = [in_dim] + dims + [1 + self.config.geo_feat_dim]
+        self.num_layers = len(dims)
+        # TODO check how to merge skip_in to config
+        self.skip_in = [4]
+
+        for l in range(0, self.num_layers - 1):
+            if l + 1 in self.skip_in:
+                out_dim = dims[l + 1] - dims[0]
+            else:
+                out_dim = dims[l + 1]
+
+            lin = nn.Linear(dims[l], out_dim)
+
+            if self.config.geometric_init:
+                if l == self.num_layers - 2:
+                    if not self.config.inside_outside:
+                        torch.nn.init.normal_(lin.weight, mean=np.sqrt(np.pi) / np.sqrt(dims[l]), std=0.0001)
+                        torch.nn.init.constant_(lin.bias, -self.config.bias)
+                    else:
+                        torch.nn.init.normal_(lin.weight, mean=-np.sqrt(np.pi) / np.sqrt(dims[l]), std=0.0001)
+                        torch.nn.init.constant_(lin.bias, self.config.bias)
+                elif l == 0:
+                    torch.nn.init.constant_(lin.bias, 0.0)
+                    torch.nn.init.constant_(lin.weight[:, 3:], 0.0)
+                    torch.nn.init.normal_(lin.weight[:, :3], 0.0, np.sqrt(2) / np.sqrt(out_dim))
+                elif l in self.skip_in:
+                    torch.nn.init.constant_(lin.bias, 0.0)
+                    torch.nn.init.normal_(lin.weight, 0.0, np.sqrt(2) / np.sqrt(out_dim))
+                    torch.nn.init.constant_(lin.weight[:, -(dims[0] - 3) :], 0.0)
+                else:
+                    torch.nn.init.constant_(lin.bias, 0.0)
+                    torch.nn.init.normal_(lin.weight, 0.0, np.sqrt(2) / np.sqrt(out_dim))
+
+            if self.config.weight_norm:
+                lin = nn.utils.weight_norm(lin)
+                # print("=======", lin.weight.shape)
+            setattr(self, "glin" + str(l), lin)
+
+        # TODO use different name for beta_init for config
+        # deviation_network to compute alpha from sdf from NeuS
+        self.deviation_network = SingleVarianceNetwork(init_val=self.config.beta_init)
+
+        # color network
+        dims = [self.config.hidden_dim_color for _ in range(self.config.num_layers_color)]
+        # point, view_direction, normal, feature, embedding
+        in_dim = (
+            3
+            + self.direction_encoding.get_out_dim()
+            + 3
+            + self.config.geo_feat_dim
+            + self.embedding_appearance.get_out_dim()
+        )
+        dims = [in_dim] + dims + [3]
+        self.num_layers_color = len(dims)
+
+        for l in range(0, self.num_layers_color - 1):
+            out_dim = dims[l + 1]
+            lin = nn.Linear(dims[l], out_dim)
+
+            if self.config.weight_norm:
+                lin = nn.utils.weight_norm(lin)
+            # print("=======", lin.weight.shape)
+            setattr(self, "clin" + str(l), lin)
+
+        self.softplus = nn.Softplus(beta=100)
+        self.relu = nn.ReLU()
+        self.sigmoid = torch.nn.Sigmoid()
+
+        self._cos_anneal_ratio = 1.0
+
+    def set_cos_anneal_ratio(self, anneal: float) -> None:
+        """Set the anneal value for the proposal network."""
+        self._cos_anneal_ratio = anneal
+
+    def forward_geonetwork(self, inputs):
+        """forward the geonetwork"""
+        if self.use_grid_feature:
+            # TODO check how we should normalize the points
+            # normalize point range as encoding assume points are in [-1, 1]
+            # positions = inputs / self.divide_factor
+            positions = self.spatial_distortion(inputs)
+
+            positions = (positions + 1.0) / 2.0
+            feature = self.encoding(positions)
+            # raise NotImplementedError
+        else:
+            feature = torch.zeros_like(inputs[:, :1].repeat(1, self.encoding.n_output_dims))
+
+        pe = self.position_encoding(inputs)
+
+        inputs = torch.cat((inputs, pe, feature), dim=-1)
+
+        x = inputs
+
+        for l in range(0, self.num_layers - 1):
+            lin = getattr(self, "glin" + str(l))
+
+            if l in self.skip_in:
+                x = torch.cat([x, inputs], 1) / np.sqrt(2)
+
+            x = lin(x)
+
+            if l < self.num_layers - 2:
+                x = self.softplus(x)
+        return x
+
+    def get_sdf(self, ray_samples: RaySamples):
+        """predict the sdf value for ray samples"""
+        positions = ray_samples.frustums.get_start_positions()
+        positions_flat = positions.view(-1, 3)
+        h = self.forward_geonetwork(positions_flat).view(*ray_samples.frustums.shape, -1)
+        sdf, _ = torch.split(h, [1, self.config.geo_feat_dim], dim=-1)
+        return sdf
+
+    def gradient(self, x):
+        """compute the gradient of the ray"""
+        x.requires_grad_(True)
+        y = self.forward_geonetwork(x)[:, :1]
+        d_output = torch.ones_like(y, requires_grad=False, device=y.device)
+        gradients = torch.autograd.grad(
+            outputs=y, inputs=x, grad_outputs=d_output, create_graph=True, retain_graph=True, only_inputs=True
+        )[0]
+        return gradients
+
+    # def get_density(self, ray_samples: RaySamples):
+    #     """Computes and returns the densities."""
+    #     positions = ray_samples.frustums.get_start_positions()
+    #     positions_flat = positions.view(-1, 3)
+    #     h = self.forward_geonetwork(positions_flat).view(*ray_samples.frustums.shape, -1)
+    #     sdf, geo_feature = torch.split(h, [1, self.config.geo_feat_dim], dim=-1)
+    #     density = self.laplace_density(sdf)
+    #     return density, geo_feature
+
+    def get_alpha(self, ray_samples: RaySamples, sdf=None, gradients=None):
+        """compute alpha from sdf as in NeuS"""
+        if sdf is None or gradients is None:
+            inputs = ray_samples.frustums.get_start_positions()
+            inputs.requires_grad_(True)
+            with torch.enable_grad():
+                h = self.forward_geonetwork(inputs)
+                sdf, _ = torch.split(h, [1, self.config.geo_feat_dim], dim=-1)
+            d_output = torch.ones_like(sdf, requires_grad=False, device=sdf.device)
+            gradients = torch.autograd.grad(
+                outputs=sdf,
+                inputs=inputs,
+                grad_outputs=d_output,
+                create_graph=True,
+                retain_graph=True,
+                only_inputs=True,
+            )[0]
+
+        inv_s = self.deviation_network.get_variance()  # Single parameter
+
+        true_cos = (ray_samples.frustums.directions * gradients).sum(-1, keepdim=True)
+
+        # anneal as NeuS
+        cos_anneal_ratio = self._cos_anneal_ratio
+
+        # "cos_anneal_ratio" grows from 0 to 1 in the beginning training iterations. The anneal strategy below makes
+        # the cos value "not dead" at the beginning training iterations, for better convergence.
+        iter_cos = -(
+            F.relu(-true_cos * 0.5 + 0.5) * (1.0 - cos_anneal_ratio) + F.relu(-true_cos) * cos_anneal_ratio
+        )  # always non-positive
+
+        # Estimate signed distances at section points
+        estimated_next_sdf = sdf + iter_cos * ray_samples.deltas * 0.5
+        estimated_prev_sdf = sdf - iter_cos * ray_samples.deltas * 0.5
+
+        prev_cdf = torch.sigmoid(estimated_prev_sdf * inv_s)
+        next_cdf = torch.sigmoid(estimated_next_sdf * inv_s)
+
+        p = prev_cdf - next_cdf
+        c = prev_cdf
+
+        alpha = ((p + 1e-5) / (c + 1e-5)).clip(0.0, 1.0)
+
+        # HF-NeuS
+        # # sigma
+        # cdf = torch.sigmoid(sdf * inv_s)
+        # e = inv_s * (1 - cdf) * (-iter_cos) * ray_samples.deltas
+        # alpha = (1 - torch.exp(-e)).clip(0.0, 1.0)
+
+        return alpha
+
+    def get_occupancy(self, sdf):
+        """compute occupancy as in UniSurf"""
+        occupancy = self.sigmoid(-10.0 * sdf)
+        return occupancy
+
+    def get_colors(self, points, directions, normals, geo_features, camera_indices):
+        """compute colors"""
+        d = self.direction_encoding(directions)
+
+        # appearance
+        if self.training:
+            embedded_appearance = self.embedding_appearance(camera_indices)
+            # set it to zero if don't use it
+            if not self.config.use_appearance_embedding:
+                embedded_appearance = torch.zeros_like(embedded_appearance)
+        else:
+            if self.use_average_appearance_embedding:
+                embedded_appearance = torch.ones(
+                    (*directions.shape[:-1], self.config.appearance_embedding_dim), device=directions.device
+                ) * self.embedding_appearance.mean(dim=0)
+            else:
+                embedded_appearance = torch.zeros(
+                    (*directions.shape[:-1], self.config.appearance_embedding_dim), device=directions.device
+                )
+
+        h = torch.cat(
+            [
+                points,
+                d,
+                normals,
+                geo_features.view(-1, self.config.geo_feat_dim),
+                embedded_appearance.view(-1, self.config.appearance_embedding_dim),
+            ],
+            dim=-1,
+        )
+
+        for l in range(0, self.num_layers_color - 1):
+            lin = getattr(self, "clin" + str(l))
+
+            h = lin(h)
+
+            if l < self.num_layers_color - 2:
+                h = self.relu(h)
+
+        rgb = self.sigmoid(h)
+
+        # unisurf
+        # rgb = self.tanh(h) * 0.5 + 0.5
+
+        return rgb
+
+    def get_outputs(self, ray_samples: RaySamples, return_alphas=False, return_occupancy=False):
+        """compute output of ray samples"""
+        if ray_samples.camera_indices is None:
+            raise AttributeError("Camera indices are not provided.")
+
+        outputs = {}
+
+        camera_indices = ray_samples.camera_indices.squeeze()
+
+        inputs = ray_samples.frustums.get_start_positions()
+        inputs = inputs.view(-1, 3)
+
+        directions = ray_samples.frustums.directions
+        directions_flat = directions.reshape(-1, 3)
+
+        inputs.requires_grad_(True)
+        with torch.enable_grad():
+            h = self.forward_geonetwork(inputs)
+            sdf, geo_feature = torch.split(h, [1, self.config.geo_feat_dim], dim=-1)
+        d_output = torch.ones_like(sdf, requires_grad=False, device=sdf.device)
+        gradients = torch.autograd.grad(
+            outputs=sdf, inputs=inputs, grad_outputs=d_output, create_graph=True, retain_graph=True, only_inputs=True
+        )[0]
+
+        rgb = self.get_colors(inputs, directions_flat, gradients, geo_feature, camera_indices)
+
+        # density = self.laplace_density(sdf)
+
+        rgb = rgb.view(*ray_samples.frustums.directions.shape[:-1], -1)
+        sdf = sdf.view(*ray_samples.frustums.directions.shape[:-1], -1)
+        # density = density.view(*ray_samples.frustums.directions.shape[:-1], -1)
+        gradients = gradients.view(*ray_samples.frustums.directions.shape[:-1], -1)
+        normals = torch.nn.functional.normalize(gradients, p=2, dim=-1)
+
+        outputs.update(
+            {
+                FieldHeadNames.RGB: rgb,
+                # FieldHeadNames.DENSITY: density,
+                FieldHeadNames.SDF: sdf,
+                FieldHeadNames.NORMAL: normals,
+                FieldHeadNames.GRADIENT: gradients,
+            }
+        )
+
+        if return_alphas:
+            # TODO use mid point sdf for NeuS
+            alphas = self.get_alpha(ray_samples, sdf, gradients)
+            outputs.update({FieldHeadNames.ALPHA: alphas})
+
+        if return_occupancy:
+            occupancy = self.get_occupancy(sdf)
+            outputs.update({FieldHeadNames.OCCUPANCY: occupancy})
+
+        return outputs
+
+    def forward(self, ray_samples: RaySamples, return_alphas=False, return_occupancy=False):
+        """Evaluates the field at points along the ray.
+
+        Args:
+            ray_samples: Samples to evaluate field on.
+        """
+        field_outputs = self.get_outputs(ray_samples, return_alphas=return_alphas, return_occupancy=return_occupancy)
+        return field_outputs

--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -302,3 +302,159 @@ def depth_loss(
         return urban_radiance_field_depth_loss(weights, termination_depth, predicted_depth, steps, sigma)
 
     raise NotImplementedError("Provided depth loss type not implemented.")
+
+
+def monosdf_normal_loss(normal_pred: torch.Tensor, normal_gt: torch.Tensor):
+    """normal consistency loss as monosdf
+    Args:
+        normal_pred (torch.Tensor): volume rendered normal
+        normal_gt (torch.Tensor): monocular normal
+    """
+    normal_gt = torch.nn.functional.normalize(normal_gt, p=2, dim=-1)
+    normal_pred = torch.nn.functional.normalize(normal_pred, p=2, dim=-1)
+    l1 = torch.abs(normal_pred - normal_gt).sum(dim=-1).mean()
+    cos = (1.0 - torch.sum(normal_pred * normal_gt, dim=-1)).mean()
+    return l1 + cos
+
+
+# copy from MiDaS
+def compute_scale_and_shift(prediction, target, mask):
+    # system matrix: A = [[a_00, a_01], [a_10, a_11]]
+    a_00 = torch.sum(mask * prediction * prediction, (1, 2))
+    a_01 = torch.sum(mask * prediction, (1, 2))
+    a_11 = torch.sum(mask, (1, 2))
+
+    # right hand side: b = [b_0, b_1]
+    b_0 = torch.sum(mask * prediction * target, (1, 2))
+    b_1 = torch.sum(mask * target, (1, 2))
+
+    # solution: x = A^-1 . b = [[a_11, -a_01], [-a_10, a_00]] / (a_00 * a_11 - a_01 * a_10) . b
+    x_0 = torch.zeros_like(b_0)
+    x_1 = torch.zeros_like(b_1)
+
+    det = a_00 * a_11 - a_01 * a_01
+    valid = det.nonzero()
+
+    x_0[valid] = (a_11[valid] * b_0[valid] - a_01[valid] * b_1[valid]) / det[valid]
+    x_1[valid] = (-a_01[valid] * b_0[valid] + a_00[valid] * b_1[valid]) / det[valid]
+
+    return x_0, x_1
+
+
+def reduction_batch_based(image_loss, M):
+    # average of all valid pixels of the batch
+
+    # avoid division by 0 (if sum(M) = sum(sum(mask)) = 0: sum(image_loss) = 0)
+    divisor = torch.sum(M)
+
+    if divisor == 0:
+        return 0
+    else:
+        return torch.sum(image_loss) / divisor
+
+
+def reduction_image_based(image_loss, M):
+    # mean of average of valid pixels of an image
+
+    # avoid division by 0 (if M = sum(mask) = 0: image_loss = 0)
+    valid = M.nonzero()
+
+    image_loss[valid] = image_loss[valid] / M[valid]
+
+    return torch.mean(image_loss)
+
+
+def mse_loss(prediction, target, mask, reduction=reduction_batch_based):
+
+    M = torch.sum(mask, (1, 2))
+    res = prediction - target
+    image_loss = torch.sum(mask * res * res, (1, 2))
+
+    return reduction(image_loss, 2 * M)
+
+
+def gradient_loss(prediction, target, mask, reduction=reduction_batch_based):
+
+    M = torch.sum(mask, (1, 2))
+
+    diff = prediction - target
+    diff = torch.mul(mask, diff)
+
+    grad_x = torch.abs(diff[:, :, 1:] - diff[:, :, :-1])
+    mask_x = torch.mul(mask[:, :, 1:], mask[:, :, :-1])
+    grad_x = torch.mul(mask_x, grad_x)
+
+    grad_y = torch.abs(diff[:, 1:, :] - diff[:, :-1, :])
+    mask_y = torch.mul(mask[:, 1:, :], mask[:, :-1, :])
+    grad_y = torch.mul(mask_y, grad_y)
+
+    image_loss = torch.sum(grad_x, (1, 2)) + torch.sum(grad_y, (1, 2))
+
+    return reduction(image_loss, M)
+
+
+class MiDaSMSELoss(nn.Module):
+    def __init__(self, reduction="batch-based"):
+        super().__init__()
+
+        if reduction == "batch-based":
+            self.__reduction = reduction_batch_based
+        else:
+            self.__reduction = reduction_image_based
+
+    def forward(self, prediction, target, mask):
+        return mse_loss(prediction, target, mask, reduction=self.__reduction)
+
+
+class GradientLoss(nn.Module):
+    def __init__(self, scales=4, reduction="batch-based"):
+        super().__init__()
+
+        if reduction == "batch-based":
+            self.__reduction = reduction_batch_based
+        else:
+            self.__reduction = reduction_image_based
+
+        self.__scales = scales
+
+    def forward(self, prediction, target, mask):
+        total = 0
+
+        for scale in range(self.__scales):
+            step = pow(2, scale)
+
+            total += gradient_loss(
+                prediction[:, ::step, ::step],
+                target[:, ::step, ::step],
+                mask[:, ::step, ::step],
+                reduction=self.__reduction,
+            )
+
+        return total
+
+
+class ScaleAndShiftInvariantLoss(nn.Module):
+    def __init__(self, alpha=0.5, scales=4, reduction="batch-based"):
+        super().__init__()
+
+        self.__data_loss = MiDaSMSELoss(reduction=reduction)
+        self.__regularization_loss = GradientLoss(scales=scales, reduction=reduction)
+        self.__alpha = alpha
+
+        self.__prediction_ssi = None
+
+    def forward(self, prediction, target, mask):
+
+        scale, shift = compute_scale_and_shift(prediction, target, mask)
+        self.__prediction_ssi = scale.view(-1, 1, 1) * prediction + shift.view(-1, 1, 1)
+
+        total = self.__data_loss(self.__prediction_ssi, target, mask)
+        if self.__alpha > 0:
+            total += self.__alpha * self.__regularization_loss(self.__prediction_ssi, target, mask)
+
+        return total
+
+    def __get_prediction_ssi(self):
+        return self.__prediction_ssi
+
+    prediction_ssi = property(__get_prediction_ssi)

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -17,7 +17,7 @@ Collection of sampling strategies
 """
 
 from abc import abstractmethod
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 import nerfacc
 import torch
@@ -584,3 +584,164 @@ class ProposalNetworkSampler(Sampler):
 
         assert ray_samples is not None
         return ray_samples, weights_list, ray_samples_list
+
+
+class NeuSSampler(Sampler):
+    """NeuS sampler that uses a sdf network to generate samples with fixed variance value in each iterations."""
+
+    def __init__(
+        self,
+        num_samples: int = 64,
+        num_samples_importance: int = 64,
+        num_samples_outside: int = 32,
+        num_upsample_steps: int = 4,
+        base_variance: float = 64,
+        single_jitter: bool = True,
+    ) -> None:
+        super().__init__()
+        self.num_samples = num_samples
+        self.num_samples_importance = num_samples_importance
+        self.num_samples_outside = num_samples_outside
+        self.num_upsample_steps = num_upsample_steps
+        self.base_variance = base_variance
+        self.single_jitter = single_jitter
+
+        # samplers
+        self.uniform_sampler = UniformSampler(single_jitter=single_jitter)
+        self.pdf_sampler = PDFSampler(
+            include_original=False,
+            single_jitter=single_jitter,
+            histogram_padding=1e-5,
+        )
+        self.outside_sampler = LinearDisparitySampler()
+        # TODO make it outside
+        # for merge samples
+        # self.error_bounded_sampler = ErrorBoundedSampler()
+
+    def generate_ray_samples(
+        self,
+        ray_bundle: Optional[RayBundle] = None,
+        sdf_fn: Optional[Callable] = None,
+        ray_samples: Optional[RaySamples] = None,
+    ) -> Union[Tuple[RaySamples, torch.Tensor], RaySamples]:
+        assert ray_bundle is not None
+        assert sdf_fn is not None
+
+        # Start with uniform sampling
+        if ray_samples is None:
+            ray_samples = self.uniform_sampler(ray_bundle, num_samples=self.num_samples)
+
+        total_iters = 0
+        sorted_index = None
+        new_samples = ray_samples
+
+        base_variance = self.base_variance
+
+        while total_iters < self.num_upsample_steps:
+
+            with torch.no_grad():
+                new_sdf = sdf_fn(new_samples)
+
+            # merge sdf predictions
+            if sorted_index is not None:
+                sdf_merge = torch.cat([sdf.squeeze(-1), new_sdf.squeeze(-1)], -1)
+                sdf = torch.gather(sdf_merge, 1, sorted_index).unsqueeze(-1)
+            else:
+                sdf = new_sdf
+
+            # compute with fix variances
+            alphas = self.rendering_sdf_with_fixed_inv_s(
+                ray_samples, sdf.reshape(ray_samples.shape), inv_s=base_variance * 2**total_iters
+            )
+
+            weights = ray_samples.get_weights_from_alphas(alphas[..., None])
+            weights = torch.cat((weights, torch.zeros_like(weights[:, :1])), dim=1)
+
+            new_samples = self.pdf_sampler(
+                ray_bundle,
+                ray_samples,
+                weights,
+                num_samples=self.num_samples_importance // self.num_upsample_steps,
+            )
+
+            ray_samples, sorted_index = self.merge_ray_samples(ray_bundle, ray_samples, new_samples)
+
+            total_iters += 1
+
+        # save_points("p.ply", ray_samples.frustums.get_start_positions().detach().cpu().numpy().reshape(-1, 3))
+        # exit(-1)
+        # TODO
+        # sample more points outside surface
+        # if self.num_samples_outside > 0:
+        #   ray_samples_uniform = self.outside_sampler(ray_bundle, num_samples=self.num_samples_outside)
+        #     ray_samples, _ = self.merge_ray_samples(ray_bundle, ray_samples, ray_samples_uniform)
+
+        return ray_samples
+
+    def rendering_sdf_with_fixed_inv_s(self, ray_samples: RaySamples, sdf: torch.Tensor, inv_s):
+        """rendering given a fixed inv_s as NeuS"""
+        batch_size = ray_samples.shape[0]
+        prev_sdf, next_sdf = sdf[:, :-1], sdf[:, 1:]
+        deltas = ray_samples.deltas[:, :-1, 0]
+        mid_sdf = (prev_sdf + next_sdf) * 0.5
+        cos_val = (next_sdf - prev_sdf) / (deltas + 1e-5)
+
+        # ----------------------------------------------------------------------------------------------------------
+        # Use min value of [ cos, prev_cos ]
+        # Though it makes the sampling (not rendering) a little bit biased, this strategy can make the sampling more
+        # robust when meeting situations like below:
+        #
+        # SDF
+        # ^
+        # |\          -----x----...
+        # | \        /
+        # |  x      x
+        # |---\----/-------------> 0 level
+        # |    \  /
+        # |     \/
+        # |
+        # ----------------------------------------------------------------------------------------------------------
+        prev_cos_val = torch.cat([torch.zeros([batch_size, 1], device=sdf.device), cos_val[:, :-1]], dim=-1)
+        cos_val = torch.stack([prev_cos_val, cos_val], dim=-1)
+        cos_val, _ = torch.min(cos_val, dim=-1, keepdim=False)
+        cos_val = cos_val.clip(-1e3, 0.0)
+
+        dist = deltas
+        prev_esti_sdf = mid_sdf - cos_val * dist * 0.5
+        next_esti_sdf = mid_sdf + cos_val * dist * 0.5
+        prev_cdf = torch.sigmoid(prev_esti_sdf * inv_s)
+        next_cdf = torch.sigmoid(next_esti_sdf * inv_s)
+        alpha = (prev_cdf - next_cdf + 1e-5) / (prev_cdf + 1e-5)
+
+        return alpha
+
+    def merge_ray_samples(self, ray_bundle: RayBundle, ray_samples_1: RaySamples, ray_samples_2: RaySamples):
+        """Merge two set of ray samples and return sorted index which can be used to merge sdf values
+        Args:
+            ray_samples_1 : ray_samples to merge
+            ray_samples_2 : ray_samples to merge
+        """
+
+        starts_1 = ray_samples_1.spacing_starts[..., 0]
+        starts_2 = ray_samples_2.spacing_starts[..., 0]
+
+        ends = torch.maximum(ray_samples_1.spacing_ends[..., -1:, 0], ray_samples_2.spacing_ends[..., -1:, 0])
+
+        bins, sorted_index = torch.sort(torch.cat([starts_1, starts_2], -1), -1)
+
+        bins = torch.cat([bins, ends], dim=-1)
+
+        # Stop gradients
+        bins = bins.detach()
+
+        euclidean_bins = ray_samples_1.spacing_to_euclidean_fn(bins)
+
+        ray_samples = ray_bundle.get_ray_samples(
+            bin_starts=euclidean_bins[..., :-1, None],
+            bin_ends=euclidean_bins[..., 1:, None],
+            spacing_starts=bins[..., :-1, None],
+            spacing_ends=bins[..., 1:, None],
+            spacing_to_euclidean_fn=ray_samples_1.spacing_to_euclidean_fn,
+        )
+
+        return ray_samples, sorted_index

--- a/nerfstudio/models/base_surface_model.py
+++ b/nerfstudio/models/base_surface_model.py
@@ -1,0 +1,423 @@
+# Copyright 2022 The Nerfstudio Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Implementation of Base surface model.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Type
+
+import torch
+import torch.nn.functional as F
+from torch.nn import Parameter
+from torchmetrics import PeakSignalNoiseRatio
+from torchmetrics.functional import structural_similarity_index_measure
+from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
+from torchtyping import TensorType
+from typing_extensions import Literal
+
+from nerfstudio.cameras.rays import RayBundle
+from nerfstudio.field_components.encodings import NeRFEncoding
+from nerfstudio.field_components.field_heads import FieldHeadNames
+from nerfstudio.field_components.spatial_distortions import SceneContraction
+from nerfstudio.fields.nerfacto_field import TCNNNerfactoField
+from nerfstudio.fields.sdf_field import SDFFieldConfig
+from nerfstudio.fields.vanilla_nerf_field import NeRFField
+from nerfstudio.model_components.losses import (
+    L1Loss,
+    MSELoss,
+    ScaleAndShiftInvariantLoss,
+    compute_scale_and_shift,
+    monosdf_normal_loss,
+)
+from nerfstudio.model_components.ray_samplers import LinearDisparitySampler
+from nerfstudio.model_components.renderers import (
+    AccumulationRenderer,
+    DepthRenderer,
+    RGBRenderer,
+    SemanticRenderer,
+)
+from nerfstudio.model_components.scene_colliders import (  # SphereCollider,
+    AABBBoxCollider,
+    NearFarCollider,
+)
+from nerfstudio.models.base_model import Model, ModelConfig
+from nerfstudio.utils import colormaps
+from nerfstudio.utils.colors import get_color
+
+
+@dataclass
+class SurfaceModelConfig(ModelConfig):
+    """Nerfacto Model Config"""
+
+    _target: Type = field(default_factory=lambda: SurfaceModel)
+    near_plane: float = 0.05
+    """How far along the ray to start sampling."""
+    far_plane: float = 4.0
+    """How far along the ray to stop sampling."""
+    far_plane_bg: float = 1000.0
+    """How far along the ray to stop sampling of the background model."""
+    background_color: Literal["random", "last_sample", "white", "black"] = "black"
+    """Whether to randomize the background color."""
+    use_average_appearance_embedding: bool = False
+    """Whether to use average appearance embedding or zeros for inference."""
+    eikonal_loss_mult: float = 0.1
+    """Monocular normal consistency loss multiplier."""
+    fg_mask_loss_mult: float = 0.01
+    """Foreground mask loss multiplier."""
+    mono_normal_loss_mult: float = 0.0
+    """Monocular normal consistency loss multiplier."""
+    mono_depth_loss_mult: float = 0.0
+    """Monocular depth consistency loss multiplier."""
+    patch_warp_loss_mult: float = 0.0
+    """Multi-view consistency warping loss multiplier."""
+    patch_size: int = 11
+    """Multi-view consistency warping loss patch size."""
+    patch_warp_angle_thres: float = 0.3
+    """Threshold for valid homograph of multi-view consistency warping loss"""
+    min_patch_variance: float = 0.01
+    """Threshold for minimal patch variance"""
+    topk: int = 4
+    """Number of minimal patch consistency selected for training"""
+    sensor_depth_truncation: float = 0.015
+    """Sensor depth trunction, default value is 0.015 which means 5cm with a rough scale value 0.3 (0.015 = 0.05 * 0.3)"""
+    sensor_depth_l1_loss_mult: float = 0.0
+    """Sensor depth L1 loss multiplier."""
+    sensor_depth_freespace_loss_mult: float = 0.0
+    """Sensor depth free space loss multiplier."""
+    sensor_depth_sdf_loss_mult: float = 0.0
+    """Sensor depth sdf loss multiplier."""
+    sparse_points_sdf_loss_mult: float = 0.0
+    """sparse point sdf loss multiplier"""
+    sdf_field: SDFFieldConfig = SDFFieldConfig()
+    """Config for SDF Field"""
+    background_model: Literal["grid", "mlp", "none"] = "mlp"
+    """background models"""
+    num_samples_outside: int = 32
+    """Number of samples outside the bounding sphere for backgound"""
+    periodic_tvl_mult: float = 0.0
+    """Total variational loss mutliplier"""
+    overwrite_near_far_plane: bool = False
+    """whether to use near and far collider from command line"""
+
+
+class SurfaceModel(Model):
+    """Base surface model
+
+    Args:
+        config: Base surface model configuration to instantiate model
+    """
+
+    config: SurfaceModelConfig
+
+    def populate_modules(self):
+        """Set the fields and modules."""
+        super().populate_modules()
+
+        self.scene_contraction = SceneContraction(order=float("inf"))
+
+        # Can we also use contraction for sdf?
+        # Fields
+        self.field = self.config.sdf_field.setup(
+            aabb=self.scene_box.aabb,
+            spatial_distortion=self.scene_contraction,
+            num_images=self.num_train_data,
+            use_average_appearance_embedding=self.config.use_average_appearance_embedding,
+        )
+
+        # Collider
+        if self.scene_box.collider_type == "near_far":
+            self.collider = NearFarCollider(near_plane=self.scene_box.near, far_plane=self.scene_box.far)
+        elif self.scene_box.collider_type == "box":
+            self.collider = AABBBoxCollider(self.scene_box, near_plane=self.scene_box.near)
+        # elif self.scene_box.collider_type == "sphere":
+        #     # TODO do we also use near if the ray don't intersect with the sphere
+        #     self.collider = SphereCollider(radius=self.scene_box.radius, soft_intersection=True)
+        else:
+            raise NotImplementedError
+
+        # command line near and far has highest priority
+        if self.config.overwrite_near_far_plane:
+            self.collider = NearFarCollider(near_plane=self.config.near_plane, far_plane=self.config.far_plane)
+
+        # background model
+        if self.config.background_model == "grid":
+            self.field_background = TCNNNerfactoField(
+                self.scene_box.aabb,
+                spatial_distortion=self.scene_contraction,
+                num_images=self.num_train_data,
+                use_average_appearance_embedding=self.config.use_average_appearance_embedding,
+            )
+        elif self.config.background_model == "mlp":
+            position_encoding = NeRFEncoding(
+                in_dim=3, num_frequencies=10, min_freq_exp=0.0, max_freq_exp=9.0, include_input=True
+            )
+            direction_encoding = NeRFEncoding(
+                in_dim=3, num_frequencies=4, min_freq_exp=0.0, max_freq_exp=3.0, include_input=True
+            )
+
+            self.field_background = NeRFField(
+                position_encoding=position_encoding,
+                direction_encoding=direction_encoding,
+                spatial_distortion=self.scene_contraction,
+            )
+        else:
+            # dummy background model
+            self.field_background = Parameter(torch.ones(1), requires_grad=False)
+
+        self.sampler_bg = LinearDisparitySampler(num_samples=self.config.num_samples_outside)
+
+        # renderers
+        background_color = (
+            get_color(self.config.background_color)
+            if self.config.background_color in set(["white", "black"])
+            else self.config.background_color
+        )
+        self.renderer_rgb = RGBRenderer(background_color=background_color)
+        self.renderer_accumulation = AccumulationRenderer()
+        self.renderer_depth = DepthRenderer(method="expected")
+        self.renderer_normal = SemanticRenderer()
+
+        # losses
+        self.rgb_loss = L1Loss()
+        self.eikonal_loss = MSELoss()
+        self.depth_loss = ScaleAndShiftInvariantLoss(alpha=0.5, scales=1)
+
+        # metrics
+        self.psnr = PeakSignalNoiseRatio(data_range=1.0)
+        self.ssim = structural_similarity_index_measure
+        self.lpips = LearnedPerceptualImagePatchSimilarity()
+
+    def get_param_groups(self) -> Dict[str, List[Parameter]]:
+        param_groups = {}
+        param_groups["fields"] = list(self.field.parameters())
+        if self.config.background_model != "none":
+            param_groups["field_background"] = list(self.field_background.parameters())
+        else:
+            param_groups["field_background"] = list(self.field_background)
+        return param_groups
+
+    @abstractmethod
+    def sample_and_forward_field(self, ray_bundle: RayBundle) -> Dict:
+        """_summary_
+
+        Args:
+            ray_bundle (RayBundle): _description_
+            return_samples (bool, optional): _description_. Defaults to False.
+        """
+
+    def get_outputs(self, ray_bundle: RayBundle) -> Dict:
+        # TODO make this configurable
+        # compute near and far from from sphere with radius 1.0
+        # ray_bundle = self.sphere_collider(ray_bundle)
+
+        samples_and_field_outputs = self.sample_and_forward_field(ray_bundle=ray_bundle)
+
+        # Shotscuts
+        field_outputs = samples_and_field_outputs["field_outputs"]
+        ray_samples = samples_and_field_outputs["ray_samples"]
+        weights = samples_and_field_outputs["weights"]
+        bg_transmittance = samples_and_field_outputs["bg_transmittance"]
+
+        rgb = self.renderer_rgb(rgb=field_outputs[FieldHeadNames.RGB], weights=weights)
+        depth = self.renderer_depth(weights=weights, ray_samples=ray_samples)
+        # the rendered depth is point-to-point distance and we should convert to depth
+        depth = depth / ray_bundle.directions_norm
+
+        # remove the rays that don't intersect with the surface
+        # hit = (field_outputs[FieldHeadNames.SDF] > 0.0).any(dim=1) & (field_outputs[FieldHeadNames.SDF] < 0).any(dim=1)
+        # depth[~hit] = 10000.0
+
+        normal = self.renderer_normal(semantics=field_outputs[FieldHeadNames.NORMAL], weights=weights)
+        accumulation = self.renderer_accumulation(weights=weights)
+
+        # background model
+        if self.config.background_model != "none":
+            # TODO remove hard-coded far value
+            # sample inversely from far to 1000 and points and forward the bg model
+            ray_bundle.nears = ray_bundle.fars
+            ray_bundle.fars = torch.ones_like(ray_bundle.fars) * self.config.far_plane_bg
+
+            ray_samples_bg = self.sampler_bg(ray_bundle)
+            # use the same background model for both density field and occupancy field
+            field_outputs_bg = self.field_background(ray_samples_bg)
+            weights_bg = ray_samples_bg.get_weights(field_outputs_bg[FieldHeadNames.DENSITY])
+
+            rgb_bg = self.renderer_rgb(rgb=field_outputs_bg[FieldHeadNames.RGB], weights=weights_bg)
+            depth_bg = self.renderer_depth(weights=weights_bg, ray_samples=ray_samples_bg)
+            accumulation_bg = self.renderer_accumulation(weights=weights_bg)
+
+            # merge background color to forgound color
+            rgb = rgb + bg_transmittance * rgb_bg
+
+            bg_outputs = {
+                "bg_rgb": rgb_bg,
+                "bg_accumulation": accumulation_bg,
+                "bg_depth": depth_bg,
+                "bg_weights": weights_bg,
+            }
+        else:
+            bg_outputs = {}
+
+        outputs = {
+            "rgb": rgb,
+            "accumulation": accumulation,
+            "depth": depth,
+            "normal": normal,
+            "weights": weights,
+            "directions_norm": ray_bundle.directions_norm,  # used to scale z_vals for free space and sdf loss
+        }
+        outputs.update(bg_outputs)
+
+        if self.training:
+            grad_points = field_outputs[FieldHeadNames.GRADIENT]
+            outputs.update({"eik_grad": grad_points})
+
+            # TODO volsdf use different point set for eikonal loss
+            # grad_points = self.field.gradient(eik_points)
+            # outputs.update({"eik_grad": grad_points})
+
+            outputs.update(samples_and_field_outputs)
+
+        # TODO how can we move it to neus_facto without out of memory
+        if "weights_list" in samples_and_field_outputs:
+            weights_list = samples_and_field_outputs["weights_list"]
+            ray_samples_list = samples_and_field_outputs["ray_samples_list"]
+
+            for i in range(len(weights_list) - 1):
+                outputs[f"prop_depth_{i}"] = self.renderer_depth(
+                    weights=weights_list[i], ray_samples=ray_samples_list[i]
+                )
+        # this is used only in viewer
+        outputs["normal_vis"] = (outputs["normal"] + 1.0) / 2.0
+        return outputs
+
+    def get_loss_dict(self, outputs, batch, metrics_dict=None) -> Dict:
+        loss_dict = {}
+        image = batch["image"].to(self.device)
+        loss_dict["rgb_loss"] = self.rgb_loss(image, outputs["rgb"])
+        if self.training:
+            # eikonal loss
+            grad_theta = outputs["eik_grad"]
+            loss_dict["eikonal_loss"] = ((grad_theta.norm(2, dim=-1) - 1) ** 2).mean() * self.config.eikonal_loss_mult
+
+            # foreground mask loss
+            if "fg_mask" in batch and self.config.fg_mask_loss_mult > 0.0:
+                fg_label = batch["fg_mask"].float().to(self.device)
+                weights_sum = outputs["weights"].sum(dim=1).clip(1e-3, 1.0 - 1e-3)
+                loss_dict["fg_mask_loss"] = (
+                    F.binary_cross_entropy(weights_sum, fg_label) * self.config.fg_mask_loss_mult
+                )
+
+            # monocular normal loss
+            if "normal" in batch and self.config.mono_normal_loss_mult > 0.0:
+                normal_gt = batch["normal"].to(self.device)
+                normal_pred = outputs["normal"]
+                loss_dict["normal_loss"] = (
+                    monosdf_normal_loss(normal_pred, normal_gt) * self.config.mono_normal_loss_mult
+                )
+
+            # monocular depth loss
+            if "depth" in batch and self.config.mono_depth_loss_mult > 0.0:
+                # TODO check it's true that's we sample from only a single image
+                # TODO only supervised pixel that hit the surface and remove hard-coded scaling for depth
+                depth_gt = batch["depth"].to(self.device)[..., None]
+                depth_pred = outputs["depth"]
+
+                mask = torch.ones_like(depth_gt).reshape(1, 32, -1).bool()
+                loss_dict["depth_loss"] = (
+                    self.depth_loss(depth_pred.reshape(1, 32, -1), (depth_gt * 50 + 0.5).reshape(1, 32, -1), mask)
+                    * self.config.mono_depth_loss_mult
+                )
+
+        return loss_dict
+
+    def get_metrics_dict(self, outputs, batch) -> Dict:
+        metrics_dict = {}
+        image = batch["image"].to(self.device)
+        metrics_dict["psnr"] = self.psnr(outputs["rgb"], image)
+        return metrics_dict
+
+    def get_image_metrics_and_images(
+        self, outputs: Dict[str, torch.Tensor], batch: Dict[str, torch.Tensor]
+    ) -> Tuple[Dict[str, float], Dict[str, torch.Tensor]]:
+
+        image = batch["image"].to(self.device)
+        rgb = outputs["rgb"]
+        acc = colormaps.apply_colormap(outputs["accumulation"])
+
+        normal = outputs["normal"]
+        # don't need to normalize here
+        # normal = torch.nn.functional.normalize(normal, p=2, dim=-1)
+        normal = (normal + 1.0) / 2.0
+
+        combined_rgb = torch.cat([image, rgb], dim=1)
+        combined_acc = torch.cat([acc], dim=1)
+        if "depth" in batch:
+            depth_gt = batch["depth"].to(self.device)
+            depth_pred = outputs["depth"]
+
+            # align to predicted depth and normalize
+            scale, shift = compute_scale_and_shift(
+                depth_pred[None, ..., 0], depth_gt[None, ...], depth_gt[None, ...] > 0.0
+            )
+            depth_pred = depth_pred * scale + shift
+
+            combined_depth = torch.cat([depth_gt[..., None], depth_pred], dim=1)
+            combined_depth = colormaps.apply_depth_colormap(combined_depth)
+        else:
+            depth = colormaps.apply_depth_colormap(
+                outputs["depth"],
+                accumulation=outputs["accumulation"],
+            )
+            combined_depth = torch.cat([depth], dim=1)
+
+        if "normal" in batch:
+            normal_gt = (batch["normal"].to(self.device) + 1.0) / 2.0
+            combined_normal = torch.cat([normal_gt, normal], dim=1)
+        else:
+            combined_normal = torch.cat([normal], dim=1)
+
+        images_dict = {
+            "img": combined_rgb,
+            "accumulation": combined_acc,
+            "depth": combined_depth,
+            "normal": combined_normal,
+        }
+
+        if "sensor_depth" in batch:
+            sensor_depth = batch["sensor_depth"]
+            depth_pred = outputs["depth"]
+
+            combined_sensor_depth = torch.cat([sensor_depth[..., None], depth_pred], dim=1)
+            combined_sensor_depth = colormaps.apply_depth_colormap(combined_sensor_depth)
+            images_dict["sensor_depth"] = combined_sensor_depth
+
+        # Switch images from [H, W, C] to [1, C, H, W] for metrics computations
+        image = torch.moveaxis(image, -1, 0)[None, ...]
+        rgb = torch.moveaxis(rgb, -1, 0)[None, ...]
+
+        psnr = self.psnr(image, rgb)
+        ssim = self.ssim(image, rgb)
+        lpips = self.lpips(image, rgb)
+
+        # all of these metrics will be logged as scalars
+        metrics_dict = {"psnr": float(psnr.item()), "ssim": float(ssim)}  # type: ignore
+        metrics_dict["lpips"] = float(lpips)
+
+        return metrics_dict, images_dict

--- a/nerfstudio/models/neus.py
+++ b/nerfstudio/models/neus.py
@@ -1,0 +1,120 @@
+# Copyright 2022 The Nerfstudio Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Implementation of NeuS.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Type
+
+from nerfstudio.cameras.rays import RayBundle
+from nerfstudio.engine.callbacks import (
+    TrainingCallback,
+    TrainingCallbackAttributes,
+    TrainingCallbackLocation,
+)
+from nerfstudio.field_components.field_heads import FieldHeadNames
+from nerfstudio.model_components.ray_samplers import NeuSSampler
+from nerfstudio.models.base_surface_model import SurfaceModel, SurfaceModelConfig
+
+
+@dataclass
+class NeuSModelConfig(SurfaceModelConfig):
+    """NeuS Model Config"""
+
+    _target: Type = field(default_factory=lambda: NeuSModel)
+    num_samples: int = 64
+    """Number of uniform samples"""
+    num_samples_importance: int = 64
+    """Number of importance samples"""
+    num_up_sample_steps: int = 4
+    """number of up sample step, 1 for simple coarse-to-fine sampling"""
+    base_variance: float = 64
+    """fixed base variance in NeuS sampler, the inv_s will be base * 2 ** iter during upsample"""
+    perturb: bool = True
+    """use to use perturb for the sampled points"""
+
+
+class NeuSModel(SurfaceModel):
+    """NeuS model
+
+    Args:
+        config: NeuS configuration to instantiate model
+    """
+
+    config: NeuSModelConfig
+
+    def populate_modules(self):
+        """Set the fields and modules."""
+        super().populate_modules()
+
+        self.sampler = NeuSSampler(
+            num_samples=self.config.num_samples,
+            num_samples_importance=self.config.num_samples_importance,
+            num_samples_outside=self.config.num_samples_outside,
+            num_upsample_steps=self.config.num_up_sample_steps,
+            base_variance=self.config.base_variance,
+        )
+
+        self.anneal_end = 50000
+
+    def get_training_callbacks(
+        self, training_callback_attributes: TrainingCallbackAttributes
+    ) -> List[TrainingCallback]:
+        callbacks = []
+        # anneal for cos in NeuS
+        if self.anneal_end > 0:
+
+            def set_anneal(step):
+                anneal = min([1.0, step / self.anneal_end])
+                self.field.set_cos_anneal_ratio(anneal)
+
+            callbacks.append(
+                TrainingCallback(
+                    where_to_run=[TrainingCallbackLocation.BEFORE_TRAIN_ITERATION],
+                    update_every_num_iters=1,
+                    func=set_anneal,
+                )
+            )
+
+        return callbacks
+
+    def sample_and_forward_field(self, ray_bundle: RayBundle) -> Dict:
+        ray_samples = self.sampler(ray_bundle, sdf_fn=self.field.get_sdf)
+        # save_points("a.ply", ray_samples.frustums.get_start_positions().reshape(-1, 3).detach().cpu().numpy())
+        field_outputs = self.field(ray_samples, return_alphas=True)
+        weights, transmittance = ray_samples.get_weights_and_transmittance_from_alphas(
+            field_outputs[FieldHeadNames.ALPHA]
+        )
+        bg_transmittance = transmittance[:, -1, :]
+
+        samples_and_field_outputs = {
+            "ray_samples": ray_samples,
+            "field_outputs": field_outputs,
+            "weights": weights,
+            "bg_transmittance": bg_transmittance,
+        }
+        return samples_and_field_outputs
+
+    def get_metrics_dict(self, outputs, batch) -> Dict:
+        metrics_dict = super().get_metrics_dict(outputs, batch)
+        if self.training:
+            # training statics
+            metrics_dict["s_val"] = self.field.deviation_network.get_variance().item()
+            metrics_dict["inv_s"] = 1.0 / self.field.deviation_network.get_variance().item()
+
+        return metrics_dict

--- a/nerfstudio/utils/marching_cubes.py
+++ b/nerfstudio/utils/marching_cubes.py
@@ -1,0 +1,214 @@
+from pathlib import Path
+
+import numpy as np
+import pymeshlab
+import torch
+import trimesh
+from skimage import measure
+
+avg_pool_3d = torch.nn.AvgPool3d(2, stride=2)
+upsample = torch.nn.Upsample(scale_factor=2, mode="nearest")
+
+
+@torch.no_grad()
+def get_surface_sliding(
+    sdf,
+    resolution=512,
+    bounding_box_min=(-1.0, -1.0, -1.0),
+    bounding_box_max=(1.0, 1.0, 1.0),
+    return_mesh=False,
+    level=0,
+    coarse_mask=None,
+    output_path: Path = Path("test.ply"),
+    simplify_mesh=True,
+):
+    assert resolution % 512 == 0
+    if coarse_mask is not None:
+        # we need to permute here as pytorch's grid_sample use (z, y, x)
+        coarse_mask = coarse_mask.permute(2, 1, 0)[None, None].cuda().float()
+
+    resN = resolution
+    cropN = 512
+    level = 0
+    N = resN // cropN
+
+    grid_min = bounding_box_min
+    grid_max = bounding_box_max
+    xs = np.linspace(grid_min[0], grid_max[0], N + 1)
+    ys = np.linspace(grid_min[1], grid_max[1], N + 1)
+    zs = np.linspace(grid_min[2], grid_max[2], N + 1)
+
+    # print(xs)
+    # print(ys)
+    # print(zs)
+    meshes = []
+    for i in range(N):
+        for j in range(N):
+            for k in range(N):
+                # print(i, j, k)
+                x_min, x_max = xs[i], xs[i + 1]
+                y_min, y_max = ys[j], ys[j + 1]
+                z_min, z_max = zs[k], zs[k + 1]
+
+                x = np.linspace(x_min, x_max, cropN)
+                y = np.linspace(y_min, y_max, cropN)
+                z = np.linspace(z_min, z_max, cropN)
+
+                xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
+                points = torch.tensor(np.vstack([xx.ravel(), yy.ravel(), zz.ravel()]).T, dtype=torch.float).cuda()
+
+                def evaluate(points):
+                    z = []
+                    for _, pnts in enumerate(torch.split(points, 100000, dim=0)):
+                        z.append(sdf(pnts))
+                    z = torch.cat(z, axis=0)
+                    return z
+
+                # construct point pyramids
+                points = points.reshape(cropN, cropN, cropN, 3).permute(3, 0, 1, 2)
+                if coarse_mask is not None:
+                    # breakpoint()
+                    points_tmp = points.permute(1, 2, 3, 0)[None].cuda()
+                    current_mask = torch.nn.functional.grid_sample(coarse_mask, points_tmp)
+                    current_mask = (current_mask > 0.0).cpu().numpy()[0, 0]
+                else:
+                    current_mask = None
+
+                points_pyramid = [points]
+                for _ in range(3):
+                    points = avg_pool_3d(points[None])[0]
+                    points_pyramid.append(points)
+                points_pyramid = points_pyramid[::-1]
+
+                # evalute pyramid with mask
+                mask = None
+                threshold = 2 * (x_max - x_min) / cropN * 8
+                for pid, pts in enumerate(points_pyramid):
+                    coarse_N = pts.shape[-1]
+                    pts = pts.reshape(3, -1).permute(1, 0).contiguous()
+
+                    if mask is None:
+                        # only evaluate
+                        if coarse_mask is not None:
+                            pts_sdf = torch.ones_like(pts[:, 1])
+                            valid_mask = (
+                                torch.nn.functional.grid_sample(coarse_mask, pts[None, None, None])[0, 0, 0, 0] > 0
+                            )
+                            if valid_mask.any():
+                                pts_sdf[valid_mask] = evaluate(pts[valid_mask].contiguous())
+                        else:
+                            pts_sdf = evaluate(pts)
+                    else:
+                        mask = mask.reshape(-1)
+                        pts_to_eval = pts[mask]
+
+                        if pts_to_eval.shape[0] > 0:
+                            pts_sdf_eval = evaluate(pts_to_eval.contiguous())
+                            pts_sdf[mask] = pts_sdf_eval
+                        # print("ratio", pts_to_eval.shape[0] / pts.shape[0])
+
+                    if pid < 3:
+                        # update mask
+                        mask = torch.abs(pts_sdf) < threshold
+                        mask = mask.reshape(coarse_N, coarse_N, coarse_N)[None, None]
+                        mask = upsample(mask.float()).bool()
+
+                        pts_sdf = pts_sdf.reshape(coarse_N, coarse_N, coarse_N)[None, None]
+                        pts_sdf = upsample(pts_sdf)
+                        pts_sdf = pts_sdf.reshape(-1)
+
+                    threshold /= 2.0
+
+                z = pts_sdf.detach().cpu().numpy()
+
+                # skip if no surface found
+                if current_mask is not None:
+                    valid_z = z.reshape(cropN, cropN, cropN)[current_mask]
+                    if valid_z.shape[0] <= 0 or (np.min(valid_z) > level or np.max(valid_z) < level):
+                        continue
+
+                if not (np.min(z) > level or np.max(z) < level):
+                    z = z.astype(np.float32)
+                    verts, faces, normals, _ = measure.marching_cubes(
+                        volume=z.reshape(cropN, cropN, cropN),  # .transpose([1, 0, 2]),
+                        level=level,
+                        spacing=(
+                            (x_max - x_min) / (cropN - 1),
+                            (y_max - y_min) / (cropN - 1),
+                            (z_max - z_min) / (cropN - 1),
+                        ),
+                        mask=current_mask,
+                    )
+                    # print(np.array([x_min, y_min, z_min]))
+                    # print(verts.min(), verts.max())
+                    verts = verts + np.array([x_min, y_min, z_min])
+                    # print(verts.min(), verts.max())
+
+                    meshcrop = trimesh.Trimesh(verts, faces, normals)
+                    # meshcrop.export(f"{i}_{j}_{k}.ply")
+                    meshes.append(meshcrop)
+
+    combined = trimesh.util.concatenate(meshes)
+
+    if return_mesh:
+        return combined
+    else:
+        filename = str(output_path)
+        filename_simplify = str(output_path).replace(".ply", "-simplify.ply")
+
+        combined.export(filename)
+        if simplify_mesh:
+            ms = pymeshlab.MeshSet()
+            ms.load_new_mesh(filename)
+
+            print("simply mesh")
+            ms.meshing_decimation_quadric_edge_collapse(targetfacenum=2000000)
+            ms.save_current_mesh(filename_simplify, save_face_color=False)
+
+
+@torch.no_grad()
+def get_surface_occupancy(
+    occupancy_fn,
+    resolution=512,
+    bounding_box_min=(-1.0, -1.0, -1.0),
+    bounding_box_max=(1.0, 1.0, 1.0),
+    return_mesh=False,
+    level=0.5,
+    device=None,
+    output_path: Path = Path("test.ply"),
+):
+    grid_min = bounding_box_min
+    grid_max = bounding_box_max
+    N = resolution
+    xs = np.linspace(grid_min[0], grid_max[0], N)
+    ys = np.linspace(grid_min[1], grid_max[1], N)
+    zs = np.linspace(grid_min[2], grid_max[2], N)
+
+    xx, yy, zz = np.meshgrid(xs, ys, zs, indexing="ij")
+    points = torch.tensor(np.vstack([xx.ravel(), yy.ravel(), zz.ravel()]).T, dtype=torch.float).to(device=device)
+
+    def evaluate(points):
+        z = []
+        for _, pnts in enumerate(torch.split(points, 100000, dim=0)):
+            z.append(occupancy_fn(pnts.contiguous()).contiguous())
+        z = torch.cat(z, axis=0)
+        return z
+
+    z = evaluate(points).detach().cpu().numpy()
+
+    if not (np.min(z) > level or np.max(z) < level):
+        verts, faces, normals, _ = measure.marching_cubes(
+            volume=z.reshape(resolution, resolution, resolution),
+            level=level,
+            spacing=(
+                (grid_max[0] - grid_min[0]) / (N - 1),
+                (grid_max[1] - grid_min[1]) / (N - 1),
+                (grid_max[2] - grid_min[2]) / (N - 1),
+            ),
+        )
+        verts = verts + np.array(grid_min)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        meshexport = trimesh.Trimesh(verts, faces, normals)
+        meshexport.export(str(output_path))
+    else:
+        print("=================================================no surface skip")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dependencies = [
     "u-msgpack-python>=2.4.1",
     "nuscenes-devkit>=1.1.1",
     "wandb>=0.13.3",
-    "xatlas"
+    "xatlas", 
+    "trimesh"
 ]
 
 [project.urls]

--- a/scripts/extract_mesh.py
+++ b/scripts/extract_mesh.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""
+Extract mesh from surface models using marching cubes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import torch
+import tyro
+from rich.console import Console
+
+from nerfstudio.utils.eval_utils import eval_setup
+from nerfstudio.utils.marching_cubes import get_surface_occupancy, get_surface_sliding
+
+CONSOLE = Console(width=120)
+
+
+@dataclass
+class ExtractMesh:
+    """Load a checkpoint, run marching cubes, extract mesh, and save it to a ply file."""
+
+    # Path to config YAML file.
+    load_config: Path
+    # Marching cube resolution.
+    resolution: int = 1024
+    # Name of the output file.
+    output_path: Path = Path("output.ply")
+    # Whether to simplify the mesh.
+    simplify_mesh: bool = False
+    # extract the mesh using occupancy field (unisurf) or SDF, default sdf
+    is_occupancy: bool = False
+    """Minimum of the bounding box."""
+    bounding_box_min: Tuple[float, float, float] = (-1.0, -1.0, -1.0)
+    """Maximum of the bounding box."""
+    bounding_box_max: Tuple[float, float, float] = (1.0, 1.0, 1.0)
+
+    def main(self) -> None:
+        """Main function."""
+        assert str(self.output_path)[-4:] == ".ply"
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        _, pipeline, _ = eval_setup(self.load_config)
+
+        CONSOLE.print("Extract mesh with marching cubes and may take a while")
+
+        if self.is_occupancy:
+            # for unisurf
+            get_surface_occupancy(
+                occupancy_fn=lambda x: torch.sigmoid(
+                    10 * pipeline.model.field.forward_geonetwork(x)[:, 0].contiguous()
+                ),
+                resolution=self.resolution,
+                bounding_box_min=self.bounding_box_min,
+                bounding_box_max=self.bounding_box_max,
+                level=0.5,
+                device=pipeline.model.device,
+                output_path=self.output_path,
+            )
+        else:
+            assert self.resolution % 512 == 0
+            # for sdf we can multi-scale extraction.
+            get_surface_sliding(
+                sdf=lambda x: pipeline.model.field.forward_geonetwork(x)[:, 0].contiguous(),
+                resolution=self.resolution,
+                bounding_box_min=self.bounding_box_min,
+                bounding_box_max=self.bounding_box_max,
+                coarse_mask=pipeline.model.scene_box.coarse_binary_gird,
+                output_path=self.output_path,
+                simplify_mesh=self.simplify_mesh,
+            )
+
+
+def entrypoint():
+    """Entrypoint for use with pyproject scripts."""
+    tyro.extras.set_accent_color("bright_yellow")
+    tyro.cli(tyro.conf.FlagConversionOff[ExtractMesh]).main()
+
+
+if __name__ == "__main__":
+    entrypoint()
+
+# For sphinx docs
+get_parser_fn = lambda: tyro.extras.get_parser(ExtractMesh)  # noqa


### PR DESCRIPTION
Adding in NeuS surface rendering implementation from [sdfstudio](https://github.com/autonomousvision/sdfstudio). Seems to be working with their provided Replica dataset.
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/25287427/216436361-592bd670-2efd-417b-9d26-347d243fad32.png">
I plan on adding the nerfstudio -> sdfstudio parser script as well. This method is too slow to use with the renderer so I'll also be planning on brining in the NeuS-Facto method. I pretty much followed what they implemented very closely, lmk if things make sense or if you'd like me to change implementation details. 

I also need to add in the mesh export to extract .ply file from model