### PR TITLE
Set min render value for viewer

### DIFF
--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -826,7 +826,7 @@ class ViewerState:
         else:
             image_height = (num_vis_rays / aspect_ratio) ** 0.5
             image_height = int(round(image_height, -1))
-            image_height = min(self.max_resolution, image_height)
+            image_height = max(min(self.max_resolution, image_height), 30)
         image_width = int(image_height * aspect_ratio)
         if image_width > self.max_resolution:
             image_width = self.max_resolution


### PR DESCRIPTION
Sometime the viewer would get into a weird state at the beginning of training if the initial render resolution is too low. This causes the GPU to be inefficient which then leads to a bad estimate of rendering speed. This in turn causes it to render in lower resolution leading to a feedback loop. 