### PR TITLE
double-quote filenames in process-data commands so that on Windows, paths with spaces don't fail

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -79,7 +79,7 @@ def get_num_frames_in_video(video: Path) -> int:
         The number of frames in a video.
     """
     cmd = f"ffprobe -v error -select_streams v:0 -count_packets \
-            -show_entries stream=nb_read_packets -of csv=p=0 {video}"
+            -show_entries stream=nb_read_packets -of csv=p=0 \"{video}\""
     output = run_command(cmd)
     assert output is not None
     output = output.strip(" ,\t\n\r")
@@ -114,7 +114,7 @@ def convert_video_to_images(
         print("Number of frames in video:", num_frames)
 
         out_filename = image_dir / "frame_%05d.png"
-        ffmpeg_cmd = f"ffmpeg -i {video_path}"
+        ffmpeg_cmd = f"ffmpeg -i \"{video_path}\""
         spacing = num_frames // num_frames_target
 
         if spacing > 1:
@@ -168,7 +168,7 @@ def copy_images_list(
         file_type = image_paths[0].suffix
         filename = f"frame_%05d{file_type}"
         crop = f"crop=iw-{crop_border_pixels*2}:ih-{crop_border_pixels*2}"
-        ffmpeg_cmd = f"ffmpeg -y -noautorotate -i {image_dir / filename} -q:v 2 -vf {crop} {image_dir / filename}"
+        ffmpeg_cmd = f"ffmpeg -y -noautorotate -i \"{image_dir / filename}\" -q:v 2 -vf {crop} \"{image_dir / filename}\""
         run_command(ffmpeg_cmd, verbose=verbose)
 
     num_frames = len(image_paths)
@@ -210,9 +210,9 @@ def copy_and_upscale_polycam_depth_maps_list(
         for idx, depth_map in enumerate(polycam_depth_image_filenames):
             destination = depth_dir / f"frame_{idx + 1:05d}{depth_map.suffix}"
             ffmpeg_cmd = [
-                f"ffmpeg -y -i {depth_map} ",
+                f"ffmpeg -y -i \"{depth_map}\" ",
                 f"-q:v 2 -vf scale=iw*{upscale_factor}:ih*{upscale_factor}:flags=neighbor ",
-                f"{destination}",
+                f"\"{destination}\"",
             ]
             ffmpeg_cmd = " ".join(ffmpeg_cmd)
             run_command(ffmpeg_cmd, verbose=verbose)
@@ -222,7 +222,7 @@ def copy_and_upscale_polycam_depth_maps_list(
         file_type = depth_dir.glob("frame_*").__next__().suffix
         filename = f"frame_%05d{file_type}"
         crop = f"crop=iw-{crop_border_pixels * 2}:ih-{crop_border_pixels * 2}"
-        ffmpeg_cmd = f"ffmpeg -y -i {depth_dir / filename} -q:v 2 -vf {crop} {depth_dir / filename}"
+        ffmpeg_cmd = f"ffmpeg -y -i \"{depth_dir / filename}\" -q:v 2 -vf {crop} \"{depth_dir / filename}\""
         run_command(ffmpeg_cmd, verbose=verbose)
 
     CONSOLE.log("[bold green]:tada: Done upscaling depth maps.")
@@ -282,9 +282,9 @@ def downscale_images(image_dir: Path, num_downscales: int, folder_name: str = "i
             for f in files:
                 filename = f.name
                 ffmpeg_cmd = [
-                    f"ffmpeg -y -noautorotate -i {image_dir / filename} ",
+                    f"ffmpeg -y -noautorotate -i \"{image_dir / filename}\" ",
                     f"-q:v 2 -vf scale=iw/{downscale_factor}:ih/{downscale_factor} ",
-                    f"{downscale_dir / filename}",
+                    f"\"{downscale_dir / filename}\"",
                 ]
                 ffmpeg_cmd = " ".join(ffmpeg_cmd)
                 run_command(ffmpeg_cmd, verbose=verbose)

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -78,8 +78,8 @@ def get_num_frames_in_video(video: Path) -> int:
     Returns:
         The number of frames in a video.
     """
-    cmd = f"ffprobe -v error -select_streams v:0 -count_packets \
-            -show_entries stream=nb_read_packets -of csv=p=0 \"{video}\""
+    cmd = f'ffprobe -v error -select_streams v:0 -count_packets \
+            -show_entries stream=nb_read_packets -of csv=p=0 "{video}"'
     output = run_command(cmd)
     assert output is not None
     output = output.strip(" ,\t\n\r")
@@ -114,7 +114,7 @@ def convert_video_to_images(
         print("Number of frames in video:", num_frames)
 
         out_filename = image_dir / "frame_%05d.png"
-        ffmpeg_cmd = f"ffmpeg -i \"{video_path}\""
+        ffmpeg_cmd = f'ffmpeg -i "{video_path}"'
         spacing = num_frames // num_frames_target
 
         if spacing > 1:
@@ -168,7 +168,7 @@ def copy_images_list(
         file_type = image_paths[0].suffix
         filename = f"frame_%05d{file_type}"
         crop = f"crop=iw-{crop_border_pixels*2}:ih-{crop_border_pixels*2}"
-        ffmpeg_cmd = f"ffmpeg -y -noautorotate -i \"{image_dir / filename}\" -q:v 2 -vf {crop} \"{image_dir / filename}\""
+        ffmpeg_cmd = f'ffmpeg -y -noautorotate -i "{image_dir / filename}" -q:v 2 -vf {crop} "{image_dir / filename}"'
         run_command(ffmpeg_cmd, verbose=verbose)
 
     num_frames = len(image_paths)
@@ -210,9 +210,9 @@ def copy_and_upscale_polycam_depth_maps_list(
         for idx, depth_map in enumerate(polycam_depth_image_filenames):
             destination = depth_dir / f"frame_{idx + 1:05d}{depth_map.suffix}"
             ffmpeg_cmd = [
-                f"ffmpeg -y -i \"{depth_map}\" ",
+                f'ffmpeg -y -i "{depth_map}" ',
                 f"-q:v 2 -vf scale=iw*{upscale_factor}:ih*{upscale_factor}:flags=neighbor ",
-                f"\"{destination}\"",
+                f'"{destination}"',
             ]
             ffmpeg_cmd = " ".join(ffmpeg_cmd)
             run_command(ffmpeg_cmd, verbose=verbose)
@@ -222,7 +222,7 @@ def copy_and_upscale_polycam_depth_maps_list(
         file_type = depth_dir.glob("frame_*").__next__().suffix
         filename = f"frame_%05d{file_type}"
         crop = f"crop=iw-{crop_border_pixels * 2}:ih-{crop_border_pixels * 2}"
-        ffmpeg_cmd = f"ffmpeg -y -i \"{depth_dir / filename}\" -q:v 2 -vf {crop} \"{depth_dir / filename}\""
+        ffmpeg_cmd = f'ffmpeg -y -i "{depth_dir / filename}" -q:v 2 -vf {crop} "{depth_dir / filename}"'
         run_command(ffmpeg_cmd, verbose=verbose)
 
     CONSOLE.log("[bold green]:tada: Done upscaling depth maps.")
@@ -282,9 +282,9 @@ def downscale_images(image_dir: Path, num_downscales: int, folder_name: str = "i
             for f in files:
                 filename = f.name
                 ffmpeg_cmd = [
-                    f"ffmpeg -y -noautorotate -i \"{image_dir / filename}\" ",
+                    f'ffmpeg -y -noautorotate -i "{image_dir / filename}" ',
                     f"-q:v 2 -vf scale=iw/{downscale_factor}:ih/{downscale_factor} ",
-                    f"\"{downscale_dir / filename}\"",
+                    f'"{downscale_dir / filename}"',
                 ]
                 ffmpeg_cmd = " ".join(ffmpeg_cmd)
                 run_command(ffmpeg_cmd, verbose=verbose)

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -350,7 +350,7 @@ class ProcessInsta360:
         if not filename_back.exists():
             raise FileNotFoundError(f"Could not find {filename_back}")
 
-        ffprobe_cmd = f"ffprobe -v quiet -print_format json -show_streams -select_streams v:0 {filename_back}"
+        ffprobe_cmd = f"ffprobe -v quiet -print_format json -show_streams -select_streams v:0 \"{filename_back}\""
 
         ffprobe_output = process_data_utils.run_command(ffprobe_cmd)
 

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -350,7 +350,7 @@ class ProcessInsta360:
         if not filename_back.exists():
             raise FileNotFoundError(f"Could not find {filename_back}")
 
-        ffprobe_cmd = f"ffprobe -v quiet -print_format json -show_streams -select_streams v:0 \"{filename_back}\""
+        ffprobe_cmd = f'ffprobe -v quiet -print_format json -show_streams -select_streams v:0 "{filename_back}"'
 
         ffprobe_output = process_data_utils.run_command(ffprobe_cmd)
 


### PR DESCRIPTION
Fixes #1346 .
Confirmed on Windows 10 for `ns-process-data` `images` and `video` with spaces in filename.

Unable to test all processing options though.