### PR TITLE
Handle uncalibrated Metashape sensor

### DIFF
--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -58,10 +58,14 @@ def metashape_to_json(  # pylint: disable=too-many-statements
     sensors = chunk.find("sensors")
 
     # TODO Add support for per-frame intrinsics
-    if sensors is None or len(sensors) != 1:
+    if sensors is None:
+        raise ValueError("No sensors found")
+
+    calibrated_sensors = [sensor for sensor in sensors if sensor.find("calibration")]
+    if len(calibrated_sensors) != 1:
         raise ValueError("Only one sensor is supported for now")
 
-    sensor = sensors.find("sensor")
+    sensor = calibrated_sensors[0]
 
     data = {}
 
@@ -98,6 +102,14 @@ def metashape_to_json(  # pylint: disable=too-many-statements
         if camera_label not in image_filename_map:
             continue
         frame["file_path"] = image_filename_map[camera_label].as_posix()
+
+        if camera.get("sensor_id") != sensor.get("id"):
+            # this should only happen when we have a sensor that didn't had calibration
+            if verbose:
+                CONSOLE.print(f"Missing sensor calibration for {camera.get('label')}, Skipping")
+            num_skipped += 1
+            continue
+
         if camera.find("transform") is None:
             if verbose:
                 CONSOLE.print(f"Missing transforms data for {camera.get('label')}, Skipping")


### PR DESCRIPTION
This fix allows loading Metashape XML files which
contain an additional uncalibrated sensor.

Metashape XML format keeps unmatched images but
assignes a dummy sensor to them. The sensor has
no calibration data.

related to https://github.com/nerfstudio-project/nerfstudio/issues/1224