### PR TITLE
Allow methods configs to be discovered from external packages.

### DIFF
--- a/docs/developer_guides/config.md
+++ b/docs/developer_guides/config.md
@@ -118,3 +118,27 @@ Often times, you just want to play with the parameters of an existing model with
   # NOTE: the dataparser and associated configurations go at the end of the command
   ns-train {METHOD_NAME} --vis viewer {DATA_PARSER} --scale-factor 0.5
   ```
+  
+### Extending Nerfstudio with custom methods
+In order to extend the Nerfstudio and register your own methods, you can package your code as a python package
+and register it with Nerfstudio as a `nerfstudio.method_configs` entrypoint in the `pyproject.toml` file.
+The Nerfstudio will automatically look for all registered methods and will register them to be used
+by method such as `ns-train`.
+
+Here is an example:
+```python
+"""my_package/my_config.py"""
+
+MyConfig = TrainerConfig(
+    method_name="my-method",
+    ...
+)
+
+"""pyproject.toml"""
+[project]
+name = "my_package"
+...
+
+[project.entry-points.'nerfstudio.method_configs']
+my-method = 'my_package.my_config:MyConfig'
+```

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -57,6 +57,7 @@ from nerfstudio.models.tensorf import TensoRFModelConfig
 from nerfstudio.models.vanilla_nerf import NeRFModel, VanillaModelConfig
 from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
 from nerfstudio.pipelines.dynamic_batch import DynamicBatchPipelineConfig
+from nerfstudio.plugins.registry import discover_methods
 
 method_configs: Dict[str, TrainerConfig] = {}
 descriptions = {
@@ -386,6 +387,10 @@ method_configs["nerfplayer-ngp"] = TrainerConfig(
     viewer=ViewerConfig(num_rays_per_chunk=64000),
     vis="viewer",
 )
+
+external_methods, external_descriptions = discover_methods()
+method_configs.update(external_methods)
+descriptions.update(external_descriptions)
 
 AnnotatedBaseConfigUnion = tyro.conf.SuppressFixed[  # Don't show unparseable (fixed) arguments in helptext.
     tyro.conf.FlagConversionOff[

--- a/nerfstudio/plugins/registry.py
+++ b/nerfstudio/plugins/registry.py
@@ -1,0 +1,32 @@
+"""
+Module that keeps all registered plugins and allows for plugin discovery.
+"""
+
+import sys
+
+from rich.progress import Console
+
+from nerfstudio.engine.trainer import TrainerConfig
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+CONSOLE = Console(width=120)
+
+
+def discover_methods():
+    """
+    Discovers all methods registered using the `nerfstudio.method_configs` entrypoint.
+    """
+    methods = {}
+    descriptions = {}
+    discovered_entry_points = entry_points(group="nerfstudio.method_configs")
+    for name in discovered_entry_points.names:
+        method = discovered_entry_points[name].load()
+        if not isinstance(method, TrainerConfig):
+            CONSOLE.print("[bold yellow]Warning: Could not entry point {n} as it is not an instance of TrainerConfig")
+            continue
+        methods[method.method_name] = method
+        descriptions[method.method_name] = getattr(method, "description", method.method_name)
+    return methods, descriptions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "functorch==0.2.1",
     "h5py>=2.9.0",
     "imageio>=2.21.1",
+    'importlib-metadata>=6.0.0; python_version < "3.10"',
     "ipywidgets>=7.6",
     "jupyterlab>=3.3.4",
     "matplotlib>=3.5.3",

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -1,0 +1,44 @@
+import sys
+
+import nerfstudio.plugins.registry as registry
+from nerfstudio.engine.trainer import TrainerConfig
+from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
+
+if sys.version_info < (3, 10):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
+
+
+TestConfig = TrainerConfig(
+    method_name="test-method",
+    pipeline=VanillaPipelineConfig(),
+    optimizers={},
+)
+
+
+def test_discover_methods():
+    """Tests if a custom method gets properly registered using the discover_methods method"""
+    entry_points_backup = registry.entry_points
+
+    def entry_points(group=None):
+        return importlib_metadata.EntryPoints(
+            [
+                importlib_metadata.EntryPoint(
+                    name="test", value="test_registry:TestConfig", group="nerfstudio.method_configs"
+                )
+            ]
+        ).select(group=group)
+
+    try:
+        # Mock importlib entry_points
+        registry.entry_points = entry_points
+
+        # Discover plugins
+        methods, _ = registry.discover_methods()
+        assert "test-method" in methods
+        config = methods["test-method"]
+        assert isinstance(config, TrainerConfig)
+    finally:
+        # Revert mock
+        registry.entry_points = entry_points_backup


### PR DESCRIPTION
This PR implements a discovery mechanism for TrainerConfigs. The main objective is to allow other researchers to publish their own methods which use Nerfstudio without them needing to copy the source code. They will publish only the method implementation with TrainerConfig, and it will be automatically discovered and registered by Nerfstudio.

The implementation uses the package metadata to find the TrainerConfigs. In particular, it will look for the "nerfstudio.method_configs" entry point.

I believe this will improve the collaboration as contributors no longer need to clone the entire repository if they only want to try a small change. Also, this way, Nerfstudio's authors can wait if an implementation works well before porting it into the Nerfstudio codebase.