### PR TITLE
add viewer.local config property when viewing local instance

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -153,3 +153,5 @@ class ViewerConfig(PrintableConfig):
     connecting to the viewer"""
     codec: Literal["H264", "VP8"] = "VP8"
     """Video codec that viewer will use."""
+    local: bool = False
+    """If running local server instance, avoid using relays to communicate with the viewer."""

--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -669,28 +669,31 @@ class ViewerState:
         # returns the description to for WebRTC to the specific websocket connection
         offer = RTCSessionDescription(data["sdp"], data["type"])
 
-        if self.config.skip_openrelay:
-            ice_servers = [
-                RTCIceServer(urls="stun:stun.l.google.com:19302"),
-            ]
+        if self.config.local:
+            pc = RTCPeerConnection()
         else:
-            ice_servers = [
-                RTCIceServer(urls="stun:stun.l.google.com:19302"),
-                RTCIceServer(urls="stun:openrelay.metered.ca:80"),
-                RTCIceServer(
-                    urls="turn:openrelay.metered.ca:80", username="openrelayproject", credential="openrelayproject"
-                ),
-                RTCIceServer(
-                    urls="turn:openrelay.metered.ca:443", username="openrelayproject", credential="openrelayproject"
-                ),
-                RTCIceServer(
-                    urls="turn:openrelay.metered.ca:443?transport=tcp",
-                    username="openrelayproject",
-                    credential="openrelayproject",
-                ),
-            ]
+            if self.config.skip_openrelay:
+                ice_servers = [
+                    RTCIceServer(urls="stun:stun.l.google.com:19302"),
+                ]
+            else:
+                ice_servers = [
+                    RTCIceServer(urls="stun:stun.l.google.com:19302"),
+                    RTCIceServer(urls="stun:openrelay.metered.ca:80"),
+                    RTCIceServer(
+                        urls="turn:openrelay.metered.ca:80", username="openrelayproject", credential="openrelayproject"
+                    ),
+                    RTCIceServer(
+                        urls="turn:openrelay.metered.ca:443", username="openrelayproject", credential="openrelayproject"
+                    ),
+                    RTCIceServer(
+                        urls="turn:openrelay.metered.ca:443?transport=tcp",
+                        username="openrelayproject",
+                        credential="openrelayproject",
+                    ),
+                ]
 
-        pc = RTCPeerConnection(configuration=RTCConfiguration(iceServers=ice_servers))
+            pc = RTCPeerConnection(configuration=RTCConfiguration(iceServers=ice_servers))
         self.pcs.add(pc)
 
         video = SingleFrameStreamTrack()


### PR DESCRIPTION
If running local server instance, avoid using relays to communicate with the viewer.