### PR TITLE
Add support for sparse depth maps

### DIFF
--- a/nerfstudio/models/depth_nerfacto.py
+++ b/nerfstudio/models/depth_nerfacto.py
@@ -24,7 +24,7 @@ from typing import Dict, Tuple, Type
 import torch
 
 from nerfstudio.cameras.rays import RayBundle
-from nerfstudio.model_components.losses import DephtLossType, depth_loss
+from nerfstudio.model_components.losses import DepthLossType, depth_loss
 from nerfstudio.models.nerfacto import NerfactoModel, NerfactoModelConfig
 from nerfstudio.utils import colormaps
 
@@ -46,7 +46,7 @@ class DepthNerfactoModelConfig(NerfactoModelConfig):
     """Starting uncertainty around depth values in meters (defaults to 0.2m)."""
     sigma_decay_rate: float = 0.99985
     """Rate of exponential decay."""
-    depth_loss_type: DephtLossType = DephtLossType.DS_NERF
+    depth_loss_type: DepthLossType = DepthLossType.DS_NERF
     """Depth loss type."""
 
 
@@ -118,7 +118,10 @@ class DepthNerfactoModel(NerfactoModel):
             far_plane=torch.max(ground_truth_depth),
         )
         images["depth"] = torch.cat([ground_truth_depth_colormap, predicted_depth_colormap], dim=1)
-        metrics["depth_mse"] = torch.nn.functional.mse_loss(outputs["depth"], ground_truth_depth)
+        depth_mask = ground_truth_depth > 0
+        metrics["depth_mse"] = torch.nn.functional.mse_loss(
+            outputs["depth"][depth_mask], ground_truth_depth[depth_mask]
+        )
         return metrics, images
 
     def _get_sigma(self):


### PR DESCRIPTION
# Background

In nerfstudio, the losses for depth don't support sparse depth maps.  

# Description

1. Modified `ds_nerf_depth_loss`, `urban_radiance_field_depth_loss` in `losses.py`.

2. Modified the way of computing `depth_mse` in eval. 

3. Fixed typo `Depht` -> `Depth`.

# Verification
Train `depth-nerfacto` with the `Replica` Dataset using only two views with sparse depth supervision (randomly masking out 90% of the depth map). left: groundtruth sparse depth map. right: predicted dense depth map. Results below are generated using `ds_nerf_depth_loss`. 

![Screenshot 2023-02-07 at 2 05 44 PM](https://user-images.githubusercontent.com/107962411/217377380-6c098669-5027-4e10-b73f-178bc4eee04c.png)

![Screenshot 2023-02-07 at 2 06 34 PM](https://user-images.githubusercontent.com/107962411/217377523-3313fa9c-2197-4b99-865b-de023edc94bf.png)
