### PR TITLE
add time

### DIFF
--- a/nerfstudio/cameras/camera_paths.py
+++ b/nerfstudio/cameras/camera_paths.py
@@ -102,7 +102,7 @@ def get_spiral_path(
 
     times = None
     if camera.times is not None:
-        times = torch.linspace(0, 1, steps)[:,None]
+        times = torch.linspace(0, 1, steps)[:, None]
     return Cameras(
         fx=camera.fx[0],
         fy=camera.fy[0],

--- a/nerfstudio/cameras/camera_paths.py
+++ b/nerfstudio/cameras/camera_paths.py
@@ -100,12 +100,16 @@ def get_spiral_path(
         new_c2ws.append(c2wh[:3, :4])
     new_c2ws = torch.stack(new_c2ws, dim=0)
 
+    times = None
+    if camera.times is not None:
+        times = torch.linspace(0, 1, steps)[:,None]
     return Cameras(
         fx=camera.fx[0],
         fy=camera.fy[0],
         cx=camera.cx[0],
         cy=camera.cy[0],
         camera_to_worlds=new_c2ws,
+        times=times,
     )
 
 

--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -230,7 +230,7 @@ class Cameras(TensorDataclass):
             c_x_y: cx or cy for when h_w == None
         """
         if isinstance(h_w, int):
-            h_w = torch.Tensor([h_w]).to(torch.int64).to(self.device)
+            h_w = torch.as_tensor([h_w]).to(torch.int64).to(self.device)
         elif isinstance(h_w, torch.Tensor):
             assert not torch.is_floating_point(h_w), f"height and width tensor must be of type int, not: {h_w.dtype}"
             h_w = h_w.to(torch.int64).to(self.device)
@@ -238,7 +238,7 @@ class Cameras(TensorDataclass):
                 h_w = h_w.unsqueeze(-1)
         # assert torch.all(h_w == h_w.view(-1)[0]), "Batched cameras of different h, w will be allowed in the future."
         elif h_w is None:
-            h_w = torch.Tensor((c_x_y * 2).to(torch.int64).to(self.device))
+            h_w = torch.as_tensor((c_x_y * 2)).to(torch.int64).to(self.device)
         else:
             raise ValueError("Height must be an int, tensor, or None, received: " + str(type(h_w)))
         return h_w

--- a/nerfstudio/field_components/temporal_grid.py
+++ b/nerfstudio/field_components/temporal_grid.py
@@ -116,7 +116,6 @@ class TemporalGridEncodeFunc(Function):
     @staticmethod
     @custom_bwd
     def backward(ctx, grad):
-
         inputs, temporal_row_index, embeddings, offsets, dy_dx = ctx.saved_tensors
         B, D, grid_channel, C, L, S, H, gridtype = ctx.dims
         align_corners = ctx.align_corners
@@ -211,9 +210,9 @@ class TemporalGridEncoder(nn.Module):
         # allocate parameters
         offsets = []
         offset = 0
-        self.max_params = 2 ** log2_hashmap_size
+        self.max_params = 2**log2_hashmap_size
         for i in range(num_levels):
-            resolution = int(np.ceil(base_resolution * per_level_scale ** i))
+            resolution = int(np.ceil(base_resolution * per_level_scale**i))
             params_in_level = min(
                 self.max_params, (resolution if align_corners else resolution + 1) ** input_dim
             )  # limit max number

--- a/nerfstudio/field_components/temporal_grid.py
+++ b/nerfstudio/field_components/temporal_grid.py
@@ -211,9 +211,9 @@ class TemporalGridEncoder(nn.Module):
         # allocate parameters
         offsets = []
         offset = 0
-        self.max_params = 2**log2_hashmap_size
+        self.max_params = 2 ** log2_hashmap_size
         for i in range(num_levels):
-            resolution = int(np.ceil(base_resolution * per_level_scale**i))
+            resolution = int(np.ceil(base_resolution * per_level_scale ** i))
             params_in_level = min(
                 self.max_params, (resolution if align_corners else resolution + 1) ** input_dim
             )  # limit max number
@@ -336,7 +336,7 @@ class TemporalGridEncoder(nn.Module):
         """
         outputs = TemporalGridEncodeFunc.apply(
             xyz,
-            self.get_temporal_index(time[:, 0]),
+            self.get_temporal_index(time[:, 0].float()),
             self.embeddings,
             self.offsets,
             self.per_level_scale,


### PR DESCRIPTION
Added time to the `spiral` rendering script

**Known limitations:**
`DyCheck` data set has a different `z` axis. So the video is upside down:

https://user-images.githubusercontent.com/12553253/217924350-bf009510-5aba-462a-80f4-7aaf964d6e58.mp4

A quick fix is to add `-` to the up axis (but this is not included in this PR as it impacts other datasets)

https://user-images.githubusercontent.com/12553253/217924591-b5eca1dd-fb50-4d5f-873b-82020d53cdc7.mp4

Using exported camera path is fine

https://user-images.githubusercontent.com/12553253/217924749-359147fe-397a-4f7b-9507-491f9545169d.mp4

**But** exported camera path is with a fixed timestamp. Perhaps we can improve UI and allow user to specify timestamp for key frames as well?
