### PR TITLE
Switch to Generic model interface

### DIFF
--- a/docs/developer_guides/config.md
+++ b/docs/developer_guides/config.md
@@ -31,14 +31,8 @@ class NerfactoModelConfig(ModelConfig):
     _target: Type = field(default_factory=lambda: NerfactoModel)
     ...
 
-class NerfactoModel(Model):
-     """Nerfacto model
-
-    Args:
-        config: Nerfacto configuration to instantiate model
-    """
-
-    config: NerfactoModelConfig
+class NerfactoModel(Model[NerfactoModelConfig]):
+     """Nerfacto model"""
     ...
 ```
 

--- a/docs/developer_guides/debugging_tools/local_logger.md
+++ b/docs/developer_guides/debugging_tools/local_logger.md
@@ -8,10 +8,9 @@ A skeleton of the local writer config is defined below.
 """nerfstudio/configs/base_config.py""""
 
 @dataclass
-class LocalWriterConfig(InstantiateConfig):
+class LocalWriterConfig(InstantiateConfig[writer.LocalWriter]):
     """Local Writer config"""
 
-    _target: Type = writer.LocalWriter
     enable: bool = False
     stats_to_track: Tuple[writer.EventName, ...] = (
         writer.EventName.ITER_TRAIN_TIME,

--- a/docs/developer_guides/pipelines/datamanagers.md
+++ b/docs/developer_guides/pipelines/datamanagers.md
@@ -44,14 +44,12 @@ We've implemented a VanillaDataManager that implements the standard logic of mos
 
 ```python
 @dataclass
-class VanillaDataManagerConfig(InstantiateConfig):
+class VanillaDataManagerConfig(InstantiateConfig["VanillaDataManager"]):
     """Configuration for data manager instantiation; DataManager is in charge of keeping the train/eval dataparsers;
     After instantiation, data manager holds both train/eval datasets and is in charge of returning unpacked
     train/eval data at each iteration
     """
 
-    _target: Type = field(default_factory=lambda: VanillaDataManager)
-    """target class to instantiate"""
     dataparser: AnnotatedDataParserUnion = BlenderDataParserConfig()
     """specifies the dataparser used to unpack the data"""
     train_num_rays_per_batch: int = 1024

--- a/docs/developer_guides/pipelines/dataparsers.md
+++ b/docs/developer_guides/pipelines/dataparsers.md
@@ -73,10 +73,8 @@ class NerfstudioDataParserConfig(DataParserConfig):
     """The fraction of images to use for training. The remaining images are for eval."""
 
 @dataclass
-class Nerfstudio(DataParser):
+class Nerfstudio(DataParser[NerfstudioDataParserConfig]):
     """Nerfstudio DatasetParser"""
-
-    config: NerfstudioDataParserConfig
 
     def _generate_dataparser_outputs(self, split="train"):
         meta = load_from_json(self.config.data / "transforms.json")

--- a/docs/developer_guides/pipelines/models.md
+++ b/docs/developer_guides/pipelines/models.md
@@ -111,14 +111,8 @@ There are a lot of options! Thankfully, our config system makes this easy to han
 Furthermore, you have Python autocomplete and static checking working in your favor. At the top of every Model, we specify the config and then can easily pull of values throughout the implementation. Let's take a look at the beginning of the NerfactoModel implementation.
 
 ```python
-class NerfactoModel(Model):
-    """Nerfacto model
-
-    Args:
-        config: Nerfacto configuration to instantiate model
-    """
-
-    config: NerfactoModelConfig
+class NerfactoModel(Model[NerfactoModelConfig]):
+    """Nerfacto model"""
 
     def populate_modules(self):
         """Set the fields and modules."""

--- a/nerfstudio/cameras/camera_optimizers.py
+++ b/nerfstudio/cameras/camera_optimizers.py
@@ -39,10 +39,8 @@ from nerfstudio.utils import poses as pose_utils
 
 
 @dataclass
-class CameraOptimizerConfig(InstantiateConfig):
+class CameraOptimizerConfig(InstantiateConfig["CameraOptimizer"]):
     """Configuration of optimization for camera poses."""
-
-    _target: Type = field(default_factory=lambda: CameraOptimizer)
 
     mode: Literal["off", "SO3xR3", "SE3"] = "off"
     """Pose optimization strategy to use. If enabled, we recommend SO3xR3."""

--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, Optional
 
 import yaml
 from rich.console import Console
-from typing_extensions import Literal
+from typing_extensions import Literal, TypeVar
 
 from nerfstudio.configs.base_config import (
     InstantiateConfig,
@@ -37,10 +37,11 @@ from nerfstudio.engine.schedulers import SchedulerConfig
 from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
 
 CONSOLE = Console(width=120)
+T = TypeVar("T")
 
 
 @dataclass
-class ExperimentConfig(InstantiateConfig):
+class ExperimentConfig(InstantiateConfig[T]):
     """Full config contents for running an experiment. Any experiment types (like training) will be
     subclassed from this, and must have their _target field defined accordingly."""
 

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -258,14 +258,12 @@ class DataManager(nn.Module):
 
 
 @dataclass
-class VanillaDataManagerConfig(InstantiateConfig):
+class VanillaDataManagerConfig(InstantiateConfig["VanillaDataManager"]):
     """Configuration for data manager instantiation; DataManager is in charge of keeping the train/eval dataparsers;
     After instantiation, data manager holds both train/eval datasets and is in charge of returning unpacked
     train/eval data at each iteration
     """
 
-    _target: Type = field(default_factory=lambda: VanillaDataManager)
-    """Target class to instantiate."""
     dataparser: AnnotatedDataParserUnion = BlenderDataParserConfig()
     """Specifies the dataparser used to unpack the data."""
     train_num_rays_per_batch: int = 1024

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -61,7 +61,7 @@ from nerfstudio.data.utils.dataloaders import (
     FixedIndicesEvalDataloader,
     RandIndicesEvalDataloader,
 )
-from nerfstudio.data.utils.nerfstudio_collate import nerfstudio_collate
+from nerfstudio.data.utils.nerfstudio_collate import CollateFunction, nerfstudio_collate
 from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes
 from nerfstudio.model_components.ray_generators import RayGenerator
 from nerfstudio.utils.misc import IterableWrapper
@@ -281,7 +281,7 @@ class VanillaDataManagerConfig(InstantiateConfig):
     camera_optimizer: CameraOptimizerConfig = CameraOptimizerConfig()
     """Specifies the camera pose optimizer used during training. Helpful if poses are noisy, such as for data from
     Record3D."""
-    collate_fn = staticmethod(nerfstudio_collate)
+    collate_fn: CollateFunction = field(default_factory=lambda: nerfstudio_collate)
     """Specifies the collate function to use for the train and eval dataloaders."""
     camera_res_scale_factor: float = 1.0
     """The scale factor for scaling spatial data such as images, mask, semantics

--- a/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -60,14 +61,12 @@ def traj_string_to_matrix(traj_string: str):
 
 
 @dataclass
-class ARKitScenesDataParserConfig(DataParserConfig):
+class ARKitScenesDataParserConfig(DataParserConfig, InstantiateConfig["ARKitScenes"]):
     """ARKitScenes dataset config.
     ARKitScenes dataset (http://github.com/apple/ARKitScenes) is a large-scale 3D dataset of indoor scenes.
     This dataparser uses 3D deteciton subset of the ARKitScenes dataset.
     """
 
-    _target: Type = field(default_factory=lambda: ARKitScenes)
-    """target class to instantiate"""
     data: Path = Path("data/ARKitScenes/3dod/Validation/41069021")
     """Path to ARKitScenes folder with densely extracted scenes."""
     scene_scale: float = 1.0

--- a/nerfstudio/data/dataparsers/base_dataparser.py
+++ b/nerfstudio/data/dataparsers/base_dataparser.py
@@ -91,11 +91,9 @@ class DataparserOutputs:
 
 
 @dataclass
-class DataParserConfig(cfg.InstantiateConfig):
+class DataParserConfig:
     """Basic dataset config"""
 
-    _target: Type = field(default_factory=lambda: DataParser[DataParserConfig])
-    """_target: target class to instantiate"""
     data: Path = Path()
     """Directory specifying location of data."""
 

--- a/nerfstudio/data/dataparsers/base_dataparser.py
+++ b/nerfstudio/data/dataparsers/base_dataparser.py
@@ -20,7 +20,7 @@ import json
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
 
 import torch
 from torchtyping import TensorType
@@ -94,23 +94,26 @@ class DataparserOutputs:
 class DataParserConfig(cfg.InstantiateConfig):
     """Basic dataset config"""
 
-    _target: Type = field(default_factory=lambda: DataParser)
+    _target: Type = field(default_factory=lambda: DataParser[DataParserConfig])
     """_target: target class to instantiate"""
     data: Path = Path()
     """Directory specifying location of data."""
 
 
+TDataParserConfig = TypeVar("TDataParserConfig", bound=DataParserConfig)
+
+
 @dataclass
-class DataParser:
+class DataParser(Generic[TDataParserConfig]):
     """A dataset.
 
     Args:
         config: datasetparser config containing all information needed to instantiate dataset
     """
 
-    config: DataParserConfig
+    config: TDataParserConfig
 
-    def __init__(self, config: DataParserConfig):
+    def __init__(self, config: TDataParserConfig):
         super().__init__()
         self.config = config
 

--- a/nerfstudio/data/dataparsers/blender_dataparser.py
+++ b/nerfstudio/data/dataparsers/blender_dataparser.py
@@ -24,6 +24,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -35,7 +36,7 @@ from nerfstudio.utils.io import load_from_json
 
 
 @dataclass
-class BlenderDataParserConfig(DataParserConfig):
+class BlenderDataParserConfig(DataParserConfig, InstantiateConfig["Blender"]):
     """Blender dataset parser config"""
 
     _target: Type = field(default_factory=lambda: Blender)

--- a/nerfstudio/data/dataparsers/blender_dataparser.py
+++ b/nerfstudio/data/dataparsers/blender_dataparser.py
@@ -49,12 +49,10 @@ class BlenderDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class Blender(DataParser):
+class Blender(DataParser[BlenderDataParserConfig]):
     """Blender Dataset
     Some of this code comes from https://github.com/yenchenlin/nerf-pytorch/blob/master/load_blender.py#L37.
     """
-
-    config: BlenderDataParserConfig
 
     def __init__(self, config: BlenderDataParserConfig):
         super().__init__(config=config)

--- a/nerfstudio/data/dataparsers/dnerf_dataparser.py
+++ b/nerfstudio/data/dataparsers/dnerf_dataparser.py
@@ -24,6 +24,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -35,11 +36,9 @@ from nerfstudio.utils.io import load_from_json
 
 
 @dataclass
-class DNeRFDataParserConfig(DataParserConfig):
+class DNeRFDataParserConfig(DataParserConfig, InstantiateConfig["DNeRF"]):
     """D-NeRF dataset parser config"""
 
-    _target: Type = field(default_factory=lambda: DNeRF)
-    """target class to instantiate"""
     data: Path = Path("data/dnerf/lego")
     """Directory specifying location of data."""
     scale_factor: float = 1.0

--- a/nerfstudio/data/dataparsers/dnerf_dataparser.py
+++ b/nerfstudio/data/dataparsers/dnerf_dataparser.py
@@ -49,10 +49,8 @@ class DNeRFDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class DNeRF(DataParser):
+class DNeRF(DataParser[DNeRFDataParserConfig]):
     """DNeRF Dataset"""
-
-    config: DNeRFDataParserConfig
 
     def __init__(self, config: DNeRFDataParserConfig):
         super().__init__(config=config)

--- a/nerfstudio/data/dataparsers/dycheck_dataparser.py
+++ b/nerfstudio/data/dataparsers/dycheck_dataparser.py
@@ -198,10 +198,8 @@ class DycheckDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class Dycheck(DataParser):
+class Dycheck(DataParser[DycheckDataParserConfig]):
     """Dycheck (https://arxiv.org/abs/2210.13445) Dataset `iphone` subset"""
-
-    config: DycheckDataParserConfig
 
     def __init__(self, config: DycheckDataParserConfig):
         super().__init__(config=config)

--- a/nerfstudio/data/dataparsers/dycheck_dataparser.py
+++ b/nerfstudio/data/dataparsers/dycheck_dataparser.py
@@ -26,6 +26,7 @@ import torch
 from rich.progress import Console
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -180,11 +181,9 @@ def _rescale_depth(depth_raw: np.ndarray, cam: Dict) -> np.ndarray:
 
 
 @dataclass
-class DycheckDataParserConfig(DataParserConfig):
+class DycheckDataParserConfig(DataParserConfig, InstantiateConfig["Dycheck"]):
     """Dycheck (https://arxiv.org/abs/2210.13445) dataset parser config"""
 
-    _target: Type = field(default_factory=lambda: Dycheck)
-    """target class to instantiate"""
     data: Path = Path("data/iphone/mochi-high-five")
     """Directory specifying location of data."""
     scale_factor: float = 5.0

--- a/nerfstudio/data/dataparsers/instant_ngp_dataparser.py
+++ b/nerfstudio/data/dataparsers/instant_ngp_dataparser.py
@@ -27,6 +27,7 @@ from rich.console import Console
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -39,11 +40,9 @@ CONSOLE = Console(width=120)
 
 
 @dataclass
-class InstantNGPDataParserConfig(DataParserConfig):
+class InstantNGPDataParserConfig(DataParserConfig, InstantiateConfig["InstantNGP"]):
     """Instant-NGP dataset parser config"""
 
-    _target: Type = field(default_factory=lambda: InstantNGP)
-    """target class to instantiate"""
     data: Path = Path("data/ours/posterv2")
     """Directory or explicit json file path specifying location of data."""
     scene_scale: float = 0.3333

--- a/nerfstudio/data/dataparsers/instant_ngp_dataparser.py
+++ b/nerfstudio/data/dataparsers/instant_ngp_dataparser.py
@@ -51,10 +51,8 @@ class InstantNGPDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class InstantNGP(DataParser):
+class InstantNGP(DataParser[InstantNGPDataParserConfig]):
     """Instant NGP Dataset"""
-
-    config: InstantNGPDataParserConfig
 
     def _generate_dataparser_outputs(self, split="train"):
         if self.config.data.suffix == ".json":

--- a/nerfstudio/data/dataparsers/minimal_dataparser.py
+++ b/nerfstudio/data/dataparsers/minimal_dataparser.py
@@ -43,10 +43,8 @@ class MinimalDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class MinimalDataParser(DataParser):
+class MinimalDataParser(DataParser[MinimalDataParserConfig]):
     """Minimal DatasetParser"""
-
-    config: MinimalDataParserConfig
 
     def _generate_dataparser_outputs(self, split="train"):
         filepath = self.config.data / f"{split}.npz"

--- a/nerfstudio/data/dataparsers/minimal_dataparser.py
+++ b/nerfstudio/data/dataparsers/minimal_dataparser.py
@@ -24,6 +24,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -34,11 +35,9 @@ from nerfstudio.data.scene_box import SceneBox
 
 
 @dataclass
-class MinimalDataParserConfig(DataParserConfig):
+class MinimalDataParserConfig(DataParserConfig, InstantiateConfig["MinimalDataParser"]):
     """Minimal dataset config"""
 
-    _target: Type = field(default_factory=lambda: MinimalDataParser)
-    """target class to instantiate"""
     data: Path = Path("/home/nikhil/nerfstudio-main/tests/data/lego_test/minimal_parser")
 
 

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -28,6 +28,7 @@ from typing_extensions import Literal
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -41,11 +42,9 @@ MAX_AUTO_RESOLUTION = 1600
 
 
 @dataclass
-class NerfstudioDataParserConfig(DataParserConfig):
+class NerfstudioDataParserConfig(DataParserConfig, InstantiateConfig["Nerfstudio"]):
     """Nerfstudio dataset config"""
 
-    _target: Type = field(default_factory=lambda: Nerfstudio)
-    """target class to instantiate"""
     data: Path = Path("data/nerfstudio/poster")
     """Directory or explicit json file path specifying location of data."""
     scale_factor: float = 1.0

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -67,10 +67,9 @@ class NerfstudioDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class Nerfstudio(DataParser):
+class Nerfstudio(DataParser[NerfstudioDataParserConfig]):
     """Nerfstudio DatasetParser"""
 
-    config: NerfstudioDataParserConfig
     downscale_factor: Optional[int] = None
 
     def _generate_dataparser_outputs(self, split="train"):

--- a/nerfstudio/data/dataparsers/nuscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/nuscenes_dataparser.py
@@ -26,6 +26,7 @@ from nuscenes.nuscenes import NuScenes as NuScenesDatabase
 from typing_extensions import Literal
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -50,7 +51,7 @@ def rotation_translation_to_pose(r_quat, t_vec):
 
 
 @dataclass
-class NuScenesDataParserConfig(DataParserConfig):
+class NuScenesDataParserConfig(DataParserConfig, InstantiateConfig["NuScenes"]):
     """NuScenes dataset config.
     NuScenes (https://www.nuscenes.org/nuscenes) is an autonomous driving dataset containing 1000 20s clips.
     Each clip was recorded with a suite of sensors including 6 surround cameras.
@@ -59,8 +60,6 @@ class NuScenesDataParserConfig(DataParserConfig):
     To create these masks use scripts/datasets/process_nuscenes_masks.py.
     """
 
-    _target: Type = field(default_factory=lambda: NuScenes)
-    """target class to instantiate"""
     data: Path = Path("scene-0103")  # TODO: rename to scene but keep checkpoint saving name?
     """Name of the scene."""
     data_dir: Path = Path("/mnt/local/NuScenes")

--- a/nerfstudio/data/dataparsers/nuscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/nuscenes_dataparser.py
@@ -80,15 +80,15 @@ class NuScenesDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class NuScenes(DataParser):
+class NuScenes(DataParser[NuScenesDataParserConfig]):
     """NuScenes DatasetParser"""
-
-    config: NuScenesDataParserConfig
 
     def _generate_dataparser_outputs(self, split="train"):
         # pylint: disable=too-many-statements
 
-        nusc = NuScenesDatabase(version=self.config.version, dataroot=self.config.data_dir, verbose=self.config.verbose)
+        nusc = NuScenesDatabase(
+            version=self.config.version, dataroot=str(self.config.data_dir), verbose=self.config.verbose
+        )
         cameras = ["CAM_" + camera for camera in self.config.cameras]
 
         assert (

--- a/nerfstudio/data/dataparsers/phototourism_dataparser.py
+++ b/nerfstudio/data/dataparsers/phototourism_dataparser.py
@@ -69,12 +69,10 @@ class PhototourismDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class Phototourism(DataParser):
+class Phototourism(DataParser[PhototourismDataParserConfig]):
     """Phototourism dataset. This is based on https://github.com/kwea123/nerf_pl/blob/nerfw/datasets/phototourism.py
     and uses colmap's utils file to read the poses.
     """
-
-    config: PhototourismDataParserConfig
 
     def __init__(self, config: PhototourismDataParserConfig):
         super().__init__(config=config)

--- a/nerfstudio/data/dataparsers/phototourism_dataparser.py
+++ b/nerfstudio/data/dataparsers/phototourism_dataparser.py
@@ -27,6 +27,7 @@ from typing_extensions import Literal
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -45,11 +46,9 @@ CONSOLE = Console(width=120)
 
 
 @dataclass
-class PhototourismDataParserConfig(DataParserConfig):
+class PhototourismDataParserConfig(DataParserConfig, InstantiateConfig["Phototourism"]):
     """Phototourism dataset parser config"""
 
-    _target: Type = field(default_factory=lambda: Phototourism)
-    """target class to instantiate"""
     data: Path = Path("data/phototourism/brandenburg-gate")
     """Directory specifying location of data."""
     scale_factor: float = 3.0

--- a/nerfstudio/data/dataparsers/scannet_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannet_dataparser.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -32,7 +33,7 @@ from nerfstudio.data.scene_box import SceneBox
 
 
 @dataclass
-class ScanNetDataParserConfig(DataParserConfig):
+class ScanNetDataParserConfig(DataParserConfig, InstantiateConfig["ScanNet"]):
     """ScanNet dataset config.
     ScanNet dataset (https://www.scan-net.org/) is a large-scale 3D dataset of indoor scenes.
     This dataparser assumes that the dense stream was extracted from .sens files.
@@ -43,8 +44,6 @@ class ScanNetDataParserConfig(DataParserConfig):
      - pose/
     """
 
-    _target: Type = field(default_factory=lambda: ScanNet)
-    """target class to instantiate"""
     data: Path = Path("data/scannet/scene0423_02")
     """Path to ScanNet folder with densely extracted scenes."""
     scene_scale: float = 1.0

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -24,6 +24,7 @@ from rich.console import Console
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -36,11 +37,9 @@ CONSOLE = Console()
 
 
 @dataclass
-class SDFStudioDataParserConfig(DataParserConfig):
+class SDFStudioDataParserConfig(DataParserConfig, InstantiateConfig["SDFStudio"]):
     """Scene dataset parser config"""
 
-    _target: Type = field(default_factory=lambda: SDFStudio)
-    """target class to instantiate"""
     data: Path = Path("data/DTU/scan65")
     """Directory specifying location of data."""
     include_mono_prior: bool = False

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -59,10 +59,8 @@ class SDFStudioDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class SDFStudio(DataParser):
+class SDFStudio(DataParser[SDFStudioDataParserConfig]):
     """SDFStudio Dataset"""
-
-    config: SDFStudioDataParserConfig
 
     def _generate_dataparser_outputs(self, split="train"):  # pylint: disable=unused-argument,too-many-statements
         # load meta data

--- a/nerfstudio/data/dataparsers/sitcoms3d_dataparser.py
+++ b/nerfstudio/data/dataparsers/sitcoms3d_dataparser.py
@@ -59,10 +59,8 @@ class Sitcoms3DDataParserConfig(DataParserConfig):
 
 
 @dataclass
-class Sitcoms3D(DataParser):
+class Sitcoms3D(DataParser[Sitcoms3DDataParserConfig]):
     """Sitcoms3D Dataset"""
-
-    config: Sitcoms3DDataParserConfig
 
     def _generate_dataparser_outputs(self, split="train"):  # pylint: disable=unused-argument,too-many-statements
 

--- a/nerfstudio/data/dataparsers/sitcoms3d_dataparser.py
+++ b/nerfstudio/data/dataparsers/sitcoms3d_dataparser.py
@@ -28,6 +28,7 @@ import torch
 from rich.console import Console
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
@@ -41,11 +42,9 @@ CONSOLE = Console()
 
 
 @dataclass
-class Sitcoms3DDataParserConfig(DataParserConfig):
+class Sitcoms3DDataParserConfig(DataParserConfig, InstantiateConfig["Sitcoms3D"]):
     """sitcoms3D dataset parser config"""
 
-    _target: Type = field(default_factory=lambda: Sitcoms3D)
-    """target class to instantiate"""
     data: Path = Path("data/sitcoms3d/TBBT-big_living_room")
     """Directory specifying location of data."""
     include_semantics: bool = True

--- a/nerfstudio/data/utils/data_utils.py
+++ b/nerfstudio/data/utils/data_utils.py
@@ -45,7 +45,7 @@ def get_semantics_and_mask_tensors_from_path(
     If no mask is required - use mask_indices = []
     """
     if isinstance(mask_indices, List):
-        mask_indices = torch.tensor(mask_indices, dtype="int64").view(1, 1, -1)
+        mask_indices = torch.tensor(mask_indices, dtype=torch.int64).view(1, 1, -1)
     pil_image = Image.open(filepath)
     if scale_factor != 1.0:
         width, height = pil_image.size

--- a/nerfstudio/data/utils/nerfstudio_collate.py
+++ b/nerfstudio/data/utils/nerfstudio_collate.py
@@ -19,11 +19,12 @@ Custom collate function that includes cases for nerfstudio types.
 import collections
 import collections.abc
 import re
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, List, Union
 
 import torch
 import torch.utils.data
 from torch._six import string_classes
+from typing_extensions import Protocol, TypeVar
 
 from nerfstudio.cameras.cameras import Cameras
 
@@ -34,9 +35,17 @@ NERFSTUDIO_COLLATE_ERR_MSG_FORMAT = (
 np_str_obj_array_pattern = re.compile(r"[SaUO]")
 
 
-def nerfstudio_collate(
-    batch, extra_mappings: Union[Dict[type, Callable], None] = None
-):  # pylint: disable=too-many-return-statements
+T = TypeVar("T")
+
+
+class CollateFunction(Protocol):  # pylint: disable=too-few-public-methods,missing-class-docstring
+    def __call__(self, batch: List[T], extra_mappings: Union[Dict[type, Callable], None] = None) -> T:
+        raise NotImplementedError()
+
+
+def nerfstudio_collate(  # pylint: disable=too-many-return-statements
+    batch: List[T], extra_mappings: Union[Dict[type, Callable], None] = None
+) -> T:
     r"""
     This is the default pytorch collate function, but with support for nerfstudio types. All documentation
     below is copied straight over from pytorch's default_collate function, python version 3.8.13,

--- a/nerfstudio/engine/schedulers.py
+++ b/nerfstudio/engine/schedulers.py
@@ -28,7 +28,7 @@ from nerfstudio.configs.base_config import InstantiateConfig
 
 
 @dataclass
-class SchedulerConfig(InstantiateConfig):
+class SchedulerConfig(InstantiateConfig["Scheduler"]):
     """Basic scheduler config"""
 
     _target: Type = field(default_factory=lambda: Scheduler)

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -57,11 +57,9 @@ TORCH_DEVICE = Union[torch.device, str]  # pylint: disable=invalid-name
 
 
 @dataclass
-class TrainerConfig(ExperimentConfig):
+class TrainerConfig(ExperimentConfig["Trainer"]):
     """Configuration for training regimen"""
 
-    _target: Type = field(default_factory=lambda: Trainer)
-    """target class to instantiate"""
     steps_per_save: int = 1000
     """Number of steps between saves."""
     steps_per_eval_batch: int = 500

--- a/nerfstudio/models/base_model.py
+++ b/nerfstudio/models/base_model.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch import nn
@@ -52,7 +52,10 @@ class ModelConfig(InstantiateConfig):
     """specifies number of rays per chunk during eval"""
 
 
-class Model(nn.Module):
+TConfig = TypeVar("TConfig", bound=ModelConfig)
+
+
+class Model(nn.Module, Generic[TConfig]):
     """Model class
     Where everything (Fields, Optimizers, Samplers, Visualization, etc) is linked together. This should be
     subclassed for custom NeRF model.
@@ -62,11 +65,11 @@ class Model(nn.Module):
         scene_box: dataset scene box
     """
 
-    config: ModelConfig
+    config: TConfig
 
     def __init__(
         self,
-        config: ModelConfig,
+        config: TConfig,
         scene_box: SceneBox,
         num_train_data: int,
         **kwargs,
@@ -101,6 +104,7 @@ class Model(nn.Module):
         # NOTE: call `super().populate_modules()` in subclasses
 
         if self.config.enable_collider:
+            assert self.config.collider_params is not None
             self.collider = NearFarCollider(
                 near_plane=self.config.collider_params["near_plane"], far_plane=self.config.collider_params["far_plane"]
             )

--- a/nerfstudio/models/base_model.py
+++ b/nerfstudio/models/base_model.py
@@ -34,14 +34,13 @@ from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes
 from nerfstudio.model_components.scene_colliders import NearFarCollider
 
+TModel = TypeVar("TModel", bound="Model")
 
 # Model related configs
 @dataclass
-class ModelConfig(InstantiateConfig):
+class ModelConfig(InstantiateConfig[TModel]):
     """Configuration for model instantiation"""
 
-    _target: Type = field(default_factory=lambda: Model)
-    """target class to instantiate"""
     enable_collider: bool = True
     """Whether to create a scene collider to filter rays."""
     collider_params: Optional[Dict[str, float]] = to_immutable_dict({"near_plane": 2.0, "far_plane": 6.0})

--- a/nerfstudio/models/depth_nerfacto.py
+++ b/nerfstudio/models/depth_nerfacto.py
@@ -18,6 +18,7 @@ Nerfacto augmented with depth supervision.
 
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass, field
 from typing import Dict, Tuple, Type
 
@@ -49,6 +50,9 @@ class DepthNerfactoModelConfig(NerfactoModelConfig):
     depth_loss_type: DepthLossType = DepthLossType.DS_NERF
     """Depth loss type."""
 
+    def setup(self, **kwargs) -> DepthNerfactoModel:
+        return typing.cast(DepthNerfactoModel, super().setup(**kwargs))
+
 
 class DepthNerfactoModel(NerfactoModel):
     """Depth loss augmented nerfacto model.
@@ -58,6 +62,9 @@ class DepthNerfactoModel(NerfactoModel):
     """
 
     config: DepthNerfactoModelConfig
+
+    def __init__(self, config: DepthNerfactoModelConfig, scene_box: SceneBox, num_train_data: int, **kwargs) -> None:
+        super().__init__(config, scene_box, num_train_data, **kwargs)
 
     def populate_modules(self):
         """Set the fields and modules."""

--- a/nerfstudio/models/instant_ngp.py
+++ b/nerfstudio/models/instant_ngp.py
@@ -50,7 +50,7 @@ from nerfstudio.utils import colormaps
 
 
 @dataclass
-class InstantNGPModelConfig(ModelConfig):
+class InstantNGPModelConfig(ModelConfig["NGPModel"]):
     """Instant NGP Model Config"""
 
     _target: Type = field(

--- a/nerfstudio/models/instant_ngp.py
+++ b/nerfstudio/models/instant_ngp.py
@@ -81,18 +81,14 @@ class InstantNGPModelConfig(ModelConfig):
     """The color that is given to untrained areas."""
 
 
-class NGPModel(Model):
+class NGPModel(Model[InstantNGPModelConfig]):
     """Instant NGP model
 
     Args:
         config: instant NGP configuration to instantiate model
     """
 
-    config: InstantNGPModelConfig
     field: TCNNInstantNGPField
-
-    def __init__(self, config: InstantNGPModelConfig, **kwargs) -> None:
-        super().__init__(config=config, **kwargs)
 
     def populate_modules(self):
         """Set the fields and modules."""

--- a/nerfstudio/models/mipnerf.py
+++ b/nerfstudio/models/mipnerf.py
@@ -36,24 +36,17 @@ from nerfstudio.model_components.renderers import (
     DepthRenderer,
     RGBRenderer,
 )
-from nerfstudio.models.base_model import Model, ModelConfig
+from nerfstudio.models.base_model import Model
+from nerfstudio.models.vanilla_nerf import VanillaModelConfig
 from nerfstudio.utils import colormaps, colors, misc
 
 
-class MipNerfModel(Model):
+class MipNerfModel(Model[VanillaModelConfig]):
     """mip-NeRF model
 
     Args:
         config: MipNerf configuration to instantiate model
     """
-
-    def __init__(
-        self,
-        config: ModelConfig,
-        **kwargs,
-    ) -> None:
-        self.field = None
-        super().__init__(config=config, **kwargs)
 
     def populate_modules(self):
         """Set the fields and modules"""

--- a/nerfstudio/models/mipnerf.py
+++ b/nerfstudio/models/mipnerf.py
@@ -17,7 +17,8 @@ Implementation of mip-NeRF.
 """
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+import dataclasses
+from typing import Dict, List, Tuple, Type
 
 import torch
 from torch.nn import Parameter
@@ -36,12 +37,19 @@ from nerfstudio.model_components.renderers import (
     DepthRenderer,
     RGBRenderer,
 )
-from nerfstudio.models.base_model import Model
+from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.models.vanilla_nerf import VanillaModelConfig
 from nerfstudio.utils import colormaps, colors, misc
 
 
-class MipNerfModel(Model[VanillaModelConfig]):
+class MipNerfModelConfig(VanillaModelConfig):
+    _target: Type = dataclasses.field(default_factory=lambda: MipNerfModel)
+
+    def setup(self, **kwargs) -> MipNerfModel:
+        return typing.cast(MipNerfModel, super().setup(**kwargs))
+
+
+class MipNerfModel(Model[MipNerfModelConfig]):
     """mip-NeRF model
 
     Args:

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -130,14 +130,12 @@ class NerfactoModelConfig(ModelConfig):
     """Whether to disable scene contraction or not."""
 
 
-class NerfactoModel(Model):
+class NerfactoModel(Model[NerfactoModelConfig]):
     """Nerfacto model
 
     Args:
         config: Nerfacto configuration to instantiate model
     """
-
-    config: NerfactoModelConfig
 
     def populate_modules(self):
         """Set the fields and modules."""

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -63,10 +63,9 @@ from nerfstudio.utils import colormaps
 
 
 @dataclass
-class NerfactoModelConfig(ModelConfig):
+class NerfactoModelConfig(ModelConfig["NerfactoModel"]):
     """Nerfacto Model Config"""
 
-    _target: Type = field(default_factory=lambda: NerfactoModel)
     near_plane: float = 0.05
     """How far along the ray to start sampling."""
     far_plane: float = 1000.0

--- a/nerfstudio/models/nerfplayer_nerfacto.py
+++ b/nerfstudio/models/nerfplayer_nerfacto.py
@@ -19,6 +19,7 @@ NeRFPlayer (https://arxiv.org/abs/2210.15947) implementation with nerfacto backb
 from __future__ import annotations
 
 import functools
+import typing
 from dataclasses import dataclass, field
 from typing import Dict, List, Type
 
@@ -60,6 +61,7 @@ class NerfplayerNerfactoModelConfig(NerfactoModelConfig):
     """Nerfplayer Model Config with Nerfacto backbone"""
 
     _target: Type = field(default_factory=lambda: NerfplayerNerfactoModel)
+
     near_plane: float = 0.05
     """How far along the ray to start sampling."""
     far_plane: float = 1000.0
@@ -87,6 +89,9 @@ class NerfplayerNerfactoModelConfig(NerfactoModelConfig):
     """Temporal TV balancing weight for feature channels."""
     depth_weight: float = 1e-1
     """depth loss balancing weight for feature channels."""
+
+    def setup(self, **kwargs) -> NerfplayerNerfactoModel:
+        return typing.cast(NerfplayerNerfactoModel, super().setup(**kwargs))
 
 
 class NerfplayerNerfactoModel(NerfactoModel):

--- a/nerfstudio/models/nerfplayer_ngp.py
+++ b/nerfstudio/models/nerfplayer_ngp.py
@@ -18,6 +18,7 @@ Implementation of NeRFPlayer (https://arxiv.org/abs/2210.15947) with InstantNGP 
 
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass, field
 from typing import Type
 
@@ -80,6 +81,9 @@ class NerfplayerNGPModelConfig(InstantNGPModelConfig):
     """The training background color that is given to untrained areas."""
     disable_viewing_dependent: bool = True
     """Disable viewing dependent effects."""
+
+    def setup(self, **kwargs) -> NerfplayerNGPModel:
+        return typing.cast(NerfplayerNGPModel, super().setup(**kwargs))
 
 
 class NerfplayerNGPModel(NGPModel):

--- a/nerfstudio/models/semantic_nerfw.py
+++ b/nerfstudio/models/semantic_nerfw.py
@@ -65,14 +65,12 @@ class SemanticNerfWModelConfig(NerfactoModelConfig):
     pass_semantic_gradients: bool = False
 
 
-class SemanticNerfWModel(Model):
+class SemanticNerfWModel(Model[SemanticNerfWModelConfig]):
     """Nerfacto model
 
     Args:
         config: Nerfacto configuration to instantiate model
     """
-
-    config: SemanticNerfWModelConfig
 
     def __init__(self, config: SemanticNerfWModelConfig, metadata: Dict, **kwargs) -> None:
         assert "semantics" in metadata.keys() and isinstance(metadata["semantics"], Semantics)

--- a/nerfstudio/models/semantic_nerfw.py
+++ b/nerfstudio/models/semantic_nerfw.py
@@ -18,6 +18,7 @@ Semantic NeRF-W implementation which should be fast enough to view in the viewer
 
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Type
 
@@ -63,6 +64,9 @@ class SemanticNerfWModelConfig(NerfactoModelConfig):
     """Whether to use transient embedding."""
     semantic_loss_weight: float = 1.0
     pass_semantic_gradients: bool = False
+
+    def setup(self, **kwargs) -> SemanticNerfWModel:
+        return typing.cast(SemanticNerfWModel, super().setup(**kwargs))
 
 
 class SemanticNerfWModel(Model[SemanticNerfWModelConfig]):

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -57,11 +57,9 @@ from nerfstudio.utils import colormaps, colors, misc
 
 
 @dataclass
-class TensoRFModelConfig(ModelConfig):
+class TensoRFModelConfig(ModelConfig["TensoRFModel"]):
     """TensoRF model config"""
 
-    _target: Type = field(default_factory=lambda: TensoRFModel)
-    """target class to instantiate"""
     init_resolution: int = 128
     """initial render resolution"""
     final_resolution: int = 300

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -81,7 +81,7 @@ class TensoRFModelConfig(ModelConfig):
     tensorf_encoding: Literal["triplane", "vm", "cp"] = "vm"
 
 
-class TensoRFModel(Model):
+class TensoRFModel(Model[TensoRFModelConfig]):
     """TensoRF Model
 
     Args:

--- a/nerfstudio/models/vanilla_nerf.py
+++ b/nerfstudio/models/vanilla_nerf.py
@@ -60,26 +60,12 @@ class VanillaModelConfig(ModelConfig):
     """Parameters to instantiate temporal distortion with"""
 
 
-class NeRFModel(Model):
+class NeRFModel(Model[VanillaModelConfig]):
     """Vanilla NeRF model
 
     Args:
         config: Basic NeRF configuration to instantiate model
     """
-
-    def __init__(
-        self,
-        config: VanillaModelConfig,
-        **kwargs,
-    ) -> None:
-        self.field_coarse = None
-        self.field_fine = None
-        self.temporal_distortion = None
-
-        super().__init__(
-            config=config,
-            **kwargs,
-        )
 
     def populate_modules(self):
         """Set the fields and modules"""
@@ -120,6 +106,7 @@ class NeRFModel(Model):
         self.ssim = structural_similarity_index_measure
         self.lpips = LearnedPerceptualImagePatchSimilarity(normalize=True)
 
+        self.temporal_distortion = None
         if getattr(self.config, "enable_temporal_distortion", False):
             params = self.config.temporal_distortion_params
             kind = params.pop("kind")

--- a/nerfstudio/models/vanilla_nerf.py
+++ b/nerfstudio/models/vanilla_nerf.py
@@ -45,10 +45,9 @@ from nerfstudio.utils import colormaps, colors, misc
 
 
 @dataclass
-class VanillaModelConfig(ModelConfig):
+class VanillaModelConfig(ModelConfig["NeRFModel"]):
     """Vanilla Model Config"""
 
-    _target: Type = field(default_factory=lambda: NeRFModel)
     num_coarse_samples: int = 64
     """Number of samples in coarse field evaluation"""
     num_importance_samples: int = 128

--- a/nerfstudio/pipelines/base_pipeline.py
+++ b/nerfstudio/pipelines/base_pipeline.py
@@ -189,22 +189,20 @@ class Pipeline(nn.Module):
         """
 
 
+TModelConfig = TypeVar("TModelConfig", bound=ModelConfig)
+
+
 @dataclass
-class VanillaPipelineConfig(cfg.InstantiateConfig):
+class VanillaPipelineConfig(cfg.InstantiateConfig["VanillaPipeline"]):
     """Configuration for pipeline instantiation"""
 
-    _target: Type = field(default_factory=lambda: VanillaPipeline)
-    """target class to instantiate"""
     datamanager: VanillaDataManagerConfig = VanillaDataManagerConfig()
     """specifies the datamanager config"""
-    model: ModelConfig = ModelConfig()
+    model: ModelConfig = field(default_factory=ModelConfig[Model])
     """specifies the model config"""
 
 
-TPipelineConfig = TypeVar("TPipelineConfig", bound=VanillaPipelineConfig, default=VanillaPipelineConfig)
-
-
-class VanillaPipeline(Pipeline, Generic[TPipelineConfig]):
+class VanillaPipeline(Pipeline):
     """The pipeline class for the vanilla nerf setup of multiple cameras for one or a few scenes.
 
         config: configuration to instantiate pipeline
@@ -221,11 +219,11 @@ class VanillaPipeline(Pipeline, Generic[TPipelineConfig]):
         model: The model that will be used
     """
 
-    config: TPipelineConfig
+    config: VanillaPipelineConfig
 
     def __init__(
         self,
-        config: TPipelineConfig,
+        config: VanillaPipelineConfig,
         device: str,
         test_mode: Literal["test", "val", "inference"] = "val",
         world_size: int = 1,

--- a/nerfstudio/pipelines/dynamic_batch.py
+++ b/nerfstudio/pipelines/dynamic_batch.py
@@ -37,12 +37,11 @@ class DynamicBatchPipelineConfig(VanillaPipelineConfig):
     """The maximum number of samples to be placed along a ray."""
 
 
-class DynamicBatchPipeline(VanillaPipeline):
+class DynamicBatchPipeline(VanillaPipeline[DynamicBatchPipelineConfig]):
     """Pipeline with logic for changing the number of rays per batch."""
 
     # pylint: disable=abstract-method
 
-    config: DynamicBatchPipelineConfig
     datamanager: VanillaDataManager
     dynamic_num_rays_per_batch: int
 
@@ -90,6 +89,7 @@ class DynamicBatchPipeline(VanillaPipeline):
 
         # add the number of rays
         assert "num_rays_per_batch" not in metrics_dict
+        assert self.datamanager.train_pixel_sampler is not None
         metrics_dict["num_rays_per_batch"] = torch.tensor(self.datamanager.train_pixel_sampler.num_rays_per_batch)
 
         return model_outputs, loss_dict, metrics_dict
@@ -99,6 +99,7 @@ class DynamicBatchPipeline(VanillaPipeline):
 
         # add the number of rays
         assert "num_rays_per_batch" not in metrics_dict
+        assert self.datamanager.eval_pixel_sampler is not None
         metrics_dict["num_rays_per_batch"] = torch.tensor(self.datamanager.eval_pixel_sampler.num_rays_per_batch)
 
         return model_outputs, loss_dict, metrics_dict

--- a/nerfstudio/pipelines/dynamic_batch.py
+++ b/nerfstudio/pipelines/dynamic_batch.py
@@ -16,12 +16,16 @@
 A pipeline that dynamically chooses the number of rays to sample.
 """
 
+from __future__ import annotations
+
+import typing
 from dataclasses import dataclass, field
 from typing import Type
 
 import torch
-from typing_extensions import Literal
+from typing_extensions import Literal, TypeVar
 
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManager
 from nerfstudio.pipelines.base_pipeline import VanillaPipeline, VanillaPipelineConfig
 
@@ -31,17 +35,22 @@ class DynamicBatchPipelineConfig(VanillaPipelineConfig):
     """Dynamic Batch Pipeline Config"""
 
     _target: Type = field(default_factory=lambda: DynamicBatchPipeline)
+
     target_num_samples: int = 262144  # 1 << 18
     """The target number of samples to use for an entire batch of rays."""
     max_num_samples_per_ray: int = 1024  # 1 << 10
     """The maximum number of samples to be placed along a ray."""
 
+    def setup(self, **kwargs) -> DynamicBatchPipeline:
+        return typing.cast(DynamicBatchPipeline, super().setup(**kwargs))
 
-class DynamicBatchPipeline(VanillaPipeline[DynamicBatchPipelineConfig]):
+
+class DynamicBatchPipeline(VanillaPipeline):
     """Pipeline with logic for changing the number of rays per batch."""
 
     # pylint: disable=abstract-method
 
+    config: DynamicBatchPipelineConfig
     datamanager: VanillaDataManager
     dynamic_num_rays_per_batch: int
 

--- a/nerfstudio/utils/misc.py
+++ b/nerfstudio/utils/misc.py
@@ -20,9 +20,12 @@ Miscellaneous helper code.
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
 
 
-def get_dict_to_torch(stuff: Any, device: Union[torch.device, str] = "cpu", exclude: Optional[List[str]] = None):
+def get_dict_to_torch(stuff: T, device: Union[torch.device, str] = "cpu", exclude: Optional[List[str]] = None) -> T:
     """Set everything in the dict to the specified torch device.
 
     Args:


### PR DESCRIPTION
This PR changes the Model's class interface to accept the type of the config. This should improve the type hints for the models (as you no longer need to override the __init__ method).
But I am not sure if this is needed or if using Generic could break compatibility for older python versions.
Please feel free to reject this PR if you are not sure of the benefits.