### PR TITLE
nerfacc tag v0.3.4 from github, until package fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "mediapy>=1.1.0",
     "msgpack>=1.0.4",
     "msgpack_numpy>=0.4.8",
-    "nerfacc==0.3.3",
+    "nerfacc @ git+https://git@github.com/KAIR-BAIR/nerfacc@v0.3.4",
     "open3d>=0.16.0",
     "opencv-python==4.6.0.66",
     "Pillow>=9.3.0",


### PR DESCRIPTION
nerfacc-0.3.3 causes other issues (on Windows at least, see https://github.com/KAIR-BAIR/nerfacc/pull/150), and package 0.3.4 is broken, so use working git tag.

See https://github.com/KAIR-BAIR/nerfacc/issues/156#issuecomment-1419890977