### PR TITLE
Save camera path json into outputs according to 'camera_path_filename'

### DIFF
--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -388,14 +388,13 @@ class ViewerState:
         if camera_path_payload:
             # save a model checkpoint
             trainer.save_checkpoint(step)
-            # write to json file in datapath directory
-            camera_path_filename = camera_path_payload["camera_path_filename"] + ".json"
+            # write to json file in outputs directory
+            camera_path_filename = Path(camera_path_payload["camera_path_filename"])
+            camera_path_filename = camera_path_filename.with_suffix(".json")
+            camera_path_filename.parent.mkdir(exist_ok=True)
             camera_path = camera_path_payload["camera_path"]
-            camera_paths_directory = os.path.join(self.datapath, "camera_paths")
-            if not os.path.exists(camera_paths_directory):
-                os.mkdir(camera_paths_directory)
 
-            write_to_json(Path(os.path.join(camera_paths_directory, camera_path_filename)), camera_path)
+            write_to_json(camera_path_filename, camera_path)
             self.vis["camera_path_payload"].delete()
 
     def _check_populate_paths_payload(self, trainer, step: int):


### PR DESCRIPTION
Fix for https://github.com/nerfstudio-project/nerfstudio/issues/1415

This PR changes behaviour of camera path saving during “Rendering” -> “copy command” in the webviewer. 

Originally, it was a problem with using the --data option for ns-train with a .json file as the target.

Probably, I've just done something wrong. I'm not sure why in my experiments `camera_path_filename` is `../../data/capture/camera_paths/outputs/exp_name/instant-ngp-bounded/2023-02-13_203323/camera_path.json.json`. I've fixed “.json.json” by using `camera_path_filename.with_suffix(".json")`. But there is not such directory anyway (even without double .json).

My intuition that  [here](https://github.com/nerfstudio-project/nerfstudio/blob/9808ebbcb8cc0be355c688b5fab8e5e45955b5ad/nerfstudio/viewer/server/viewer_utils.py#L392) `camera_path_filename` is already pointing to the desirable path for camera path output. And it's setted in web-viewer automatically. In my case it's `outputs/exp_name/instant-ngp-bounded/2023-02-13_203323/camera_path.json`. So, I don't see a point, why do we need  `os.path.join(camera_paths_directory, camera_path_filename)` concatenation with `camera_paths_directory` (that is `os.path.join(self.datapath, "camera_paths")`) [here](https://github.com/nerfstudio-project/nerfstudio/blob/9808ebbcb8cc0be355c688b5fab8e5e45955b5ad/nerfstudio/viewer/server/viewer_utils.py#L398).

Sorry if I miss something very obvious. 
