### PR TITLE
Fix mesh export normals

### DIFF
--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -151,6 +151,8 @@ def generate_point_cloud(
                     CONSOLE.print(f"Please set --normal_output_name to one of: {outputs.keys()}", justify="center")
                     sys.exit(1)
                 normal = outputs[normal_output_name]
+                assert torch.min(normal) >= 0.0 and torch.max(normal) <= 1.0, "Normal values from method output must be in [0, 1]"
+                normal = (normal * 2.0) - 1.0
             point = ray_bundle.origins + ray_bundle.directions * depth
 
             if use_bounding_box:

--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -151,7 +151,9 @@ def generate_point_cloud(
                     CONSOLE.print(f"Please set --normal_output_name to one of: {outputs.keys()}", justify="center")
                     sys.exit(1)
                 normal = outputs[normal_output_name]
-                assert torch.min(normal) >= 0.0 and torch.max(normal) <= 1.0, "Normal values from method output must be in [0, 1]"
+                assert (
+                    torch.min(normal) >= 0.0 and torch.max(normal) <= 1.0
+                ), "Normal values from method output must be in [0, 1]"
                 normal = (normal * 2.0) - 1.0
             point = ray_bundle.origins + ray_bundle.directions * depth
 


### PR DESCRIPTION
We have started using the NormalsShader for displaying normals, this shifts the normals between [0,1] which breaks the mesh export. This PR updates the exporter to assume [0,1] values.