### PR TITLE
ns-process-data: fix image renaming for the --skip-colmap case

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -48,7 +48,7 @@ import numpy as np
 import requests
 from rich.console import Console
 from rich.progress import track
-from typing_extensions import Literal, OrderedDict
+from typing_extensions import Literal
 
 from nerfstudio.process_data.process_data_utils import CameraModel
 from nerfstudio.utils.rich_utils import status
@@ -587,7 +587,7 @@ def colmap_to_json(
     output_dir: Path,
     camera_model: CameraModel,
     camera_mask_path: Optional[Path] = None,
-    image_rename_map: Optional[OrderedDict[str, str]] = None,
+    image_rename_map: Optional[Dict[str, str]] = None,
 ) -> int:
     """Converts COLMAP's cameras.bin and images.bin to a JSON file.
 

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -48,7 +48,7 @@ import numpy as np
 import requests
 from rich.console import Console
 from rich.progress import track
-from typing_extensions import Literal
+from typing_extensions import Literal, OrderedDict
 
 from nerfstudio.process_data.process_data_utils import CameraModel
 from nerfstudio.utils.rich_utils import status
@@ -587,6 +587,7 @@ def colmap_to_json(
     output_dir: Path,
     camera_model: CameraModel,
     camera_mask_path: Optional[Path] = None,
+    image_rename_map: Optional[OrderedDict[str, str]] = None,
 ) -> int:
     """Converts COLMAP's cameras.bin and images.bin to a JSON file.
 
@@ -619,7 +620,10 @@ def colmap_to_json(
         c2w = c2w[np.array([1, 0, 2, 3]), :]
         c2w[2, :] *= -1
 
-        name = Path(f"./images/{im_data.name}")
+        name = im_data.name
+        if image_rename_map is not None:
+            name = image_rename_map[name]
+        name = Path(f"./images/{name}")
 
         frame = {
             "file_path": name.as_posix(),

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -249,7 +249,7 @@ def copy_images(data: Path, image_dir: Path, verbose) -> OrderedDict[Path, Path]
         image_dir: Path to the output directory.
         verbose: If True, print extra logging.
     Returns:
-        The number of images copied.
+        The mapping from the original filenames to the new ones.
     """
     with status(msg="[bold yellow]Copying images...", spinner="bouncingBall", verbose=verbose):
         image_paths = list_images(data)

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -24,7 +24,7 @@ from typing import List, Optional, Tuple
 import cv2
 import numpy as np
 from rich.console import Console
-from typing_extensions import Literal
+from typing_extensions import Literal, OrderedDict
 
 from nerfstudio.utils.rich_utils import status
 from nerfstudio.utils.scripts import run_command
@@ -241,7 +241,7 @@ def copy_and_upscale_polycam_depth_maps_list(
     return copied_depth_map_paths
 
 
-def copy_images(data: Path, image_dir: Path, verbose) -> int:
+def copy_images(data: Path, image_dir: Path, verbose) -> OrderedDict[Path, Path]:
     """Copy images from a directory to a new directory.
 
     Args:
@@ -258,9 +258,8 @@ def copy_images(data: Path, image_dir: Path, verbose) -> int:
             CONSOLE.log("[bold red]:skull: No usable images in the data folder.")
             sys.exit(1)
 
-        num_frames = len(copy_images_list(image_paths, image_dir, verbose))
-
-    return num_frames
+        copied_images = copy_images_list(image_paths, image_dir, verbose)
+        return OrderedDict((original_path, new_path) for original_path, new_path in zip(image_paths, copied_images))
 
 
 def downscale_images(image_dir: Path, num_downscales: int, folder_name: str = "images", verbose: bool = False) -> str:

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -8,12 +8,12 @@ import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 import tyro
 from rich.console import Console
-from typing_extensions import Annotated, Literal, OrderedDict
+from typing_extensions import Annotated, Literal
 
 from nerfstudio.process_data import (
     colmap_utils,
@@ -113,7 +113,7 @@ class ProcessImages:
         install_checks.check_ffmpeg_installed()
         install_checks.check_colmap_installed()
 
-        image_rename_map: Optional[OrderedDict[str, str]] = None
+        image_rename_map: Optional[Dict[str, str]] = None
         self.output_dir.mkdir(parents=True, exist_ok=True)
         image_dir = self.output_dir / "images"
         image_dir.mkdir(parents=True, exist_ok=True)
@@ -134,7 +134,7 @@ class ProcessImages:
             image_rename_map_paths = process_data_utils.copy_images(
                 self.data, image_dir=image_dir, verbose=self.verbose
             )
-            image_rename_map = OrderedDict((a.name, b.name) for a, b in image_rename_map_paths.items())
+            image_rename_map = dict((a.name, b.name) for a, b in image_rename_map_paths.items())
             num_frames = len(image_rename_map)
             summary_log.append(f"Starting with {num_frames} images")
 

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -96,6 +96,7 @@ class ProcessImages:
 
     def main(self) -> None:
         """Process images into a nerfstudio dataset."""
+        # pylint: disable=too-many-statements
         require_cameras_exist = False
         colmap_model_path = self.output_dir / Path(self.colmap_model_path)
         if self.colmap_model_path != DEFAULT_COLMAP_PATH:


### PR DESCRIPTION
This PR (hopefuly) fixes problems introduced in #1366 and partially fixed in ( #1454 ). I am sorry for the problems introduced by the first PR.

@tancik , can you please take a look? This should fix the problems in the original PR while adding back the functionality of (--skip-colmap).