### PR TITLE
Enable viewer with eval

### DIFF
--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -69,7 +69,7 @@ class ExperimentConfig(InstantiateConfig):
         }
     )
     """Dictionary of optimizer groups and their schedulers"""
-    vis: Literal["viewer", "wandb", "tensorboard"] = "wandb"
+    vis: Literal["viewer", "wandb", "tensorboard", "viewer+wandb", "viewer+tensorboard"] = "wandb"
     """Which visualizer to use."""
     data: Optional[Path] = None
     """Alias for --pipeline.datamanager.dataparser.data"""
@@ -78,15 +78,15 @@ class ExperimentConfig(InstantiateConfig):
 
     def is_viewer_enabled(self) -> bool:
         """Checks if a viewer is enabled."""
-        return "viewer" == self.vis
+        return ("viewer" == self.vis) | ("viewer+wandb" == self.vis) | ("viewer+tensorboard" == self.vis)
 
     def is_wandb_enabled(self) -> bool:
         """Checks if wandb is enabled."""
-        return "wandb" == self.vis
+        return ("wandb" == self.vis) | ("viewer+wandb" == self.vis)
 
     def is_tensorboard_enabled(self) -> bool:
         """Checks if tensorboard is enabled."""
-        return "tensorboard" == self.vis
+        return ("tensorboard" == self.vis) | ("viewer+tensorboard" == self.vis)
 
     def set_timestamp(self) -> None:
         """Dynamically set the experiment timestamp"""

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -252,10 +252,14 @@ class Trainer:
     @check_main_thread
     def _check_viewer_warnings(self) -> None:
         """Helper to print out any warnings regarding the way the viewer/loggers are enabled"""
-        if self.config.is_viewer_enabled():
+        if (
+            self.config.is_viewer_enabled()
+            and not self.config.is_tensorboard_enabled()
+            and not self.config.is_wandb_enabled()
+        ):
             string = (
-                "[NOTE] Not running eval iterations since only viewer is enabled."
-                " Use [yellow]--vis wandb[/yellow] or [yellow]--vis tensorboard[/yellow] to run with eval instead."
+                "[NOTE] Not running eval iterations since only viewer is enabled.\n"
+                "Use [yellow]--vis {wandb, tensorboard, viewer+wandb, viewer+tensorboard}[/yellow] to run with eval."
             )
             CONSOLE.print(f"{string}")
 


### PR DESCRIPTION
Allow users to use wandb or tensorboard at the same time as the viewer.