### PR TITLE
make alpha threshold configurable

### DIFF
--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -430,6 +430,7 @@ class VolumetricSampler(Sampler):
         near_plane: float = 0.0,
         far_plane: Optional[float] = None,
         cone_angle: float = 0.0,
+        alpha_thre: float = 1e-2,
     ) -> Tuple[RaySamples, TensorType["total_samples",]]:
         """Generate ray samples in a bounding box.
 
@@ -439,6 +440,7 @@ class VolumetricSampler(Sampler):
             near_plane: Near plane for raymarching
             far_plane: Far plane for raymarching
             cone_angle: Cone angle for raymarching, set to 0 for uniform marching.
+            alpha_thre: Alpha threshold for skipping empty space.
 
         Returns:
             a tuple of (ray_samples, packed_info, ray_indices)
@@ -469,14 +471,13 @@ class VolumetricSampler(Sampler):
             t_max=t_max,
             scene_aabb=self.scene_aabb,
             grid=self.occupancy_grid,
-            # this is a workaround - using density causes crash and damage quality. should be fixed
-            sigma_fn=None,  # self.get_sigma_fn(rays_o, rays_d),
+            sigma_fn=self.get_sigma_fn(rays_o, rays_d),
             render_step_size=render_step_size,
             near_plane=near_plane,
             far_plane=far_plane,
             stratified=self.training,
             cone_angle=cone_angle,
-            alpha_thre=1e-2,
+            alpha_thre=alpha_thre,
         )
         num_samples = starts.shape[0]
         if num_samples == 0:

--- a/nerfstudio/models/instant_ngp.py
+++ b/nerfstudio/models/instant_ngp.py
@@ -73,6 +73,8 @@ class InstantNGPModelConfig(ModelConfig):
     """Contraction type used for spatial deformation of the field."""
     cone_angle: float = 0.004
     """Should be set to 0.0 for blender scenes but 1./256 for real scenes."""
+    alpha_thre: float = 1e-2
+    """Alpha threshold for skipping empty space. Should be set to 0 for blender scenes."""
     render_step_size: float = 0.01
     """Minimum step size for rendering."""
     near_plane: float = 0.05
@@ -178,6 +180,7 @@ class NGPModel(Model):
                 far_plane=self.config.far_plane,
                 render_step_size=self.config.render_step_size,
                 cone_angle=self.config.cone_angle,
+                alpha_thre=self.config.alpha_thre,
             )
 
         field_outputs = self.field(ray_samples)


### PR DESCRIPTION
As a follow-up to https://github.com/nerfstudio-project/nerfstudio/issues/1099 (I've been trying to debug differences between nerfacc's iNGP performance and that of this repo as the former gives better PSNR results), I noticed that alpha_thre is currently hardcoded to 1e-2, which causes all samples to get rejected initially when training against the blender scenes. Setting it to 0 like in the nerfacc repo seems to fix the issue