### PR TITLE
fixes for nerf synthetic dataset

### DIFF
--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -120,6 +120,8 @@ class NerfactoModelConfig(ModelConfig):
     """Whether use single jitter or not for the proposal networks."""
     predict_normals: bool = False
     """Whether to predict normals or not."""
+    disable_scene_contraction: bool = False
+    """Whether to disable scene contraction or not."""
 
 
 class NerfactoModel(Model):
@@ -134,8 +136,11 @@ class NerfactoModel(Model):
     def populate_modules(self):
         """Set the fields and modules."""
         super().populate_modules()
-
-        scene_contraction = SceneContraction(order=float("inf"))
+        
+        if self.config.disable_scene_contraction:
+            scene_contraction = None
+        else:
+            scene_contraction = SceneContraction(order=float("inf"))
 
         # Fields
         self.field = TCNNNerfactoField(

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -136,7 +136,7 @@ class NerfactoModel(Model):
     def populate_modules(self):
         """Set the fields and modules."""
         super().populate_modules()
-        
+
         if self.config.disable_scene_contraction:
             scene_contraction = None
         else:

--- a/scripts/benchmarking/launch_eval_blender.sh
+++ b/scripts/benchmarking/launch_eval_blender.sh
@@ -58,7 +58,7 @@ if [ -z "${GPU_IDX[0]+x}" ]; then
 fi
 echo "available gpus... ${GPU_IDX[*]}"
 
-DATASETS=("lego")
+DATASETS=("mic" "ficus" "chair" "hotdog" "materials" "drums" "ship" "lego")
 idx=0
 len=${#GPU_IDX[@]}
 GPU_PID=()

--- a/scripts/benchmarking/launch_eval_blender.sh
+++ b/scripts/benchmarking/launch_eval_blender.sh
@@ -58,7 +58,7 @@ if [ -z "${GPU_IDX[0]+x}" ]; then
 fi
 echo "available gpus... ${GPU_IDX[*]}"
 
-DATASETS=("mic" "ficus" "chair" "hotdog" "materials" "drums" "ship" "lego")
+DATASETS=("lego")
 idx=0
 len=${#GPU_IDX[@]}
 GPU_PID=()

--- a/scripts/benchmarking/launch_train_blender.sh
+++ b/scripts/benchmarking/launch_train_blender.sh
@@ -28,7 +28,7 @@ fi
 method_opts=()
 if [ "$method_name" = "nerfacto" ]; then
     # https://github.com/nerfstudio-project/nerfstudio/issues/806#issuecomment-1284327844
-    method_opts=(--pipeline.model.background-color white --pipeline.model.proposal-initial-sampler uniform --pipeline.model.near-plane 2. --pipeline.model.far-plane 6. --pipeline.datamanager.camera-optimizer.mode off --pipeline.model.use-average-appearance-embedding False)
+    method_opts=(--pipeline.model.background-color white --pipeline.model.proposal-initial-sampler uniform --pipeline.model.near-plane 2. --pipeline.model.far-plane 6. --pipeline.datamanager.camera-optimizer.mode off --pipeline.model.use-average-appearance-embedding False --pipeline.model.distortion-loss-mult 0 --pipeline.model.disable-scene-contraction True)
 fi
 
 shift $((OPTIND-1))


### PR DESCRIPTION
Train `nerfacto` model on the `nerf-synthetic` requires some fixes:

- disable scene contraction to the model.
- filter out samples that are outside of scene aabb. (zero density)
- disable distortion loss.

Commands to train:
``` bash
CUDA_VISIBLE_DEVICES=0 ns-train nerfacto --vis wandb --data="data/blender/lego/" --experiment-name="blender_lego" --relative-model-dir=nerfstudio_models/ --steps-per-save=0 --max-num-iterations=16500 --logging.local-writer.enable=False --logging.enable-profiler=False --pipeline.model.background-color white --pipeline.model.proposal-initial-sampler uniform --pipeline.model.near-plane 2. --pipeline.model.far-plane 6. --pipeline.datamanager.camera-optimizer.mode off --pipeline.model.use-average-appearance-embedding False --pipeline.model.distortion-loss-mult 0 --pipeline.model.disable-scene-contraction True  blender-data
```

Commands to eval:
``` bash
ns-eval --load-config="outputs/blender_lego/nerfacto/2023-02-25_213401/config.yml" --output-path="outputs/blender_lego/nerfacto/2023-02-25_213401/eval.json"
```

With this fix I get results like this:
```
{
  "experiment_name": "blender_lego",
  "method_name": "nerfacto",
  "checkpoint": "outputs/blender_lego/nerfacto/2023-02-25_213401/nerfstudio_models/step-000016499.ckpt",
  "results": {
    "psnr": 32.037696838378906,
    "ssim": 0.9637818336486816,
    "lpips": 0.02030528150498867,
    "num_rays_per_sec": 905799.5,
    "fps": 1.4153116941452026
  }
}
```

<img width="1722" alt="Screen Shot 2023-02-25 at 1 58 47 PM" src="https://user-images.githubusercontent.com/10151885/221381437-f18bbe46-34fc-415f-90bc-d62ed18d0304.png">
<img width="591" alt="Screen Shot 2023-02-25 at 2 02 26 PM" src="https://user-images.githubusercontent.com/10151885/221381529-d87d44ab-503e-440a-ae91-fb0c4d50ef63.png">

Before the fix the results are like this:
<img width="1716" alt="Screen Shot 2023-02-25 at 2 01 45 PM" src="https://user-images.githubusercontent.com/10151885/221381517-b434bb51-0c63-4faa-b698-651fcf4a9e0a.png">
<img width="585" alt="Screen Shot 2023-02-25 at 2 02 18 PM" src="https://user-images.githubusercontent.com/10151885/221381528-755be9b6-63b9-468a-926d-7e9a9a709fe9.png">

