### PR TITLE
Extending ns-render to support loop rendering using interpolated cameras

### DIFF
--- a/nerfstudio/cameras/camera_paths.py
+++ b/nerfstudio/cameras/camera_paths.py
@@ -38,7 +38,7 @@ def get_interpolated_camera_path(cameras: Cameras, steps: int) -> Cameras:
         A new set of cameras along a path.
     """
     Ks = cameras.get_intrinsics_matrices().cpu().numpy()
-    poses = cameras.camera_to_worlds().cpu().numpy()
+    poses = cameras.camera_to_worlds.cpu().numpy()
     poses, Ks = get_interpolated_poses_many(poses, Ks, steps_per_transition=steps)
 
     cameras = Cameras(fx=Ks[:, 0, 0], fy=Ks[:, 1, 1], cx=Ks[0, 0, 2], cy=Ks[0, 1, 2], camera_to_worlds=poses)

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -178,7 +178,7 @@ def get_interpolated_poses(pose_a, pose_b, steps: int = 10) -> List[float]:
         pose = np.identity(4)
         pose[:3, :3] = quaternion_matrix(quat)[:3, :3]
         pose[:3, 3] = tran
-        poses_ab.append(pose)
+        poses_ab.append(pose[:3])
     return poses_ab
 
 
@@ -215,14 +215,18 @@ def get_interpolated_poses_many(
         tuple of new poses and intrinsics
     """
     traj = []
-    Ks = []
+    k_interp = []
     for idx in range(poses.shape[0] - 1):
         pose_a = poses[idx]
         pose_b = poses[idx + 1]
         poses_ab = get_interpolated_poses(pose_a, pose_b, steps=steps_per_transition)
         traj += poses_ab
-        Ks += get_interpolated_k(Ks[idx], Ks[idx + 1], steps_per_transition)
-    return torch.stack(traj, dim=0), torch.stack(Ks, dim=0)
+        k_interp += get_interpolated_k(Ks[idx], Ks[idx + 1], steps=steps_per_transition)
+
+    traj = np.stack(traj, axis=0)
+    k_interp = np.stack(k_interp, axis=0)
+
+    return torch.tensor(traj), torch.tensor(k_interp)
 
 
 def normalize(x) -> TensorType[...]:

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -265,7 +265,7 @@ class RenderTrajectory:
     """Name of the renderer outputs to use. rgb, depth, etc. concatenates them along y axis"""
     traj: Literal["spiral", "filename", "interpolate"] = "spiral"
     """Trajectory type to render. Select between spiral-shaped trajectory, trajectory loaded from
-    a viewer-generated file and camera paths from the dataset interpolated and rendered in a loop."""
+    a viewer-generated file and interpolated camera paths from the eval dataset."""
     downscale_factor: int = 1
     """Scaling factor to apply to the camera image resolution."""
     camera_path_filename: Path = Path("camera_path.json")
@@ -276,8 +276,8 @@ class RenderTrajectory:
     """How long the video should be."""
     output_format: Literal["images", "video"] = "video"
     """How to save output data."""
-    loop_interpolation_steps: int = 10
-    """Number of interpolation steps between loop points."""
+    interpolation_steps: int = 10
+    """Number of interpolation steps between eval dataset cameras."""
     eval_num_rays_per_chunk: Optional[int] = None
     """Specifies number of rays per chunk during eval."""
 
@@ -317,7 +317,7 @@ class RenderTrajectory:
         elif self.traj == "interpolate":
             camera_type = CameraType.PERSPECTIVE
             camera_path = get_interpolated_camera_path(
-                cameras=pipeline.datamanager.eval_dataloader.cameras, steps=self.loop_interpolation_steps
+                cameras=pipeline.datamanager.eval_dataloader.cameras, steps=self.interpolation_steps
             )
         else:
             assert_never(self.traj)

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -98,7 +98,6 @@ def _render_trajectory_video(
 
         with progress:
             for camera_idx in progress.track(range(cameras.size), description=""):
-
                 aabb_box = None
                 if crop_data is not None:
                     bounding_box_min = crop_data.center - crop_data.scale / 2.0
@@ -260,7 +259,8 @@ class RenderTrajectory:
     rendered_output_names: List[str] = field(default_factory=lambda: ["rgb"])
     """Name of the renderer outputs to use. rgb, depth, etc. concatenates them along y axis"""
     traj: Literal["spiral", "filename", "loop"] = "spiral"
-    """Trajectory to render."""
+    """Trajectory type to render. Select between spiral-shaped trajectory, trajectory loaded from
+    a viewer-generated file and camera paths from the dataset interpolated and rendered in a loop."""
     downscale_factor: int = 1
     """Scaling factor to apply to the camera image resolution."""
     camera_path_filename: Path = Path("camera_path.json")
@@ -311,7 +311,9 @@ class RenderTrajectory:
             camera_path = get_path_from_json(camera_path)
         elif self.traj == "loop":
             camera_type = CameraType.PERSPECTIVE
-            camera_path = get_interpolated_camera_path(cameras=pipeline.datamanager.eval_dataloader.cameras, steps=self.loop_interpolation_steps)
+            camera_path = get_interpolated_camera_path(
+                cameras=pipeline.datamanager.eval_dataloader.cameras, steps=self.loop_interpolation_steps
+            )
         else:
             assert_never(self.traj)
 


### PR DESCRIPTION
This PR extends possibility of ns-render utility to render the data using already available camera poses. It is helpful when working with large datasets (ScanNet, ARKitScenes) as well as HPC clusters where computational nodes are not connected to the internet. 