### PR TITLE
Fix logic when using filename datasets

### DIFF
--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -96,7 +96,9 @@ class ExperimentConfig(InstantiateConfig):
     def set_experiment_name(self) -> None:
         """Dynamically set the experiment name"""
         if self.experiment_name is None:
-            self.experiment_name = str(self.pipeline.datamanager.dataparser.data).replace("../", "").replace("/", "-")
+            datapath = self.pipeline.datamanager.dataparser.data
+            datapath = datapath.parent if datapath.is_file() else datapath
+            self.experiment_name = str(datapath).replace("../", "").replace("/", "-")
 
     def get_base_dir(self) -> Path:
         """Retrieve the base directory to set relative paths"""

--- a/nerfstudio/viewer/server/viewer_utils.py
+++ b/nerfstudio/viewer/server/viewer_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=too-many-lines
+
 """Code to interface with the `vis/` (the JS viewer).
 """
 from __future__ import annotations
@@ -70,11 +72,13 @@ def get_viewer_version() -> str:
 
 
 @check_main_thread
-def setup_viewer(config: cfg.ViewerConfig, log_filename: Path, datapath: str):
+def setup_viewer(config: cfg.ViewerConfig, log_filename: Path, datapath: Path):
     """Sets up the viewer if enabled
 
     Args:
         config: the configuration to instantiate viewer
+        log_filename: the log filename to write to
+        datapath: the path to the dataset
     """
     viewer_state = ViewerState(config, log_filename=log_filename, datapath=datapath)
     banner_messages = [f"Viewer at: {viewer_state.viewer_url}"]
@@ -250,14 +254,16 @@ class ViewerState:
 
     Args:
         config: viewer setup configuration
+        log_filename: filename to log viewer output to
+        datapath: path to data
     """
 
-    def __init__(self, config: cfg.ViewerConfig, log_filename: Path, datapath: str):
+    def __init__(self, config: cfg.ViewerConfig, log_filename: Path, datapath: Path):
         self.config = config
         self.vis = None
         self.viewer_url = None
         self.log_filename = log_filename
-        self.datapath = datapath
+        self.datapath = datapath.parent if datapath.is_file() else datapath
         if self.config.launch_bridge_server:
             # start the viewer bridge server
             assert self.config.websocket_port is not None


### PR DESCRIPTION
If a users specified the dataset using `.../transforms.json` the model would train properly, but would save in the wrong place and the camera path logic would also fail. The PR strips the `transform.json` to avoid these issues.