### PR TITLE
Bug fix for SHRenderer()

### DIFF
--- a/nerfstudio/model_components/renderers.py
+++ b/nerfstudio/model_components/renderers.py
@@ -183,7 +183,7 @@ class SHRenderer(nn.Module):
         rgb = torch.sum(sh, dim=-1) + 0.5  # [..., num_samples, 3]
 
         if self.activation is not None:
-            self.activation(rgb)
+            rgb = self.activation(rgb)
 
         if not self.training:
             rgb = torch.nan_to_num(rgb)


### PR DESCRIPTION
The current SHRenderer does not apply the activation function correctly due to a typo. Now it's fixed.