### PR TITLE
Fixing data processing script when depth is not used

### DIFF
--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -415,7 +415,7 @@ class ProcessVideo:
                 )
             )
         else:
-            image_id_to_depth_path = {}
+            image_id_to_depth_path = None
 
         # Save transforms.json
         if (colmap_dir / "sparse" / "0" / "cameras.bin").exists():
@@ -558,7 +558,7 @@ class ProcessInsta360:
                 )
             )
         else:
-            image_id_to_depth_path = {}
+            image_id_to_depth_path = None
 
         # Save transforms.json
         if (colmap_dir / "sparse" / "0" / "cameras.bin").exists():


### PR DESCRIPTION
This fixes `process_data.py` for case where depth is not used. There is breaking the data processing script for colmap here https://github.com/nerfstudio-project/nerfstudio/blob/258ee26983a1985610fcb8681db403a9c1b9d2fe/nerfstudio/process_data/colmap_utils.py#L448 since `{} is not None` evaluates to True. 