### PR TITLE
Fix pose centering flag for ARKitScenes dataparser

### DIFF
--- a/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
@@ -141,7 +141,7 @@ class ARKitScenes(DataParser):
         poses = torch.from_numpy(np.stack(poses).astype(np.float32))
         intrinsics = torch.from_numpy(np.stack(intrinsics).astype(np.float32))
 
-        if self.config.scale_poses:
+        if self.config.center_poses:
             poses[:, :3, 3] -= poses[:, :3, 3].mean(dim=0)
 
         if self.config.scale_poses:


### PR DESCRIPTION
A quick fix of typo in the ARKitScenes dataparser.