### PR TITLE
Fix crash when having no eval dataset and not using the viewer

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -238,7 +238,9 @@ class Trainer:
                     writer.put_dict(name="Train Loss Dict", scalar_dict=loss_dict, step=step)
                     writer.put_dict(name="Train Metrics Dict", scalar_dict=metrics_dict, step=step)
 
-                self.eval_iteration(step)
+                # Do not perform evaluation if there are no validation images
+                if self.pipeline.datamanager.eval_dataset:
+                    self.eval_iteration(step)
 
                 if step_check(step, self.config.steps_per_save):
                     self.save_checkpoint(step)


### PR DESCRIPTION
When using WandB or TensorBoard, Nerfstudio considers that evaluation is enabled and thus crashes if the evaluation dataset is empty.

I just added a check before performing an evaluation iteration to avoid that issue.