### PR TITLE
camera_utils: add "vertical" orientation and "focus" center methods

### DIFF
--- a/docs/developer_guides/pipelines/dataparsers.md
+++ b/docs/developer_guides/pipelines/dataparsers.md
@@ -67,10 +67,16 @@ class NerfstudioDataParserConfig(DataParserConfig):
     """How much to downscale images. If not set, images are chosen such that the max dimension is <1600px."""
     scene_scale: float = 1.0
     """How much to scale the region of interest by."""
-    orientation_method: Literal["pca", "up"] = "up"
+    orientation_method: Literal["pca", "up", "vertical", "none"] = "up"
     """The method to use for orientation."""
+    center_method: Literal["poses", "focus", "none"] = "poses"
+    """The method to use to center the poses."""
+    auto_scale_poses: bool = True
+    """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
     train_split_fraction: float = 0.9
     """The fraction of images to use for training. The remaining images are for eval."""
+    depth_unit_scale_factor: float = 1e-3
+    """Scales the depth values to meters. Default value is 0.001 for a millimeter to meter conversion."""
 
 @dataclass
 class Nerfstudio(DataParser):

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -430,7 +430,9 @@ def rotation_matrix(a: TensorType[3], b: TensorType[3]) -> TensorType[3, 3]:
 
 
 def auto_orient_and_center_poses(
-    poses: TensorType["num_poses":..., 4, 4], method: Literal["pca", "up", "none"] = "up", center_poses: bool = True
+    poses: TensorType["num_poses":..., 4, 4],
+    method: Literal["pca", "up", "vertical", "none"] = "up",
+    center_method: Literal["poses", "focus", "none"] = "poses",
 ) -> Tuple[TensorType["num_poses":..., 3, 4], TensorType[4, 4]]:
     """Orients and centers the poses. We provide two methods for orientation: pca and up.
 
@@ -439,25 +441,54 @@ def auto_orient_and_center_poses(
     up: Orient the poses so that the average up vector is aligned with the z axis.
         This method works well when images are not at arbitrary angles.
 
+    There are two centering methods:
+    poses: The poses are centered around the origin.
+    focus: The origin is set to the focus of attention of all cameras (the
+        closest point to cameras optical axes).
 
     Args:
         poses: The poses to orient.
         method: The method to use for orientation.
-        center_poses: If True, the poses are centered around the origin.
+        center_method: The method to use to center the poses.
 
     Returns:
         Tuple of the oriented poses and the transform matrix.
     """
 
-    translation = poses[..., :3, 3]
+    origins = poses[..., :3, 3]
 
-    mean_translation = torch.mean(translation, dim=0)
-    translation_diff = translation - mean_translation
+    mean_origin = torch.mean(origins, dim=0)
+    translation_diff = origins - mean_origin
 
-    if center_poses:
-        translation = mean_translation
+    if center_method == "poses":
+        translation = mean_origin
+    elif center_method == "focus":
+        # https://github.com/google-research/multinerf/blob/1c8b1c552133cdb2de1c1f3c871b2813f6662265/internal/camera_utils.py#L145
+        # https://github.com/bmild/nerf/blob/18b8aebda6700ed659cb27a0c348b737a5f6ab60/load_llff.py#L197
+        active_directions = poses[:, :3, 2:3]
+        active_origins = poses[:, :3, 3:4]
+        # initial value for testing if the focus_pt is in front or behind
+        focus_pt = mean_origin
+        # Prune cameras which have the current have the focus_pt behind them.
+        active = torch.sum(active_directions.squeeze(-1) * (focus_pt - active_origins.squeeze(-1)), dim=-1) > 0
+        done = False
+        # We need at least two active cameras, else fallback on the previous solution.
+        # This may be the "poses" solution if no cameras are active on first iteration, e.g.
+        # they are in an outward-looking configuration.
+        while torch.sum(active.int()) > 1 and not done:
+            active_directions = active_directions[active]
+            active_origins = active_origins[active]
+            # https://en.wikipedia.org/wiki/Line–line_intersection#In_more_than_two_dimensions
+            m = torch.eye(3) - active_directions * torch.transpose(active_directions, -2, -1)
+            mt_m = torch.transpose(m, -2, -1) @ m
+            focus_pt = torch.linalg.inv(mt_m.mean(0)) @ (mt_m @ active_origins).mean(0)[:, 0]
+            active = torch.sum(active_directions.squeeze(-1) * (focus_pt - active_origins.squeeze(-1)), dim=-1) > 0
+            if active.all():
+                # the set of active cameras did not change, so we're done.
+                done = True
+        translation = focus_pt
     else:
-        translation = torch.zeros_like(mean_translation)
+        translation = torch.zeros_like(mean_origin)
 
     if method == "pca":
         _, eigvec = torch.linalg.eigh(translation_diff.T @ translation_diff)
@@ -471,9 +502,19 @@ def auto_orient_and_center_poses(
 
         if oriented_poses.mean(axis=0)[2, 1] < 0:
             oriented_poses[:, 1:3] = -1 * oriented_poses[:, 1:3]
-    elif method == "up":
+    elif method in ("up", "vertical"):
         up = torch.mean(poses[:, :3, 1], dim=0)
         up = up / torch.linalg.norm(up)
+        if method == "vertical":
+            # If cameras are not all parallel (e.g. not in an LLFF configuration),
+            # we can find the 3D direction that most projects vertically in all
+            # cameras by minimizing ||Xu|| s.t. ||u||=1. This total least squares
+            # problem is solved by SVD.
+            x_axis_matrix = poses[:, :3, 0]
+            _, _, Vh = torch.linalg.svd(x_axis_matrix, full_matrices=False)
+            up_vertical = Vh[2, :]
+            # It may be pointing up or down. Use "up" to disambiguate the sign.
+            up = up_vertical if torch.dot(up_vertical, up) > 0 else -up_vertical
 
         rotation = rotation_matrix(up, torch.Tensor([0, 0, 1]))
         transform = torch.cat([rotation, rotation @ -translation[..., None]], dim=-1)

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -436,13 +436,15 @@ def auto_orient_and_center_poses(
 ) -> Tuple[TensorType["num_poses":..., 3, 4], TensorType[4, 4]]:
     """Orients and centers the poses. We provide two methods for orientation: pca and up.
 
-    pca: Orient the poses so that the principal component of the points is aligned with the axes.
-        This method works well when all of the cameras are in the same plane.
+    pca: Orient the poses so that the principal directions of the camera centers are aligned
+        with the axes, Z corresponding to the smallest principal component.
+        This method works well when all of the cameras are in the same plane, for example when
+        images are taken using a mobile robot.
     up: Orient the poses so that the average up vector is aligned with the z axis.
         This method works well when images are not at arbitrary angles.
     vertical: Orient the poses so that the Z 3D direction projects close to the
         y axis in images. This method works better if cameras are not all
-        looking in the same 3D direction.
+        looking in the same 3D direction, which may happen in camera arrays or in LLFF.
 
     There are two centering methods:
     poses: The poses are centered around the origin.
@@ -515,10 +517,32 @@ def auto_orient_and_center_poses(
             # cameras by minimizing ||Xu|| s.t. ||u||=1. This total least squares
             # problem is solved by SVD.
             x_axis_matrix = poses[:, :3, 0]
-            _, _, Vh = torch.linalg.svd(x_axis_matrix, full_matrices=False)
-            up_vertical = Vh[2, :]
-            # It may be pointing up or down. Use "up" to disambiguate the sign.
-            up = up_vertical if torch.dot(up_vertical, up) > 0 else -up_vertical
+            _, S, Vh = torch.linalg.svd(x_axis_matrix, full_matrices=False)
+            # Singular values are S_i=||Xv_i|| for each right singular vector v_i.
+            # ||S|| = sqrt(n) because lines of X are all unit vectors and the v_i
+            # are an orthonormal basis.
+            # ||Xv_i|| = sqrt(sum(dot(x_axis_j,v_i)^2)), thus S_i/sqrt(n) is the
+            # RMS of cosines between x axes and v_i. If the second smallest singular
+            # value corresponds to an angle error less than 10° (cos(80°)=0.17),
+            # this is probably a degenerate camera configuration (typical values
+            # are around 5° average error for the true vertical). In this case,
+            # rather than taking the vector corresponding to the smallest singular
+            # value, we project the "up" vector on the plane spanned by the two
+            # best singular vectors. We could also just fallback to the "up"
+            # solution.
+            if S[1] > 0.17 * math.sqrt(poses.shape[0]):
+                # regular non-degenerate configuration
+                up_vertical = Vh[2, :]
+                # It may be pointing up or down. Use "up" to disambiguate the sign.
+                up = up_vertical if torch.dot(up_vertical, up) > 0 else -up_vertical
+            else:
+                # Degenerate configuration: project "up" on the plane spanned by
+                # the last two right singular vectors (which are orthogonal to the
+                # first). v_0 is a unit vector, no need to divide by its norm when
+                # projecting.
+                up = up - Vh[0, :] * torch.dot(up, Vh[0, :])
+                # re-normalize
+                up = up / torch.linalg.norm(up)
 
         rotation = rotation_matrix(up, torch.Tensor([0, 0, 1]))
         transform = torch.cat([rotation, rotation @ -translation[..., None]], dim=-1)

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -444,7 +444,8 @@ def auto_orient_and_center_poses(
     There are two centering methods:
     poses: The poses are centered around the origin.
     focus: The origin is set to the focus of attention of all cameras (the
-        closest point to cameras optical axes).
+        closest point to cameras optical axes). Recommended for inward-looking
+        camera configurations.
 
     Args:
         poses: The poses to orient.
@@ -465,7 +466,7 @@ def auto_orient_and_center_poses(
     elif center_method == "focus":
         # https://github.com/google-research/multinerf/blob/1c8b1c552133cdb2de1c1f3c871b2813f6662265/internal/camera_utils.py#L145
         # https://github.com/bmild/nerf/blob/18b8aebda6700ed659cb27a0c348b737a5f6ab60/load_llff.py#L197
-        active_directions = poses[:, :3, 2:3]
+        active_directions = -poses[:, :3, 2:3]
         active_origins = poses[:, :3, 3:4]
         # initial value for testing if the focus_pt is in front or behind
         focus_pt = mean_origin

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -440,6 +440,9 @@ def auto_orient_and_center_poses(
         This method works well when all of the cameras are in the same plane.
     up: Orient the poses so that the average up vector is aligned with the z axis.
         This method works well when images are not at arbitrary angles.
+    vertical: Orient the poses so that the Z 3D direction projects close to the
+        y axis in images. This method works better if cameras are not all
+        looking in the same 3D direction.
 
     There are two centering methods:
     poses: The poses are centered around the origin.

--- a/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 from typing_extensions import Literal
 
+from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,

--- a/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
@@ -21,6 +21,7 @@ from typing import Type
 import cv2
 import numpy as np
 import torch
+from typing_extensions import Literal
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.data.dataparsers.base_dataparser import (

--- a/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
@@ -70,11 +70,13 @@ class ARKitScenesDataParserConfig(DataParserConfig):
     """target class to instantiate"""
     data: Path = Path("data/ARKitScenes/3dod/Validation/41069021")
     """Path to ARKitScenes folder with densely extracted scenes."""
+    scale_factor: float = 1.0
+    """How much to scale the camera origins by."""
     scene_scale: float = 1.0
     """How much to scale the region of interest by."""
-    center_poses: bool = True
-    """Whether to center the poses."""
-    scale_poses: bool = True
+    center_method: Literal["poses", "focus", "none"] = "poses"
+    """The method to use to center the poses."""
+    auto_scale_poses: bool = True
     """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
     train_split_fraction: float = 0.9
     """The fraction of images to use for training. The remaining images are for eval."""
@@ -141,11 +143,19 @@ class ARKitScenes(DataParser):
         poses = torch.from_numpy(np.stack(poses).astype(np.float32))
         intrinsics = torch.from_numpy(np.stack(intrinsics).astype(np.float32))
 
-        if self.config.center_poses:
-            poses[:, :3, 3] -= poses[:, :3, 3].mean(dim=0)
+        poses, transform_matrix = camera_utils.auto_orient_and_center_poses(
+            poses,
+            method="none",
+            center_method=self.config.center_method,
+        )
 
-        if self.config.scale_poses:
-            poses[:, :3, 3] /= poses[:, :3, 3].abs().max()
+        # Scale poses
+        scale_factor = 1.0
+        if self.config.auto_scale_poses:
+            scale_factor /= float(torch.max(torch.abs(poses[:, :3, 3])))
+        scale_factor *= self.config.scale_factor
+
+        poses[:, :3, 3] *= scale_factor
 
         # Choose image_filenames and poses based on split, but after auto orient and scaling the poses.
         image_filenames = [image_filenames[i] for i in indices]
@@ -177,6 +187,8 @@ class ARKitScenes(DataParser):
             image_filenames=image_filenames,
             cameras=cameras,
             scene_box=scene_box,
+            dataparser_scale=scale_factor,
+            dataparser_transform=transform_matrix,
             metadata={
                 "depth_filenames": depth_filenames if len(depth_filenames) > 0 else None,
                 "depth_unit_scale_factor": self.config.depth_unit_scale_factor,

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -54,10 +54,10 @@ class NerfstudioDataParserConfig(DataParserConfig):
     """How much to downscale images. If not set, images are chosen such that the max dimension is <1600px."""
     scene_scale: float = 1.0
     """How much to scale the region of interest by."""
-    orientation_method: Literal["pca", "up", "none"] = "up"
+    orientation_method: Literal["pca", "up", "vertical", "none"] = "up"
     """The method to use for orientation."""
-    center_poses: bool = True
-    """Whether to center the poses."""
+    center_method: Literal["poses", "focus", "none"] = "poses" = True
+    """The method to use to center the poses."""
     auto_scale_poses: bool = True
     """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
     train_split_fraction: float = 0.9

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -56,7 +56,7 @@ class NerfstudioDataParserConfig(DataParserConfig):
     """How much to scale the region of interest by."""
     orientation_method: Literal["pca", "up", "vertical", "none"] = "up"
     """The method to use for orientation."""
-    center_method: Literal["poses", "focus", "none"] = "poses" = True
+    center_method: Literal["poses", "focus", "none"] = "poses"
     """The method to use to center the poses."""
     auto_scale_poses: bool = True
     """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
@@ -209,7 +209,7 @@ class Nerfstudio(DataParser):
         poses, transform_matrix = camera_utils.auto_orient_and_center_poses(
             poses,
             method=orientation_method,
-            center_poses=self.config.center_poses,
+            center_method=self.config.center_method,
         )
 
         # Scale poses

--- a/nerfstudio/data/dataparsers/phototourism_dataparser.py
+++ b/nerfstudio/data/dataparsers/phototourism_dataparser.py
@@ -60,12 +60,12 @@ class PhototourismDataParserConfig(DataParserConfig):
     """The fraction of images to use for training. The remaining images are for eval."""
     scene_scale: float = 1.0
     """How much to scale the region of interest by."""
-    orientation_method: Literal["pca", "up", "none"] = "up"
+    orientation_method: Literal["pca", "up", "vertical", "none"] = "up"
     """The method to use for orientation."""
+    center_method: Literal["poses", "focus", "none"] = "poses"
+    """The method to use to center the poses."""
     auto_scale_poses: bool = True
     """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
-    center_poses: bool = True
-    """Whether to center the poses."""
 
 
 @dataclass
@@ -147,7 +147,7 @@ class Phototourism(DataParser):
             raise ValueError(f"Unknown dataparser split {split}")
 
         poses, transform_matrix = camera_utils.auto_orient_and_center_poses(
-            poses, method=self.config.orientation_method, center_poses=self.config.center_poses
+            poses, method=self.config.orientation_method, center_method=self.config.center_method
         )
 
         # Scale poses

--- a/nerfstudio/data/dataparsers/scannet_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannet_dataparser.py
@@ -21,6 +21,7 @@ from typing import Type
 import cv2
 import numpy as np
 import torch
+from typing_extensions import Literal
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.data.dataparsers.base_dataparser import (

--- a/nerfstudio/data/dataparsers/scannet_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannet_dataparser.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 from typing_extensions import Literal
 
+from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
@@ -162,6 +163,8 @@ class ScanNet(DataParser):
             image_filenames=image_filenames,
             cameras=cameras,
             scene_box=scene_box,
+            dataparser_scale=scale_factor,
+            dataparser_transform=transform_matrix,
             metadata={
                 "depth_filenames": depth_filenames if len(depth_filenames) > 0 else None,
                 "depth_unit_scale_factor": self.config.depth_unit_scale_factor,

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -116,7 +116,7 @@ class SDFStudio(DataParser):
             camera_to_worlds, transform = camera_utils.auto_orient_and_center_poses(
                 camera_to_worlds,
                 method="up",
-                center_poses=False,
+                center_method="none",
             )
 
         # scene box from meta data


### PR DESCRIPTION
This PR adds a better vertical direction estimation (named "vertical"), which should work in most cases, even when cameras are in a parallel (eg LLFF) configuration (except that in this configuration cameras should be looking horizontally).
It also adds a different centering method, more appropriate for inward-looking configurations, called "focus". The previous unnamed centering method is now called "poses"

Additionally, we fixed inconsistent naming of `auto_scale_poses` as `scale_poses` is a couple of DataParserConfig. 

**Note:** The authors of this PR are @f-dy (previously known as @devernay, but I had to create another account for work-related contributions) and @gilureta .

### "vertical" orientation method

The existing orientation method, which is called "up", works by averaging the up vector (Y) of all cameras. It has issues, e.g. when cameras were mostly looking down and had an uneven distribution. However, it's still very useful when camera poses are random, for example when scanning a full room rather than a single object.

COLMAP has a [slightly different approach](https://github.com/colmap/colmap/blob/bf3e19140f491c3042bfd85b7192ef7d249808ec/src/estimators/coordinate_frame.cc#L145), but it also works from the cameras Y direction in 3D, so we expect the same failure cases as the current "up" solution:

* It tests all Y axes as potential reference axis, and count the number of inliers among the other axes. Inliers have a [cosine distance below 0.05, corresponding to 18.2°](https://github.com/colmap/colmap/blob/bf3e19140f491c3042bfd85b7192ef7d249808ec/src/estimators/coordinate_frame.h#L51)
* It takes the axis that has the [largest number of inliers](https://github.com/colmap/colmap/blob/bf3e19140f491c3042bfd85b7192ef7d249808ec/src/estimators/coordinate_frame.cc#L122), and computes the [average of the inliers](https://github.com/colmap/colmap/blob/bf3e19140f491c3042bfd85b7192ef7d249808ec/src/estimators/coordinate_frame.cc#L138) (including itself)

This "vertical" orientation method works by finding the 3D direction that is most orthogonal to the X direction of all cameras. This means that this 3D direction projects close to the Y axis of all cameras. This also means that the vanishing point corresponding to the vertical direction should project close to the Y axis. This gives us a vector that may point down instead of up, so we use the previous "up" computation to disambiguate that situation.

This works in all cases where photos are correctly oriented (also a requirement for the "up" method), and also requires *some* rotation in the camera poses, else the vertical may be any direction in the sagittal plane (the plane spanned by their Z and Y axes), which is shared by all cameras.

We detect that degeneracy: since the vertical is given as the right singular vector corresponding to the smallest singular value of a nx3 matrix, we also check the second smallest, detect the degeneracy, and resolve the ambiguity by chosing he direction within that "vertical plane" that best aligns with the previous "up" vector. This is obtained by projecting that "up" vector onto the plane. See comments in the code.

### "focus" centering method



The "focus" centering method works better than "poses" when cameras are turning around something. It works by finding the 3D intersection of the cameras optical axes. Of course 3D lines have no chance to intersect, so it finds the nearest point to these axes, as described in this [Wikipedia page](https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#In_more_than_two_dimensions). The solution is $\Theta(n)$.

This method is in Multinerf [(source)](https://github.com/google-research/multinerf/blob/1c8b1c552133cdb2de1c1f3c871b2813f6662265/internal/camera_utils.py#L145) and original NeRF [(source)](https://github.com/bmild/nerf/blob/18b8aebda6700ed659cb27a0c348b737a5f6ab60/load_llff.py#L197).

instant-ngp [(source)](https://github.com/NVlabs/instant-ngp/blob/664031a1cfeaabcce8ab4658f2104c3f1d8c5a10/scripts/record3d2nerf.py#L40) has a slightly different solution (non-optimal, but maybe more robust): it averages the pairwise intersections of all optical axes (there are $n(n-1)$ in total, making it an $\Theta(n^2)$ solution).

For better robustness, we added an additional check: we only consider the cameras that "see" the focus of attention. We simply check that the focus of attention is not behind the camera. We loop until the set of "active" cameras doesn't change. That way, if most cameras are inward-looking but a few are outward-looking, the latter will be excluded from the computation. Because we start from the "poses" solution (which is the centroid of the camera origins), it usually does only one iteration, so the solution is $\Theta(n)$ on average, but I'm pretty sure someone can design a camera configuration that leads to the worst case $\Theta(n^2)$ complexity (one camera de-activated at each iteration).

A real generic method would work from the sparse SFM reconstruction or the provided depth maps, simply computing their centroid, or a robust centroid (start from the centroid, then do IRLS with Huber weights).

COLMAP's model_aligner with alignment_type=plane centers the coordinate system [on the centroid of the reconstruction](https://github.com/colmap/colmap/blob/bf3e19140f491c3042bfd85b7192ef7d249808ec/src/exe/model.cc#L245)

### Results with previous method

Center is above the real object center, up direction is off.
![Image](https://user-images.githubusercontent.com/124616582/222332146-589b1540-cb77-4fae-8874-643a9c0db74b.jpg)
![Image](https://user-images.githubusercontent.com/124616582/222332185-edbe4640-13d6-4bb9-a113-a21326f8551c.jpg)
![Image](https://user-images.githubusercontent.com/124616582/222332225-1928a3cf-9b1f-428e-b5d6-28458ea56d0a.jpg)



### Results with proposed method

Center is at the object center, up direction is OK (only the last image was produced with the fully trained model)

![Image](https://user-images.githubusercontent.com/124616582/222332404-be50ce23-05b1-4193-a9b8-267c93b61c03.jpg)

![Image](https://user-images.githubusercontent.com/124616582/222332448-44e75a3f-4b84-47d5-b370-8a47fb296fdd.jpg)

![Image](https://user-images.githubusercontent.com/124616582/222332482-391457d2-8ecd-4212-9c29-defd180c651a.jpg)

Here's the camera path, which explains the tilted frame in the previous version:
<img width="628" alt="image" src="https://user-images.githubusercontent.com/124616582/222333887-2e961be7-9949-446e-aad5-2a9de09d1efa.png">


