### PR TITLE
scripts/exporter.py: export PLY compatible with PCL

### DIFF
--- a/scripts/exporter.py
+++ b/scripts/exporter.py
@@ -2,6 +2,8 @@
 Script for exporting NeRF into other formats.
 """
 
+# pylint: disable=no-member
+
 from __future__ import annotations
 
 import json

--- a/scripts/exporter.py
+++ b/scripts/exporter.py
@@ -94,7 +94,11 @@ class ExportPointCloud(Exporter):
 
         CONSOLE.print(f"[bold green]:white_check_mark: Generated {pcd}")
         CONSOLE.print("Saving Point Cloud...")
-        o3d.io.write_point_cloud(str(self.output_dir / "point_cloud.ply"), pcd)
+        tpcd = o3d.t.geometry.PointCloud.from_legacy(pcd)
+        # The legacy PLY writer converts colors to UInt8,
+        # let us do the same to save space.
+        tpcd.point.colors = (tpcd.point.colors * 255).to(o3d.core.Dtype.UInt8)
+        o3d.t.io.write_point_cloud(str(self.output_dir / "point_cloud.ply"), tpcd)
         print("\033[A\033[A")
         CONSOLE.print("[bold green]:white_check_mark: Saving Point Cloud")
 


### PR DESCRIPTION
Use the newer Open3D Tensor API to write pointclouds as float32, which are compatible with PCL (see https://github.com/isl-org/Open3D/issues/1633).

this also reduces the file size (almost by half)

fixes https://github.com/nerfstudio-project/nerfstudio/issues/1571