### PR TITLE
TensoRF go brrrrrrr

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -310,6 +310,8 @@ method_configs["tensorf"] = TrainerConfig(
     pipeline=VanillaPipelineConfig(
         datamanager=VanillaDataManagerConfig(
             dataparser=BlenderDataParserConfig(),
+            train_num_rays_per_batch=4096,
+            eval_num_rays_per_batch=4096,
         ),
         model=TensoRFModelConfig(),
     ),

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -118,7 +118,6 @@ class TensoRFModel(Model):
     def get_training_callbacks(
         self, training_callback_attributes: TrainingCallbackAttributes
     ) -> List[TrainingCallback]:
-
         # the callback that we want to run every X iterations after the training iteration
         def reinitialize_optimizer(
             self, training_callback_attributes: TrainingCallbackAttributes, step: int  # pylint: disable=unused-argument

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -70,8 +70,10 @@ class TensoRFModelConfig(ModelConfig):
     """specifies a list of iteration step numbers to perform upsampling"""
     loss_coefficients: Dict[str, float] = to_immutable_dict({"rgb_loss": 1.0})
     """Loss specific weights."""
-    num_samples: int = 256
+    num_samples: int = 50
     """Number of samples in field evaluation"""
+    num_uniform_samples: int = 200
+    """Number of samples in density evalutaion"""
     num_den_components: int = 16
     """Number of components in density encoding"""
     num_color_components: int = 48
@@ -219,8 +221,8 @@ class TensoRFModel(Model):
         )
 
         # samplers
-        self.sampler_uniform = UniformSampler(num_samples=self.config.num_samples, single_jitter=True)
-        self.sampler_pdf = PDFSampler(num_samples=self.config.num_samples // 2, single_jitter=True)
+        self.sampler_uniform = UniformSampler(num_samples=self.config.num_uniform_samples, single_jitter=True)
+        self.sampler_pdf = PDFSampler(num_samples=self.config.num_samples, single_jitter=True, include_original=False)
 
         # renderers
         self.renderer_rgb = RGBRenderer(background_color=colors.WHITE)

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -73,7 +73,7 @@ class TensoRFModelConfig(ModelConfig):
     num_samples: int = 50
     """Number of samples in field evaluation"""
     num_uniform_samples: int = 200
-    """Number of samples in density evalutaion"""
+    """Number of samples in density evaluation"""
     num_den_components: int = 16
     """Number of components in density encoding"""
     num_color_components: int = 48


### PR DESCRIPTION
Sampling bug fixed. ~28k rays/sec -> ~170k rays/sec. Seems like expected performance level--faster than nerfacto for me. Don't understand why tests are failing if y'all have any ideas.

![tensorf-speed-comparison](https://user-images.githubusercontent.com/26942890/225485083-a2638284-707f-4191-9ee3-1ca63cccc800.gif)
New TensoRF (left) vs. Old TensoRf (right)
