### PR TITLE
Use the run timestamp as run name on WandB

### DIFF
--- a/nerfstudio/utils/writer.py
+++ b/nerfstudio/utils/writer.py
@@ -283,7 +283,7 @@ class WandbWriter(Writer):
     """WandDB Writer Class"""
 
     def __init__(self, log_dir: Path):
-        wandb.init(project="nerfstudio-project", dir=str(log_dir), reinit=True)
+        wandb.init(project="nerfstudio-project", dir=str(log_dir), reinit=True, name=log_dir.name)
 
     def write_image(self, name: str, image: TensorType["H", "W", "C"], step: int) -> None:
         image = torch.permute(image, (2, 0, 1))


### PR DESCRIPTION
When running various experiments, using the "experiment name" is quite useful for tracking with Weights and Biases, but it quickly becomes a mess with the random names.

This small PR sets the name of each run to the timestamp of the run to more easily identify them from the website.

This way, one can easily distinguish between runs within an experiment by using custom timestamps.