### PR TITLE
Typo in nerfosr validation set

### DIFF
--- a/nerfstudio/data/dataparsers/nerfosr_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfosr_dataparser.py
@@ -89,7 +89,6 @@ def get_camera_params(scene_dir: str, split: str) -> Tuple[torch.Tensor, torch.T
         A tuple containing the intrinsic parameters (as a torch.Tensor of shape [N, 4, 4]),
         the camera-to-world matrices (as a torch.Tensor of shape [N, 4, 4]), and the number of cameras (N).
     """
-    split = "validation" if split == "val" else split
     split_dir = f"{scene_dir}/{split}"
 
     # camera parameters files
@@ -169,7 +168,7 @@ class NeRFOSR(DataParser):
 
         # get all split cam params
         intrinsics_train, camera_to_worlds_train, n_train = get_camera_params(scene_dir, "train")
-        intrinsics_val, camera_to_worlds_val, n_val = get_camera_params(scene_dir, "val")
+        intrinsics_val, camera_to_worlds_val, n_val = get_camera_params(scene_dir, "validation")
         intrinsics_test, camera_to_worlds_test, _ = get_camera_params(scene_dir, "test")
 
         # combine all cam params

--- a/nerfstudio/data/dataparsers/nerfosr_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfosr_dataparser.py
@@ -192,7 +192,7 @@ class NeRFOSR(DataParser):
         if split == "train":
             camera_to_worlds = camera_to_worlds[:n_train]
             intrinsics = intrinsics[:n_train]
-        elif split == "val":
+        elif split == "validation":
             camera_to_worlds = camera_to_worlds[n_train : n_train + n_val]
             intrinsics = intrinsics[n_train : n_train + n_val]
         elif split == "test":

--- a/nerfstudio/data/dataparsers/nerfosr_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfosr_dataparser.py
@@ -78,12 +78,14 @@ def _parse_osm_txt(filename: str):
     return np.array([float(x) for x in nums]).reshape([4, 4]).astype(np.float32)
 
 
-def get_camera_params(scene_dir: str, split: str) -> Tuple[torch.Tensor, torch.Tensor, int]:
+def get_camera_params(
+    scene_dir: str, split: Literal["train", "validation", "test"]
+) -> Tuple[torch.Tensor, torch.Tensor, int]:
     """Load camera intrinsic and extrinsic parameters for a given scene split.
 
     Args"
       scene_dir : The directory containing the scene data.
-      split : The split for which to load the camera parameters. Either "train", "validation", or "test".
+      split : The split for which to load the camera parameters.
 
     Returns
         A tuple containing the intrinsic parameters (as a torch.Tensor of shape [N, 4, 4]),

--- a/nerfstudio/data/dataparsers/nerfosr_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfosr_dataparser.py
@@ -83,7 +83,7 @@ def get_camera_params(scene_dir: str, split: str) -> Tuple[torch.Tensor, torch.T
 
     Args"
       scene_dir : The directory containing the scene data.
-      split : The split for which to load the camera parameters. Either "train", "val", or "test".
+      split : The split for which to load the camera parameters. Either "train", "validation", or "test".
 
     Returns
         A tuple containing the intrinsic parameters (as a torch.Tensor of shape [N, 4, 4]),


### PR DESCRIPTION
Fixing a typo for the nerf-osr validation set, 'split' was changed to 'validation' to match nerf-osr file structure but was checking for 'val' in the if statement.