### PR TITLE
Add depth supervision to the semantic-nerfw model

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -263,9 +263,9 @@ method_configs["semantic-nerfw"] = TrainerConfig(
     mixed_precision=True,
     pipeline=VanillaPipelineConfig(
         datamanager=SemanticDataManagerConfig(
-            dataparser=Sitcoms3DDataParserConfig(), train_num_rays_per_batch=4096, eval_num_rays_per_batch=8192
+            dataparser=NerfstudioDataParserConfig(), train_num_rays_per_batch=4096, eval_num_rays_per_batch=8192
         ),
-        model=SemanticNerfWModelConfig(eval_num_rays_per_chunk=1 << 16),
+        model=SemanticNerfWModelConfig(eval_num_rays_per_chunk=1 << 15),
     ),
     optimizers={
         "proposal_networks": {
@@ -277,7 +277,7 @@ method_configs["semantic-nerfw"] = TrainerConfig(
             "scheduler": None,
         },
     },
-    viewer=ViewerConfig(num_rays_per_chunk=1 << 16),
+    viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
     vis="viewer",
 )
 

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -32,6 +32,7 @@ from nerfstudio.data.dataparsers.base_dataparser import (
     DataParser,
     DataParserConfig,
     DataparserOutputs,
+    Semantics,
 )
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.io import load_from_json
@@ -86,6 +87,7 @@ class Nerfstudio(DataParser):
         image_filenames = []
         mask_filenames = []
         depth_filenames = []
+        semantic_filenames = []
         poses = []
         num_skipped_image_filenames = 0
 
@@ -161,6 +163,11 @@ class Nerfstudio(DataParser):
                 depth_fname = self._get_fname(depth_filepath, data_dir, downsample_folder_prefix="depths_")
                 depth_filenames.append(depth_fname)
 
+            if "semantic_file_path" in frame:
+                semantic_filepath = PurePath(frame["semantic_file_path"])
+                semantic_fname = self._get_fname(semantic_filepath, data_dir, downsample_folder_prefix="semantics_")
+                semantic_filenames.append(semantic_fname)
+
         if num_skipped_image_filenames >= 0:
             CONSOLE.log(f"Skipping {num_skipped_image_filenames} files in dataset split {split}.")
         assert (
@@ -180,6 +187,12 @@ class Nerfstudio(DataParser):
         ), """
         Different number of image and depth filenames.
         You should check that depth_file_path is specified for every frame (or zero frames) in transforms.json.
+        """
+        assert len(semantic_filenames) == 0 or (
+            len(semantic_filenames) == len(image_filenames)
+        ), """
+        Different number of image and semantic filenames.
+        You should check that semantic_file_path is specified for every frame (or zero frames) in transforms.json.
         """
 
         has_split_files_spec = any(f"{split}_filenames" in meta for split in ("train", "val", "test"))
@@ -238,6 +251,7 @@ class Nerfstudio(DataParser):
         image_filenames = [image_filenames[i] for i in indices]
         mask_filenames = [mask_filenames[i] for i in indices] if len(mask_filenames) > 0 else []
         depth_filenames = [depth_filenames[i] for i in indices] if len(depth_filenames) > 0 else []
+        semantic_filenames = [semantic_filenames[i] for i in indices] if len(semantic_filenames) > 0 else []
         poses = poses[indices]
 
         # in x,y,z order
@@ -297,6 +311,12 @@ class Nerfstudio(DataParser):
             applied_scale = float(meta["applied_scale"])
             scale_factor *= applied_scale
 
+        if len(semantic_filenames) > 0:
+            panoptic_classes = load_from_json(self.config.data / "panoptic_classes.json")
+            classes = panoptic_classes["thing"]
+            colors = torch.tensor(panoptic_classes["thing_colors"], dtype=torch.float32) / 255.0
+            semantics = Semantics(filenames=semantic_filenames, classes=classes, colors=colors, mask_classes=["void"])
+
         dataparser_outputs = DataparserOutputs(
             image_filenames=image_filenames,
             cameras=cameras,
@@ -305,6 +325,7 @@ class Nerfstudio(DataParser):
             dataparser_scale=scale_factor,
             dataparser_transform=transform_matrix,
             metadata={
+                "semantics": semantics if len(semantic_filenames) > 0 else None,
                 "depth_filenames": depth_filenames if len(depth_filenames) > 0 else None,
                 "depth_unit_scale_factor": self.config.depth_unit_scale_factor,
             },


### PR DESCRIPTION
This PR integrates depth supervision to the existing `semantic-nerfw` model.

- Added a `include_depth` flag to the `semantic-nerfw` model
- Added (optional) depth information to `SemanticDataset`
- Added `semantic_filenames` to the `nerfstudio_dataparser`
- Updated configurations for `semantic-nerfw` in `method_configs.py`

Trained the model on Replica Dataset with 2 scenes using both semantics and depth supervision, the results of rendered rgb, depth and semantics are shown below (left: groundtruth, right: rendered result)

![Screenshot 2023-03-20 at 1 45 02 PM](https://user-images.githubusercontent.com/107962411/226461771-ff198e5c-37d7-40b2-84b2-d34d0661a127.png)

![Screenshot 2023-03-20 at 1 42 57 PM](https://user-images.githubusercontent.com/107962411/226461423-1c5f43ac-c4f4-45b6-8309-9ec02abddc93.png)

![Screenshot 2023-03-20 at 1 45 12 PM](https://user-images.githubusercontent.com/107962411/226461794-f4e5a555-28de-4b20-b0a3-aadf555cfdf2.png)
