### PR TITLE
Fixed incorrect ffmpeg command construction

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -159,7 +159,9 @@ def convert_video_to_images(
             ffmpeg_cmd += f" -vf thumbnail={spacing},setpts=N/TB{crop_cmd} -r 1"
         else:
             CONSOLE.print("[bold red]Can't satisfy requested number of frames. Extracting all frames.")
-            ffmpeg_cmd += f" -pix_fmt bgr8 -vf {crop_cmd[1:]}"
+            ffmpeg_cmd += " -pix_fmt bgr8"
+            if crop_cmd != "":
+                ffmpeg_cmd += f" -vf {crop_cmd[1:]}"
 
         ffmpeg_cmd += f" {out_filename}"
         run_command(ffmpeg_cmd, verbose=verbose)


### PR DESCRIPTION
This PR is meant to fix Issue #1644.

Previously, the `-vf` arg was always added to the command regardless of whether there was a video filter to add or not. This PR changes this so that the `-vf` arg is only added if the `crop_cmd` is not empty (`""`).

Before making this change locally, I hit the error described in issue #1644. After making these changes, I have been able to run `ns-process-data video ...` as expected.