### PR TITLE
Imporve training stability for nerfacto & update pixsfm param

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -92,7 +92,8 @@ method_configs["nerfacto"] = TrainerConfig(
             train_num_rays_per_batch=4096,
             eval_num_rays_per_batch=4096,
             camera_optimizer=CameraOptimizerConfig(
-                mode="SO3xR3", optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2)
+                mode="SO3xR3", optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
+                scheduler = ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000)
             ),
         ),
         model=NerfactoModelConfig(eval_num_rays_per_chunk=1 << 15),
@@ -100,11 +101,11 @@ method_configs["nerfacto"] = TrainerConfig(
     optimizers={
         "proposal_networks": {
             "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-            "scheduler": None,
+            "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
         },
         "fields": {
             "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-            "scheduler": None,
+            "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
         },
     },
     viewer=ViewerConfig(num_rays_per_chunk=1 << 15),

--- a/nerfstudio/fields/nerfacto_field.py
+++ b/nerfstudio/fields/nerfacto_field.py
@@ -104,6 +104,7 @@ class TCNNNerfactoField(Field):
         use_pred_normals: bool = False,
         use_average_appearance_embedding: bool = False,
         spatial_distortion: SpatialDistortion = None,
+        sigmoid_geo_embeddimg: bool = False,
     ) -> None:
         super().__init__()
 
@@ -123,6 +124,7 @@ class TCNNNerfactoField(Field):
         self.use_semantics = use_semantics
         self.use_pred_normals = use_pred_normals
         self.pass_semantic_gradients = pass_semantic_gradients
+        self.sigmoid_geo_embeddimg = sigmoid_geo_embeddimg
 
         base_res: int = 16
         features_per_level: int = 2
@@ -248,7 +250,10 @@ class TCNNNerfactoField(Field):
         # from smaller internal (float16) parameters.
         density = trunc_exp(density_before_activation.to(positions))
         density = density * selector[..., None]
-        return density, base_mlp_out
+        if self.sigmoid_geo_embeddimg:
+            return density, torch.sigmoid(base_mlp_out)
+        else:
+            return density, base_mlp_out
 
     def get_outputs(
         self, ray_samples: RaySamples, density_embedding: Optional[TensorType] = None

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -128,6 +128,8 @@ class NerfactoModelConfig(ModelConfig):
     """Whether to predict normals or not."""
     disable_scene_contraction: bool = False
     """Whether to disable scene contraction or not."""
+    sigmoid_geo_embedding: bool = False
+    """add sigmoid to geometry embeddimg to prevent nan"""
 
 
 class NerfactoModel(Model):
@@ -161,6 +163,7 @@ class NerfactoModel(Model):
             num_images=self.num_train_data,
             use_pred_normals=self.config.predict_normals,
             use_average_appearance_embedding=self.config.use_average_appearance_embedding,
+            sigmoid_geo_embeddimg=self.config.sigmoid_geo_embedding,
         )
 
         self.density_fns = []

--- a/nerfstudio/process_data/hloc_utils.py
+++ b/nerfstudio/process_data/hloc_utils.py
@@ -117,7 +117,13 @@ def run_hloc(
         camera_model=camera_model.value
     )
     if refine_pixsfm:
-        sfm = PixSfM({"dense_features": {"max_edge": 1024}})
+        sfm = PixSfM(
+            conf={
+                "dense_features": {"use_cache": True},
+                "KA": {"dense_features": {"use_cache": True}, "max_kps_per_problem": 1000},
+                "BA": {"strategy": "costmaps"},
+            }
+        )
         refined, _ = sfm.reconstruction(
             sfm_dir,
             image_dir,


### PR DESCRIPTION
I found that when training nerfacto for a long time (eg. 100000 iter+), it can possibly run into nan, after looking for similar issues, I found https://github.com/nerfstudio-project/nerfstudio/issues/873, and I tried gradient clipping but it did not work, disabling camera optimization helped a little, the training can go to 200000 iter+, but ran nan sooner.

After several experiments, I found that add sigmoid to geo embedding help to prevent from nan, but will reduce the psnr a little.  Another better way is to add lr decay through the scheduler, and I do not observe psnr loss. Both ways can lead to 400000 iters training without nan.

Also, I tried logging the variables to determine who appeared nan in the first place, I found it is the mlp_head who output RGB, the vars before it were normal as usual.  I haven't looked detailed into this tcnn.Network, maybe it will help to determine potential bugs

```
rgb = self.mlp_head(h).view(*outputs_shape, -1).to(directions)
```

Also I update the pixsfm parameter, previous setting can easily run into oom.