### PR TITLE
add SO_REUSEADDR option to reuse the port in TIME-WAIT status

### DIFF
--- a/nerfstudio/viewer/server/subprocess.py
+++ b/nerfstudio/viewer/server/subprocess.py
@@ -44,6 +44,7 @@ def is_port_open(port: int):
     """
     try:
         sock = socket.socket()
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         _ = sock.bind(("", port))
         sock.close()
         return True


### PR DESCRIPTION
Hi,
The default websocket port in TIME-WAIT status will cause the port change to a random one. This pull request will fix it.