### PR TITLE
Exposed number of actual frames to extract with ffmpeg for more transparency

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -14,6 +14,7 @@
 
 """Helper utils for processing data into the nerfstudio format."""
 
+import math
 import os
 import shutil
 import sys

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -142,7 +142,7 @@ def convert_video_to_images(
         if num_frames == 0:
             CONSOLE.print(f"[bold red]Error: Video has no frames: {video_path}")
             sys.exit(1)
-        print("Number of frames in video:", num_frames)
+        CONSOLE.print("Number of frames in video:", num_frames)
 
         out_filename = image_dir / "frame_%05d.png"
         ffmpeg_cmd = f'ffmpeg -i "{video_path}"'
@@ -158,7 +158,7 @@ def convert_video_to_images(
         spacing = num_frames // num_frames_target
         if spacing > 1:
             ffmpeg_cmd += f" -vf thumbnail={spacing},setpts=N/TB{crop_cmd} -r 1"
-            print("Number of frames to extract:", math.ceil(num_frames / spacing))
+            CONSOLE.print("Number of frames to extract:", math.ceil(num_frames / spacing))
         else:
             CONSOLE.print("[bold red]Can't satisfy requested number of frames. Extracting all frames.")
             ffmpeg_cmd += " -pix_fmt bgr8"

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -157,7 +157,7 @@ def convert_video_to_images(
         spacing = num_frames // num_frames_target
         if spacing > 1:
             ffmpeg_cmd += f" -vf thumbnail={spacing},setpts=N/TB{crop_cmd} -r 1"
-            print("Number of frames to extract:", num_frames // spacing)
+            print("Number of frames to extract:", math.ceil(num_frames / spacing))
         else:
             CONSOLE.print("[bold red]Can't satisfy requested number of frames. Extracting all frames.")
             ffmpeg_cmd += " -pix_fmt bgr8"

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -157,6 +157,7 @@ def convert_video_to_images(
         spacing = num_frames // num_frames_target
         if spacing > 1:
             ffmpeg_cmd += f" -vf thumbnail={spacing},setpts=N/TB{crop_cmd} -r 1"
+            print("Number of frames to extract:", num_frames // spacing)
         else:
             CONSOLE.print("[bold red]Can't satisfy requested number of frames. Extracting all frames.")
             ffmpeg_cmd += " -pix_fmt bgr8"


### PR DESCRIPTION
In this PR, I've added a single print statement to share the number of frames to be extracted from a video during `ns-process-data video ...`.

Previously, the total number of frames in the video was printed but the actual number extracted by ffmpeg was not. This is important information for users because COLMAP runtime has a sharp increase when the number of input images is greater than 1000 (caused by switching linear solver type, [source here](https://github.com/colmap/colmap/issues/116#issuecomment-328452953)) and the `--num-frames-target` argument is approximate, meaning the actual number of frames may be larger than the specified target and cause the user to spend 24+ hours performing COLMAP instead of <4 hours.

Longer term I think the `--num-frames-target` argument should actually represent a maximum number of frames extracted, but for now just sharing this information is helpful.