### PR TITLE
Add support for torch v2.0.0

### DIFF
--- a/nerfstudio/data/utils/nerfstudio_collate.py
+++ b/nerfstudio/data/utils/nerfstudio_collate.py
@@ -23,7 +23,12 @@ from typing import Callable, Dict, Union
 
 import torch
 import torch.utils.data
-from torch._six import string_classes
+
+try:
+    from torch._six import string_classes
+except ImportError:
+    # _six deprecated in torch v2
+    string_classes = (str, bytes)
 
 from nerfstudio.cameras.cameras import Cameras
 


### PR DESCRIPTION
This PR fixes the codebase such that it works with torch 2.0.0.

However IT DOES NOT change the pip dependencies for the following reason:
     torch >= 1.13 includes functorch, installing functorch pip package breaks imports (breaks in 2.0.0).
     torch < 1.13 does not include functorch and it needs to be installed.
Do we still need to support 1.12?
