### PR TITLE
Monitor actual gpu memory allocation

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -238,6 +238,14 @@ class Trainer:
                     writer.put_scalar(name="Train Loss", scalar=loss, step=step)
                     writer.put_dict(name="Train Loss Dict", scalar_dict=loss_dict, step=step)
                     writer.put_dict(name="Train Metrics Dict", scalar_dict=metrics_dict, step=step)
+                    # The actual memory allocated by Pytorch. This is likely less than the amount
+                    # shown in nvidia-smi since some unused memory can be held by the caching
+                    # allocator and some context needs to be created on GPU. See Memory management
+                    # (https://pytorch.org/docs/stable/notes/cuda.html#cuda-memory-management)
+                    # for more details about GPU memory management.
+                    writer.put_scalar(
+                        name="GPU Memory (MB)", scalar=torch.cuda.max_memory_allocated() / (1024**2), step=step
+                    )
 
                 # Do not perform evaluation if there are no validation images
                 if self.pipeline.datamanager.eval_dataset:


### PR DESCRIPTION
PyTorch allocate GPU memory with async caching. Thus the memory reported by `nvidia-smi` is not the actual memory occupied by tensors. See [PyTorch Memory Management](https://pytorch.org/docs/stable/notes/cuda.html#cuda-memory-management) for more details. The memory for caching is counted by `nvidia-smi` but would not blocking new memory allocation as those memory are considered free memory in PyTorch.

An example: With the following diff patch to reduce the distortion parameter from 6-dim to 4-dim, would lead to 2GB memory increase reported by `nvidia-smi`, but `torch.cuda.max_memory_allocated()` reflects a slightly reduction on memory usage.

```git
diff --git a/nerfstudio/cameras/camera_utils.py b/nerfstudio/cameras/camera_utils.py
index 79490ae6..a068e8c2 100644
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -291,7 +291,8 @@ def get_distortion_params(
     Returns:
         torch.Tensor: A distortion parameters matrix.
     """
-    return torch.Tensor([k1, k2, k3, k4, p1, p2])
+    assert k3 == 0.0 and k4 == 0.0
+    return torch.Tensor([k1, k2, p1, p2])
 
 
 @torch.jit.script
@@ -319,10 +320,10 @@ def _compute_residual_and_jacobian(
 
     k1 = distortion_params[..., 0]
     k2 = distortion_params[..., 1]
-    k3 = distortion_params[..., 2]
-    k4 = distortion_params[..., 3]
-    p1 = distortion_params[..., 4]
-    p2 = distortion_params[..., 5]
+    k3 = 0.0
+    k4 = 0.0
+    p1 = distortion_params[..., 2]
+    p2 = distortion_params[..., 3]
 
```

<img width="696" alt="Screen Shot 2023-04-09 at 8 00 17 PM" src="https://user-images.githubusercontent.com/10151885/230816801-39266503-885d-4747-ab82-ed7ae00d27e7.png">
<img width="683" alt="Screen Shot 2023-04-09 at 8 00 05 PM" src="https://user-images.githubusercontent.com/10151885/230816805-45e232d7-8f0a-4c50-8c9f-2b897c74bd74.png">


