### PR TITLE
Remove useless code in camera_paths

### DIFF
--- a/nerfstudio/cameras/camera_paths.py
+++ b/nerfstudio/cameras/camera_paths.py
@@ -125,10 +125,6 @@ def get_path_from_json(camera_path: Dict[str, Any]) -> Cameras:
 
     image_height = camera_path["render_height"]
     image_width = camera_path["render_width"]
-    if "camera_type" in camera_path:
-        camera_type = camera_path["camera_type"]
-    else:
-        camera_type = "perspective"
 
     if "camera_type" not in camera_path:
         camera_type = CameraType.PERSPECTIVE

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -164,8 +164,8 @@ def quaternion_matrix(quaternion: ArrayLike) -> np.ndarray:
 def get_interpolated_poses(pose_a: ArrayLike, pose_b: ArrayLike, steps: int = 10) -> List[float]:
     """Return interpolation of poses with specified number of steps.
     Args:
-        poseA: first pose
-        poseB: second pose
+        pose_a: first pose
+        pose_b: second pose
         steps: number of steps the interpolated pose path should contain
     """
 
@@ -190,8 +190,8 @@ def get_interpolated_k(k_a, k_b, steps: int = 10) -> TensorType[3, 4]:
     Returns interpolated path between two camera poses with specified number of steps.
 
     Args:
-        KA: camera matrix 1
-        KB: camera matrix 2
+        k_a: camera matrix 1
+        k_b: camera matrix 2
         steps: number of steps the interpolated pose path should contain
     """
     Ks = []

--- a/nerfstudio/cameras/rays.py
+++ b/nerfstudio/cameras/rays.py
@@ -57,7 +57,7 @@ class Frustums(TensorDataclass):
         return pos
 
     def get_start_positions(self) -> TensorType[..., 3]:
-        """Calulates "start" position of frustum.
+        """Calculates "start" position of frustum.
 
         Returns:
             xyz positions.
@@ -193,7 +193,7 @@ class RayBundle(TensorDataclass):
     """Times at which rays are sampled"""
 
     def set_camera_indices(self, camera_index: int) -> None:
-        """Sets all of the the camera indices to a specific camera index.
+        """Sets all the camera indices to a specific camera index.
 
         Args:
             camera_index: Camera index.


### PR DESCRIPTION
The `camera_type` will be set in the following lines.