### PR TITLE
Improve viewer element types

### DIFF
--- a/docs/developer_guides/viewer/custom_gui.md
+++ b/docs/developer_guides/viewer/custom_gui.md
@@ -86,7 +86,7 @@ from nerfstudio.viewer.server.viewer_elements import *
 
 class MyModel(Model):
     def __init__(self):
-        self.a = ViewerButton(name="My Button", call_fn=self.handle_btn)
+        self.a = ViewerButton(name="My Button", cb_hook=self.handle_btn)
         self.b = ViewerNumber(name="Number", default_value=1.0)
         self.c = ViewerCheckbox(name="Checkbox", default_value=False)
         self.d = ViewerDropdown(name="Dropdown", default_value="A", options=["A", "B"])

--- a/nerfstudio/viewer/viser/__init__.py
+++ b/nerfstudio/viewer/viser/__init__.py
@@ -16,5 +16,6 @@
 # pylint: disable=useless-import-alias
 
 from .message_api import GuiHandle as GuiHandle
+from .message_api import GuiSelectHandle as GuiSelectHandle
 from .messages import NerfstudioMessage as NerfstudioMessage
 from .server import ViserServer as ViserServer

--- a/nerfstudio/viewer/viser/gui.py
+++ b/nerfstudio/viewer/viser/gui.py
@@ -180,15 +180,17 @@ class GuiSelectHandle(GuiHandle[TString], Generic[TString]):
         inferred where possible when handles are instantiated; for the most flexibility,
         we can declare handles as `GuiHandle[str]`.
         """
-        overwrite_value = False
+
+        # Make sure initial value is in options.
         self._impl.leva_conf["options"] = options
         if self._impl.leva_conf["value"] not in options:
             self._impl.leva_conf["value"] = options[0]
-            overwrite_value = True
 
+        # Update options.
         self._impl.api._queue(
             GuiSetLevaConfMessage(self._impl.name, self._impl.leva_conf),
         )
 
-        if overwrite_value:
+        # Make sure current value is in options.
+        if self.get_value() not in options:
             self.set_value(options[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "torchmetrics[image]>=0.9.3",
     "torchtyping>=0.1.4",
     "torchvision>=0.13.0",
-    "viser==0.0.2",
+    "viser>=0.0.5",
     "nuscenes-devkit>=1.1.1",
     "wandb>=0.13.3",
     "xatlas",


### PR DESCRIPTION
The main change is adding a type to the setter/getter for `.value`.

So `checkbox_element.value` will resolve to `bool`, `rgb_element.value` will resolve to `Tuple[int, int, int]`, etc.