### PR TITLE
Delete useless lists of tensors put to CUDA which may cause OOM.

### DIFF
--- a/nerfstudio/models/base_model.py
+++ b/nerfstudio/models/base_model.py
@@ -177,12 +177,12 @@ class Model(nn.Module):
             ray_bundle = camera_ray_bundle.get_row_major_sliced_ray_bundle(start_idx, end_idx)
             outputs = self.forward(ray_bundle=ray_bundle)
             for output_name, output in outputs.items():  # type: ignore
+                if not torch.is_tensor(output):
+                    # TODO: handle lists of tensors as well
+                    continue
                 outputs_lists[output_name].append(output)
         outputs = {}
         for output_name, outputs_list in outputs_lists.items():
-            if not torch.is_tensor(outputs_list[0]):
-                # TODO: handle lists of tensors as well
-                continue
             outputs[output_name] = torch.cat(outputs_list).view(image_height, image_width, -1)  # type: ignore
         return outputs
 


### PR DESCRIPTION
This part of data is not used but very big(RaySamples and weights), may cause OOM while evaluate with large images(2000*2000).