### PR TITLE
Fix divide by zero when train util set to 1

### DIFF
--- a/nerfstudio/viewer/server/viewer_state.py
+++ b/nerfstudio/viewer/server/viewer_state.py
@@ -303,11 +303,7 @@ class ViewerState:
         if self.camera_message is None:
             return
 
-        if (
-            self.trainer is not None
-            and self.trainer.is_training
-            and self.control_panel.train_util != 1
-        ):
+        if self.trainer is not None and self.trainer.is_training and self.control_panel.train_util != 1:
             if (
                 EventName.TRAIN_RAYS_PER_SEC.value in GLOBAL_BUFFER["events"]
                 and EventName.VIS_RAYS_PER_SEC.value in GLOBAL_BUFFER["events"]

--- a/nerfstudio/viewer/server/viewer_state.py
+++ b/nerfstudio/viewer/server/viewer_state.py
@@ -303,7 +303,11 @@ class ViewerState:
         if self.camera_message is None:
             return
 
-        if self.trainer is not None and self.trainer.is_training:
+        if (
+            self.trainer is not None
+            and self.trainer.is_training
+            and self.control_panel.train_util != 1
+        ):
             if (
                 EventName.TRAIN_RAYS_PER_SEC.value in GLOBAL_BUFFER["events"]
                 and EventName.VIS_RAYS_PER_SEC.value in GLOBAL_BUFFER["events"]


### PR DESCRIPTION
## Changes
- In `nerfstudio/viewer/server/viewer_state.py`, adds the condition `self.control_panel.train_util != 1` for rendering while training. This prevents crashing as a result of division by 0 when Train Util is set to `1.00` and completely halts rendering during training, which I believe is reasonable behavior.