### PR TITLE
add individual grad_scaler config

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -75,6 +75,8 @@ class TrainerConfig(ExperimentConfig):
     """Maximum number of iterations to run."""
     mixed_precision: bool = False
     """Whether or not to use mixed precision for training."""
+    use_grad_scaler: bool = False
+    """Use gradient scaler even if amp is disabled"""
     save_only_latest_checkpoint: bool = True
     """Whether to only save the latest checkpoint or all checkpoints."""
     # optional parameters if we want to resume training
@@ -118,13 +120,14 @@ class Trainer:
         self.world_size = world_size
         self.device: TORCH_DEVICE = "cpu" if world_size == 0 else f"cuda:{local_rank}"
         self.mixed_precision: bool = self.config.mixed_precision
+        self.use_grad_scaler: bool = self.mixed_precision or self.config.use_grad_scaler
         self.is_training: bool = True
         if self.device == "cpu":
             self.mixed_precision = False
             CONSOLE.print("Mixed precision is disabled for CPU training.")
         self._start_step: int = 0
         # optimizers
-        self.grad_scaler = GradScaler(enabled=self.mixed_precision)
+        self.grad_scaler = GradScaler(enabled=self.use_grad_scaler)
 
         self.base_dir: Path = config.get_base_dir()
         # directory to save checkpoints

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -76,7 +76,7 @@ class TrainerConfig(ExperimentConfig):
     mixed_precision: bool = False
     """Whether or not to use mixed precision for training."""
     use_grad_scaler: bool = False
-    """Use gradient scaler even if the automatic mixed precision is disabled (i.e. mixed_precision=False)"""
+    """Use gradient scaler even if the automatic mixed precision is disabled."""
     save_only_latest_checkpoint: bool = True
     """Whether to only save the latest checkpoint or all checkpoints."""
     # optional parameters if we want to resume training
@@ -121,7 +121,6 @@ class Trainer:
         self.device: TORCH_DEVICE = "cpu" if world_size == 0 else f"cuda:{local_rank}"
         self.mixed_precision: bool = self.config.mixed_precision
         self.use_grad_scaler: bool = self.mixed_precision or self.config.use_grad_scaler
-        self.is_training: bool = True
         self.training_state: Literal["training", "paused", "completed"] = "training"
 
         if self.device == "cpu":

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -76,7 +76,7 @@ class TrainerConfig(ExperimentConfig):
     mixed_precision: bool = False
     """Whether or not to use mixed precision for training."""
     use_grad_scaler: bool = False
-    """Use gradient scaler even if amp is disabled"""
+    """Use gradient scaler even if the automatic mixed precision is disabled (i.e. mixed_precision=False)"""
     save_only_latest_checkpoint: bool = True
     """Whether to only save the latest checkpoint or all checkpoints."""
     # optional parameters if we want to resume training


### PR DESCRIPTION
I am adding a nerfstudio implementation of the neural scene graph paper, and I tried to use separate nerf(nerfacto) models to represent the background and each foreground object, respectively. However, training such a complex model easily runs into nan issues at early iterations (~3K steps, which is obviously different from the ones in #873). The issue is solved by using grad_scaler only (w/o using amp).
