### PR TITLE
Set data path to launch viewer for DreamFusion

### DIFF
--- a/scripts/viewer/run_viewer.py
+++ b/scripts/viewer/run_viewer.py
@@ -63,16 +63,13 @@ class RunViewer:
         viewer_log_path = base_dir / config.viewer.relative_log_filename
 
         # NOTE: for generative pipeline(s), set the data path on-the-fly.
-        if pipeline.config.generative:
-            assert pipeline.datamanager.get_datapath() is None
-            CONSOLE.print(f"Generative models should not have data path. Setting it to {str(base_dir)}")
-            viewer_state, banner_messages = viewer_utils.setup_viewer(
-                config.viewer, log_filename=viewer_log_path, datapath=base_dir
-            )
-        else:
-            viewer_state, banner_messages = viewer_utils.setup_viewer(
-                config.viewer, log_filename=viewer_log_path, datapath=pipeline.datamanager.get_datapath()
-            )
+        viewer_state, banner_messages = viewer_utils.setup_viewer(
+            config.viewer,
+            log_filename=viewer_log_path,
+            datapath=pipeline.datamanager.get_datapath()
+            if pipeline.datamanager.get_datapath() is not None
+            else base_dir,
+        )
 
         # We don't need logging, but writer.GLOBAL_BUFFER needs to be populated
         config.logging.local_writer.enable = False

--- a/scripts/viewer/run_viewer.py
+++ b/scripts/viewer/run_viewer.py
@@ -62,18 +62,15 @@ class RunViewer:
         base_dir = config.get_base_dir()
         viewer_log_path = base_dir / config.viewer.relative_log_filename
 
-        if pipeline.datamanager.get_datapath() is None:
-            viewer_state, banner_messages = viewer_utils.setup_viewer(
-                config.viewer,
-                log_filename=viewer_log_path,
-                datapath=base_dir,
-            )
-        else:
-            viewer_state, banner_messages = viewer_utils.setup_viewer(
-                config.viewer,
-                log_filename=viewer_log_path,
-                datapath=pipeline.datamanager.get_datapath(),
-            )
+        datapath = pipeline.datamanager.get_datapath()
+        if datapath is None:
+            datapath = base_dir
+
+        viewer_state, banner_messages = viewer_utils.setup_viewer(
+            config.viewer,
+            log_filename=viewer_log_path,
+            datapath=datapath,
+        )
 
         # We don't need logging, but writer.GLOBAL_BUFFER needs to be populated
         config.logging.local_writer.enable = False

--- a/scripts/viewer/run_viewer.py
+++ b/scripts/viewer/run_viewer.py
@@ -62,14 +62,18 @@ class RunViewer:
         base_dir = config.get_base_dir()
         viewer_log_path = base_dir / config.viewer.relative_log_filename
 
-        # NOTE: for generative pipeline(s), set the data path on-the-fly.
-        viewer_state, banner_messages = viewer_utils.setup_viewer(
-            config.viewer,
-            log_filename=viewer_log_path,
-            datapath=pipeline.datamanager.get_datapath()
-            if pipeline.datamanager.get_datapath() is not None
-            else base_dir,
-        )
+        if pipeline.datamanager.get_datapath() is None:
+            viewer_state, banner_messages = viewer_utils.setup_viewer(
+                config.viewer,
+                log_filename=viewer_log_path,
+                datapath=base_dir,
+            )
+        else:
+            viewer_state, banner_messages = viewer_utils.setup_viewer(
+                config.viewer,
+                log_filename=viewer_log_path,
+                datapath=pipeline.datamanager.get_datapath(),
+            )
 
         # We don't need logging, but writer.GLOBAL_BUFFER needs to be populated
         config.logging.local_writer.enable = False

--- a/scripts/viewer/run_viewer.py
+++ b/scripts/viewer/run_viewer.py
@@ -65,9 +65,7 @@ class RunViewer:
         # NOTE: for generative pipeline(s), set the data path on-the-fly.
         if pipeline.config.generative:
             assert pipeline.datamanager.get_datapath() is None
-            CONSOLE.print(
-                f"Generative models should not have data path. Setting it to {str(base_dir)}"
-            )
+            CONSOLE.print(f"Generative models should not have data path. Setting it to {str(base_dir)}")
             viewer_state, banner_messages = viewer_utils.setup_viewer(
                 config.viewer, log_filename=viewer_log_path, datapath=base_dir
             )

--- a/scripts/viewer/run_viewer.py
+++ b/scripts/viewer/run_viewer.py
@@ -61,9 +61,20 @@ class RunViewer:
     def _start_viewer(self, config: TrainerConfig, pipeline: Pipeline):
         base_dir = config.get_base_dir()
         viewer_log_path = base_dir / config.viewer.relative_log_filename
-        viewer_state, banner_messages = viewer_utils.setup_viewer(
-            config.viewer, log_filename=viewer_log_path, datapath=pipeline.datamanager.get_datapath()
-        )
+
+        # NOTE: for generative pipeline(s), set the data path on-the-fly.
+        if pipeline.config.generative:
+            assert pipeline.datamanager.get_datapath() is None
+            CONSOLE.print(
+                f"Generative models should not have data path. Setting it to {str(base_dir)}"
+            )
+            viewer_state, banner_messages = viewer_utils.setup_viewer(
+                config.viewer, log_filename=viewer_log_path, datapath=base_dir
+            )
+        else:
+            viewer_state, banner_messages = viewer_utils.setup_viewer(
+                config.viewer, log_filename=viewer_log_path, datapath=pipeline.datamanager.get_datapath()
+            )
 
         # We don't need logging, but writer.GLOBAL_BUFFER needs to be populated
         config.logging.local_writer.enable = False


### PR DESCRIPTION
The script _run_viewer.py_ crashes when it is provided a config for a pre-trained DreamFusion model.

It is because of _None_ passed to function _viewer_utils.setup_viewer_ via parameter _datapath_,  since generative models (i.e., DreamFusion) are trained without real images.

This commit modifies the code to distinguish _generative_ model from the other.