### PR TITLE
Configurable ip address

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -137,6 +137,8 @@ class ViewerConfig(PrintableConfig):
     """The websocket port to connect to. If None, find an available port."""
     websocket_port_default: int = 7007
     """The default websocket port to connect to if websocket_port is not specified"""
+    ip_address: str = "0.0.0.0"
+    """The IP address to bind to."""
     num_rays_per_chunk: int = 32768
     """number of rays per chunk to render with viewer"""
     max_num_display_images: int = 512

--- a/nerfstudio/viewer/server/viewer_state.py
+++ b/nerfstudio/viewer/server/viewer_state.py
@@ -122,7 +122,7 @@ class ViewerState:
 
         self.camera_message = None
 
-        self.viser_server = ViserServer(host="127.0.0.1", port=websocket_port)
+        self.viser_server = ViserServer(host=config.ip_address, port=websocket_port)
 
         self.viser_server.register_handler(TrainingStateMessage, self._handle_training_state_message)
         self.viser_server.register_handler(SaveCheckpointMessage, self._handle_save_checkpoint)


### PR DESCRIPTION
Change default address back to `0.0.0.0` to match nerfstudio functionality pre #1702 and allow users to specify custom addresses. 