### PR TITLE
Use current host in landing page

### DIFF
--- a/nerfstudio/viewer/app/src/modules/WebSocketUrlField.jsx
+++ b/nerfstudio/viewer/app/src/modules/WebSocketUrlField.jsx
@@ -29,6 +29,8 @@ export default function WebSocketUrlField() {
     }
   };
 
+  const currentHost = `${window.location.protocol}//${window.location.host}`;
+
   return (
     <div>
       <TextField
@@ -42,7 +44,7 @@ export default function WebSocketUrlField() {
         helperText={testWebSocket(websocket_url) ? 'Invalid websocket URL' : ''}
       />
       <Link href={`/?websocket_url=${websocket_url}`}>
-        viewer.nerf.studio?websocket_url={websocket_url}
+        {currentHost}?websocket_url={websocket_url}
       </Link>
     </div>
   );


### PR DESCRIPTION
When running locally, and not specifying websocket URL, the landing modal showed a hardcoded viewer.nerf.studio link that will take the user away from local viewer.

This PR uses current protocol and host to fix that issue.