### PR TITLE
fix_mask

### DIFF
--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -96,6 +96,7 @@ class PixelSampler:  # pylint: disable=too-few-public-methods
             indices = self.sample_method(num_rays_per_batch, num_images, image_height, image_width, device=device)
 
         c, y, x = (i.flatten() for i in torch.split(indices, 1, dim=-1))
+        c, y, x = c.cpu(), y.cpu(), x.cpu()
         collated_batch = {
             key: value[c, y, x] for key, value in batch.items() if key != "image_idx" and value is not None
         }


### PR DESCRIPTION
Using masks to avoid sampling pixels on masked areas take times, so we should put masks to CUDA.
But this can lead to using indices on CUDA to query image pixels on CPU. 
Instead of putting all the images to CUDA, transform the indices tensor to CPU is more efficient. 