### PR TITLE
[WIP] PyTorch 2.0 and torch.compile support

### DIFF
--- a/nerfstudio/engine/schedulers.py
+++ b/nerfstudio/engine/schedulers.py
@@ -109,7 +109,7 @@ class ExponentialDecayScheduler(Scheduler):
 
     config: ExponentialDecaySchedulerConfig
 
-    def get_scheduler(self, optimizer: Optimizer, lr_init: float) -> lr_scheduler._LRScheduler:
+    def get_scheduler(self, optimizer: Optimizer, lr_init: float) -> lr_scheduler.LRScheduler:
         if self.config.lr_final is None:
             lr_final = lr_init
         else:
@@ -156,7 +156,7 @@ class CosineDecayScheduler(Scheduler):
 
     config: CosineDecaySchedulerConfig
 
-    def get_scheduler(self, optimizer: Optimizer, lr_init: float) -> lr_scheduler._LRScheduler:
+    def get_scheduler(self, optimizer: Optimizer, lr_init: float) -> lr_scheduler.LRScheduler:
         def func(step):
             if step < self.config.warm_up_end:
                 learning_factor = step / self.config.warm_up_end

--- a/nerfstudio/field_components/spatial_distortions.py
+++ b/nerfstudio/field_components/spatial_distortions.py
@@ -17,8 +17,8 @@
 from typing import Optional, Union
 
 import torch
-from functorch import jacrev, vmap
 from torch import nn
+from torch.func import jacrev, vmap
 from torchtyping import TensorType
 
 from nerfstudio.utils.math import Gaussians

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -571,7 +571,7 @@ class ProposalNetworkSampler(Sampler):
         n = self.num_proposal_network_iterations
         weights = None
         ray_samples = None
-        updated = self._steps_since_update > self.update_sched(self._step) or self._step < 10
+        updated = self._steps_since_update >= self.update_sched(self._step) or self._step < 10
         for i_level in range(n + 1):
             is_prop = i_level < n
             num_samples = self.num_proposal_samples_per_ray[i_level] if is_prop else self.num_nerf_samples_per_ray

--- a/nerfstudio/models/base_model.py
+++ b/nerfstudio/models/base_model.py
@@ -51,6 +51,12 @@ class ModelConfig(InstantiateConfig):
     eval_num_rays_per_chunk: int = 4096
     """specifies number of rays per chunk during eval"""
 
+    def setup(self, **kwargs) -> Any:
+        """Returns the instantiated object using the config."""
+        model = self._target(self, **kwargs)
+        torch.compile(model)
+        return model
+
 
 class Model(nn.Module):
     """Model class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ ns-dev-sync-viser-message-defs = "scripts.viewer.sync_viser_message_defs:entrypo
 [options]
 # equivalent to using --extra-index-url with pip, which is needed for specifying the CUDA version torch and torchvision
 dependency_links = [
-    "https://download.pytorch.org/whl/cu113"
+    "https://download.pytorch.org/whl/cu117"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "rich>=12.5.1",
     "scikit-image>=0.19.3",
     "tensorboard==2.9.0",
-    "torch>=1.12.1,<2.0.0",
+    "torch==2.0.0",
     "torchmetrics[image]>=0.9.3",
     "torchtyping>=0.1.4",
     "torchvision>=0.13.0",


### PR DESCRIPTION
I'm looking into supporting PyTorch >=2.0 to see if the new compiler has any potential speedups - I've found what I think is the root cause of the bug preventing previous upgrade attempts and am seeking advice on the right fix. 

A naive upgrade leads to the same inf checking error in #1610. I believe I've narrowed down the bug to [this line in ray_samplers.py](https://github.com/nerfstudio-project/nerfstudio/blob/3f43e0d4c3885e51f3201cb72fc4cdb262466a29/nerfstudio/model_components/ray_samplers.py#L574), where after the tenth step, pytorch will no longer calculate gradients for the proposal networks, leading to the error. 

My current commit here avoids the error and continues to train by changing `self._steps_since_update > self.update_sched(self._step)` to `self._steps_since_update >= self.update_sched(self._step)` - for the example nerfacto poster command, this clause formerly always resolved to false (1 < 1). I don't know enough about pytorch's inf checks, why the updated flag is the way it currently is in ray_samplers.py, or why upgrading to 2.0 broke this line's usefulness to know if this is a proper solution, however I think it's a start if anyone would like to contribute. 