### PR TITLE
fix video paths

### DIFF
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -181,7 +181,7 @@ def get_interpolated_poses(pose_a: ArrayLike, pose_b: ArrayLike, steps: int = 10
         pose = np.identity(4)
         pose[:3, :3] = quaternion_matrix(quat)[:3, :3]
         pose[:3, 3] = tran
-        poses_ab.append(pose[:3])
+        poses_ab.append(pose)
     return poses_ab
 
 


### PR DESCRIPTION
Fixed an issue where creating a custom camera path in the Viewer to create an mp4 would produce incorrect results.