### PR TITLE
Reduce the GPU memory required in viewer for NGP methods

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -247,7 +247,7 @@ method_configs["instant-ngp"] = TrainerConfig(
             "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
         }
     },
-    viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
+    viewer=ViewerConfig(num_rays_per_chunk=1 << 12),
     vis="viewer",
 )
 
@@ -265,7 +265,6 @@ method_configs["instant-ngp-bounded"] = TrainerConfig(
             grid_levels=1,
             alpha_thre=0.0,
             cone_angle=0.0,
-            render_step_size=0.001,
             disable_scene_contraction=True,
             near_plane=0.01,
             background_color="black",
@@ -277,7 +276,7 @@ method_configs["instant-ngp-bounded"] = TrainerConfig(
             "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
         }
     },
-    viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
+    viewer=ViewerConfig(num_rays_per_chunk=1 << 12),
     vis="viewer",
 )
 


### PR DESCRIPTION
Fix the issue #1835:

- change the default `viewer.num_rays_per_chunk` from `1 << 15` to `1 << 12`.
- remove the `render_step_size=0.001` for `instant-ngp-bounded` so that it is automatically calculated based on the scene aabb (target on roughly 1000 samples). Preset `render_step_size` would lead to tons of samples if the scene aabb is large (or in different unit).