### PR TITLE
Support equirectangular sensor with metashape

### DIFF
--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -259,6 +259,18 @@ ns-train nerfacto --data {output directory}
 
 ## Metashape
 
+All images must use the same sensor type. If the images are using an equirectangular/spherical sensor, first convert those to
+planar projections using:
+```bash
+ns-process-data images --camera-type equirectangular --data {data directory} --output-dir {output directory} \
+  --skip-colmap --skip-image-processing 
+```
+
+This will create `{data directory}/planar_projections`, containing planar projections of the equirectangular images.
+In the following (including aligning images using Metashape), only use images from that directory, i.e. use
+`{data directory}/planar_projections` as the `{data_directory}`.  See the section on processing equirectangular images
+for other useful options, such as `--images-per-equirect {8, or 14}`.
+
 1. Align your images using Metashape. `File -> Workflow -> Align Photos...`
 
 ```{image} https://user-images.githubusercontent.com/3310961/203389662-12760210-2b52-49d4-ab21-4f23bfa4a2b3.png
@@ -280,6 +292,8 @@ ns-train nerfacto --data {output directory}
 ```bash
 ns-process-data metashape --data {data directory} --xml {xml file} --output-dir {output directory}
 ```
+
+Add `--max-dataset-size -1` to use all images from the dataset, especially if using equiractangular images, which generate 8x or 14x more planar projections.
 
 4. Train with nerfstudio!
 

--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -259,17 +259,7 @@ ns-train nerfacto --data {output directory}
 
 ## Metashape
 
-All images must use the same sensor type. If the images are using an equirectangular/spherical sensor, first convert those to
-planar projections using:
-```bash
-ns-process-data images --camera-type equirectangular --data {data directory} --output-dir {output directory} \
-  --skip-colmap --skip-image-processing 
-```
-
-This will create `{data directory}/planar_projections`, containing planar projections of the equirectangular images.
-In the following (including aligning images using Metashape), only use images from that directory, i.e. use
-`{data directory}/planar_projections` as the `{data_directory}`.  See the section on processing equirectangular images
-for other useful options, such as `--images-per-equirect {8, or 14}`.
+All images must use the same sensor type (but multiple sensors are supported).
 
 1. Align your images using Metashape. `File -> Workflow -> Align Photos...`
 

--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -283,8 +283,6 @@ All images must use the same sensor type (but multiple sensors are supported).
 ns-process-data metashape --data {data directory} --xml {xml file} --output-dir {output directory}
 ```
 
-Add `--max-dataset-size -1` to use all images from the dataset, especially if using equiractangular images, which generate 8x or 14x more planar projections.
-
 4. Train with nerfstudio!
 
 ```bash

--- a/nerfstudio/process_data/images_to_nerstudio_dataset.py
+++ b/nerfstudio/process_data/images_to_nerstudio_dataset.py
@@ -56,6 +56,7 @@ class ImagesToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
             self.data = equirect_utils.generate_planar_projections_from_equirectangular(
                 self.data, pers_size, self.images_per_equirect, crop_factor=self.crop_factor
             )
+            self.camera_type = "perspective"
 
         summary_log = []
 

--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -61,19 +61,19 @@ def metashape_to_json(  # pylint: disable=too-many-statements
     if sensors is None:
         raise ValueError("No sensors found")
 
-    calibrated_sensors = [sensor for sensor in sensors if sensor.find("calibration")]
+    calibrated_sensors = [sensor for sensor in sensors if sensor.get("type") == "spherical" or sensor.find("calibration")]
     if not calibrated_sensors:
         raise ValueError("No calibrated sensor found in Metashape XML")
     sensor_type = [s.get("type") for s in calibrated_sensors]
     if sensor_type.count(sensor_type[0]) != len(sensor_type):
-        raise ValueError("All Metashape sensors do not have the same sensor type")
+        raise ValueError("All Metashape sensors do not have the same sensor type. nerfstudio does not support per-frame camera_model.")
     data = {}
     if sensor_type[0] == "frame":
         data["camera_model"] = CAMERA_MODELS["perspective"].value
     elif sensor_type[0] == "fisheye":
         data["camera_model"] = CAMERA_MODELS["fisheye"].value
     elif sensor_type[0] == "spherical":
-        data["camera_model"] = CAMERA_MODELS["equirectangular"].value
+        raise ValueError("Spherical/equirectangular sensor not supported. Generate planar projections first, see documentation.")
     else:
         # Cylindrical and RPC sensor types are not supported
         raise ValueError(f"Unsupported Metashape sensor type '{sensor_type[0]}'")

--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -61,12 +61,17 @@ def metashape_to_json(  # pylint: disable=too-many-statements
     if sensors is None:
         raise ValueError("No sensors found")
 
-    calibrated_sensors = [sensor for sensor in sensors if sensor.get("type") == "spherical" or sensor.find("calibration")]
+    calibrated_sensors = [
+        sensor for sensor in sensors if sensor.get("type") == "spherical" or sensor.find("calibration")
+    ]
     if not calibrated_sensors:
         raise ValueError("No calibrated sensor found in Metashape XML")
     sensor_type = [s.get("type") for s in calibrated_sensors]
     if sensor_type.count(sensor_type[0]) != len(sensor_type):
-        raise ValueError("All Metashape sensors do not have the same sensor type. nerfstudio does not support per-frame camera_model.")
+        raise ValueError(
+            "All Metashape sensors do not have the same sensor type. "
+            "nerfstudio does not support per-frame camera_model."
+        )
     data = {}
     if sensor_type[0] == "frame":
         data["camera_model"] = CAMERA_MODELS["perspective"].value

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -39,12 +39,13 @@ class CameraModel(Enum):
 
     OPENCV = "OPENCV"
     OPENCV_FISHEYE = "OPENCV_FISHEYE"
+    EQUIRECTANGULAR = "EQUIRECTANGULAR"
 
 
 CAMERA_MODELS = {
     "perspective": CameraModel.OPENCV,
     "fisheye": CameraModel.OPENCV_FISHEYE,
-    "equirectangular": CameraModel.OPENCV,
+    "equirectangular": CameraModel.EQUIRECTANGULAR,
 }
 
 

--- a/nerfstudio/process_data/video_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/video_to_nerfstudio_dataset.py
@@ -91,6 +91,8 @@ class VideoToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
             # remove the temp_images folder
             shutil.rmtree(self.output_dir / "temp_images", ignore_errors=True)
 
+            self.camera_type = "perspective"
+
         # # Create mask
         mask_path = process_data_utils.save_mask(
             image_dir=self.image_dir,


### PR DESCRIPTION
fixes https://github.com/nerfstudio-project/nerfstudio/issues/1634 (see sample runs in that issue)

The COLMAP logic had to be changed slightly, as mentioned here: https://github.com/nerfstudio-project/nerfstudio/issues/1634#issuecomment-1529152231 : after computing the planar projections, the ns-process-data scripts now set the camera type to perspective (which makes sense, since all the rest of the processing is on perspective cameras).