### PR TITLE
Revive the INTERSECT_WITH_NERFACC environment variable

### DIFF
--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -17,7 +17,6 @@ Camera Models
 """
 import base64
 import math
-import os
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Dict, List, Optional, Tuple, Union
@@ -33,7 +32,6 @@ import nerfstudio.utils.poses as pose_utils
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.data.scene_box import SceneBox
-from nerfstudio.utils.misc import strtobool
 from nerfstudio.utils.tensor_dataclass import TensorDataclass
 
 TORCH_DEVICE = Union[torch.device, str]  # pylint: disable=invalid-name
@@ -149,8 +147,6 @@ class Cameras(TensorDataclass):
         self.metadata = metadata
 
         self.__post_init__()  # This will do the dataclass post_init and broadcast all the tensors
-
-        self._use_nerfacc = strtobool(os.environ.get("INTERSECT_WITH_NERFACC", "TRUE"))
 
     def _init_get_fc_xy(self, fc_xy: Union[float, torch.Tensor], name: str) -> torch.Tensor:
         """

--- a/nerfstudio/utils/math.py
+++ b/nerfstudio/utils/math.py
@@ -14,6 +14,7 @@
 
 """ Math Helper Functions """
 
+import os
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -21,7 +22,9 @@ import torch
 from torchtyping import TensorType
 from typing_extensions import Literal
 
-_USE_NERFACC = True
+from nerfstudio.utils.misc import strtobool
+
+_USE_NERFACC = strtobool(os.environ.get("INTERSECT_WITH_NERFACC", "TRUE"))
 
 
 def components_from_spherical_harmonics(levels: int, directions: TensorType[..., 3]) -> TensorType[..., "components"]:


### PR DESCRIPTION
Setting Crop stops the Viewer from updating images.
In my environment, nerfacc.ray_aabb_intersect does not seem to return.

When I operate it in a specific procedure in the viewer, an IOChangeException occurs and _USE_NERFACC=False,
After that, nerfacc.ray_aabb_intersect is not called, so it can be used without problems.
If IOChangeException does not occur, nerfacc.ray_aabb_intersect will not return for a long time, and the viewer image will stop updating.
cause of the inconvenience, the environment variable INTERSECT_WITH_NERFACC has been restored.


Procedure:
a-1. start the viewer from the command line
a-2. open the viewer URL in a browser
a-3. check the Crop checkbox → this will call nerfacc.ray_aabb_intersect and stop it
a-4. dragging a scene does not update the image

Continue further,
b-1. uncheck the Crop checkbox
b-2. stop the viewer from the command line with Ctrl-C and run it again. Wait a little until it finishes loading.
b-3. Reload the open viewer in the browser.
b-4. check the Crop checkbox -> nerfacc.ray_aabb_intersect is called and stops
b-5. dragging a scene raises IOChangeException, which interrupts the call of nerfacc.ray_aabb_intersect in a-3
b-6. the loop starts spinning and _USE_NERFACC=False, so the image is not updated after that.


I do not know why it does not return from nerfacc.ray_aabb_intersect.
