### PR TITLE
implementing l1 and tv reg in the original tensorf paper

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -359,7 +359,9 @@ method_configs["tensorf"] = TrainerConfig(
             train_num_rays_per_batch=4096,
             eval_num_rays_per_batch=4096,
         ),
-        model=TensoRFModelConfig(),
+        model=TensoRFModelConfig(
+            regularization="tv",
+        ),
     ),
     optimizers={
         "fields": {

--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -485,3 +485,17 @@ class ScaleAndShiftInvariantLoss(nn.Module):
         return self.__prediction_ssi
 
     prediction_ssi = property(__get_prediction_ssi)
+
+def tv_loss(grids: TensorType["grids", "feature_dim", "row", "column"]):
+    """
+    https://github.com/apchenstu/TensoRF/blob/4ec894dc1341a2201fe13ae428631b58458f105d/utils.py#L139
+    
+    Implemation of total variation loss for explicit grids
+    """
+    number_of_grids = grids.shape[0]
+    h_tv_count = grids[:,:,1:,:].shape[1] * grids[:,:,1:,:].shape[2] * grids[:,:,1:,:].shape[3]
+    w_tv_count = grids[:,:,:,1:].shape[1] * grids[:,:,:,1:].shape[2] * grids[:,:,:,1:].shape[3]
+    h_tv = torch.pow((grids[:,:,1:,:] - grids[:,:,:-1,:]),2).sum()
+    w_tv = torch.pow((grids[:,:,:,1:] - grids[:,:,:,:-1]),2).sum()
+    return 2 * (h_tv/h_tv_count + w_tv/w_tv_count) / number_of_grids
+

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -44,7 +44,7 @@ from nerfstudio.field_components.encodings import (
 )
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.fields.tensorf_field import TensoRFField
-from nerfstudio.model_components.losses import MSELoss
+from nerfstudio.model_components.losses import MSELoss, tv_loss
 from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
 from nerfstudio.model_components.renderers import (
     AccumulationRenderer,
@@ -68,7 +68,10 @@ class TensoRFModelConfig(ModelConfig):
     """final render resolution"""
     upsampling_iters: Tuple[int, ...] = (2000, 3000, 4000, 5500, 7000)
     """specifies a list of iteration step numbers to perform upsampling"""
-    loss_coefficients: Dict[str, float] = to_immutable_dict({"rgb_loss": 1.0})
+    loss_coefficients: Dict[str, float] = to_immutable_dict({"rgb_loss": 1.0, 
+                                                             "tv_reg_density": 1e-3,
+                                                             "tv_reg_color": 1e-4,
+                                                             "l1_reg": 5e-4,})
     """Loss specific weights."""
     num_samples: int = 50
     """Number of samples in field evaluation"""
@@ -81,7 +84,8 @@ class TensoRFModelConfig(ModelConfig):
     appearance_dim: int = 27
     """Number of channels for color encoding"""
     tensorf_encoding: Literal["triplane", "vm", "cp"] = "vm"
-
+    regularization: Literal["none", "l1", "tv"] = "l1"
+    """Regularization method used in tensorf paper"""
 
 class TensoRFModel(Model):
     """TensoRF Model
@@ -241,6 +245,10 @@ class TensoRFModel(Model):
         # colliders
         if self.config.enable_collider:
             self.collider = AABBBoxCollider(scene_box=self.scene_box)
+        
+        # regularizations
+        if self.config.tensorf_encoding == "cp" and self.config.regularization == "tv":
+            raise RuntimeError("TV reg not supported for CP decomposition")
 
     def get_param_groups(self) -> Dict[str, List[Parameter]]:
         param_groups = {}
@@ -296,6 +304,20 @@ class TensoRFModel(Model):
         rgb_loss = self.rgb_loss(image, outputs["rgb"])
 
         loss_dict = {"rgb_loss": rgb_loss}
+        
+        if self.config.regularization == "l1":
+            l1_parameters = []
+            for parameter in self.field.density_encoding.parameters():
+                l1_parameters.append(parameter.view(-1))
+            loss_dict["l1_reg"] = torch.abs(torch.cat(l1_parameters)).mean()
+        elif self.config.regularization == "tv":
+            loss_dict["tv_reg_density"] = tv_loss(self.field.density_encoding.plane_coef)
+            loss_dict["tv_reg_color"] = tv_loss(self.field.color_encoding.plane_coef)
+        elif self.config.regularization == "none":
+            pass
+        else:
+            raise ValueError(f"Regularization {self.config.regularization} not supported")
+
         loss_dict = misc.scale_dict(loss_dict, self.config.loss_coefficients)
         return loss_dict
 


### PR DESCRIPTION
- l1 reg will only affect the density field
- TV reg will affect both density and color field. Note in the Tensorf repo, it applies 1e-2 weights to all the losses in the code, and an additional 1e-1/1e-2 to density/color through the config file. 