### PR TITLE
Specify Near/Far Plane for Render Depth

### DIFF
--- a/scripts/render.py
+++ b/scripts/render.py
@@ -38,9 +38,9 @@ from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.model_components import renderers
 from nerfstudio.pipelines.base_pipeline import Pipeline
 from nerfstudio.utils import install_checks
+from nerfstudio.utils.colormaps import apply_depth_colormap
 from nerfstudio.utils.eval_utils import eval_setup
 from nerfstudio.utils.rich_utils import ItersPerSecColumn
-from nerfstudio.utils.colormaps import apply_depth_colormap
 
 CONSOLE = Console(width=120)
 


### PR DESCRIPTION
Added the option to specify the near and far plane for depth rendering in addition to adding a colormap for the depth. Does this by calling `apply_depth_colormap` from `utils` along with new CLI options. Would address #1724.