### PR TITLE
Remove unecessary assert in pixel sampler on image dimensions

### DIFF
--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -101,7 +101,7 @@ class PixelSampler:  # pylint: disable=too-few-public-methods
             key: value[c, y, x] for key, value in batch.items() if key != "image_idx" and value is not None
         }
 
-        assert collated_batch["image"].shape == (num_rays_per_batch, 3), collated_batch["image"].shape
+        assert collated_batch["image"].shape[0] == num_rays_per_batch
 
         # Needed to correct the random indices to their actual camera idx locations.
         indices[:, 0] = batch["image_idx"][c]
@@ -172,7 +172,7 @@ class PixelSampler:  # pylint: disable=too-few-public-methods
 
         collated_batch["image"] = torch.cat(all_images, dim=0)
 
-        assert collated_batch["image"].shape == (num_rays_per_batch, 3), collated_batch["image"].shape
+        assert collated_batch["image"].shape[0] == num_rays_per_batch
 
         # Needed to correct the random indices to their actual camera idx locations.
         indices[:, 0] = batch["image_idx"][c]


### PR DESCRIPTION
I believe the assert statements on image shape (particularly image dimensions of '3') is unnecessary and redundant in the pixel sampler stage. When writing custom dataparsers, the user has to manage their image format already. In the base InputDataset, there are checks for image dimensions in the get_image() function that handles correct image sizes (3 or 4 channels).

I am working with hyperspectral images and having this assert statement on input dimension size inside the pixel_sampler becomes difficult to work with. I do not want to modify the original sampler logic nor subclass/write my own for my particular multi-dimensional data. The pixel sampler should not have assertions on the image dimension size since this should be done elsewhere. It should focus more on the individual sampling strategy. I believe removing these checks is warranted since the vanilla pipeline already handles the image sizes in different places. 