### PR TITLE
Enable method config registration from env variable

### DIFF
--- a/docs/developer_guides/new_methods.md
+++ b/docs/developer_guides/new_methods.md
@@ -70,6 +70,12 @@ finally run the following to register the method,
 pip install -e .
 ```
 
+When developing a new method you don't always want to install your code as a package.
+Instead, you may use the `NERFSTUDIO_METHOD_CONFIGS` environment variable to temporarily register your custom method.
+```
+export NERFSTUDIO_METHOD_CONFIGS="my-method=my_method.my_config:MyMethod"
+```
+
 ## Running custom method
 
 After registering your method you should be able to run the method with,

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -1,6 +1,7 @@
 """
 Tests for the nerfstudio.plugins.registry module.
 """
+import os
 import sys
 
 from nerfstudio.engine.trainer import TrainerConfig
@@ -49,3 +50,23 @@ def test_discover_methods():
     finally:
         # Revert mock
         registry.entry_points = entry_points_backup
+
+
+def test_discover_methods_from_environment_variable():
+    """Tests if a custom method from env variable gets properly registered using the discover_methods method"""
+    old_env = None
+    try:
+        old_env = os.environ.get("NERFSTUDIO_METHOD_CONFIGS", None)
+        os.environ["NERFSTUDIO_METHOD_CONFIGS"] = "test-method-env=test_registry:TestConfig"
+
+        # Discover plugins
+        methods, _ = registry.discover_methods()
+        assert "test-method-env" in methods
+        config = methods["test-method-env"]
+        assert isinstance(config, TrainerConfig)
+    finally:
+        # Revert mock
+        if old_env is not None:
+            os.environ["NERFSTUDIO_METHOD_CONFIGS"] = old_env
+        else:
+            del os.environ["NERFSTUDIO_METHOD_CONFIGS"]


### PR DESCRIPTION
Adds a new environment variable, "NERFSTUDIO_METHOD_CONFIGS", which enables registering custom methods without installing them as pip packages.

Tests added and docs updated.

Partially also addresses #1622.