### PR TITLE
Wandb/experiment improvements

### DIFF
--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -50,6 +50,8 @@ class ExperimentConfig(InstantiateConfig):
     """Method name. Required to set in python or via cli"""
     experiment_name: Optional[str] = None
     """Experiment name. If None, will automatically be set to dataset name"""
+    project_name: Optional[str] = "nerfstudio-project"
+    """Project name."""
     timestamp: str = "{timestamp}"
     """Experiment timestamp."""
     machine: MachineConfig = MachineConfig()

--- a/nerfstudio/data/utils/dataloaders.py
+++ b/nerfstudio/data/utils/dataloaders.py
@@ -211,7 +211,6 @@ class FixedIndicesEvalDataloader(EvalDataloader):
         self.count = 0
 
     def __iter__(self):
-        self.count = 0
         return self
 
     def __next__(self):
@@ -225,30 +224,16 @@ class FixedIndicesEvalDataloader(EvalDataloader):
 
 class RandIndicesEvalDataloader(EvalDataloader):
     """Dataloader that returns random images.
-
     Args:
         input_dataset: InputDataset to load data from
         device: Device to load data to
     """
 
-    def __init__(
-        self,
-        input_dataset: InputDataset,
-        device: Union[torch.device, str] = "cpu",
-        **kwargs,
-    ):
-        super().__init__(input_dataset, device, **kwargs)
-        self.count = 0
-
     def __iter__(self):
-        self.count = 0
         return self
 
     def __next__(self):
-        if self.count < 1:
-            image_indices = range(self.cameras.size)
-            image_idx = random.choice(image_indices)
-            ray_bundle, batch = self.get_data_from_image_idx(image_idx)
-            self.count += 1
-            return ray_bundle, batch
-        raise StopIteration
+        # choose a random image index
+        image_idx = random.randint(0, len(self.cameras) - 1)
+        ray_bundle, batch = self.get_data_from_image_idx(image_idx)
+        return ray_bundle, batch

--- a/nerfstudio/utils/writer.py
+++ b/nerfstudio/utils/writer.py
@@ -18,7 +18,6 @@ Generic Writer class
 from __future__ import annotations
 
 import enum
-import os
 from abc import abstractmethod
 from pathlib import Path
 from time import time
@@ -188,9 +187,14 @@ def setup_local_writer(config: cfg.LoggingConfig, max_iter: int, banner_messages
 
 
 @check_main_thread
-def setup_event_writer(is_wandb_enabled: bool, is_tensorboard_enabled: bool, log_dir: Path) -> None:
+def setup_event_writer(
+    is_wandb_enabled: bool,
+    is_tensorboard_enabled: bool,
+    log_dir: Path,
+    experiment_name: str,
+    project_name: str = "nerfstudio-project",
+) -> None:
     """Initialization of all event writers specified in config
-
     Args:
         config: configuration to instantiate loggers
         max_iter: maximum number of train iterations
@@ -198,7 +202,7 @@ def setup_event_writer(is_wandb_enabled: bool, is_tensorboard_enabled: bool, log
     """
     using_event_writer = False
     if is_wandb_enabled:
-        curr_writer = WandbWriter(log_dir=log_dir)
+        curr_writer = WandbWriter(log_dir=log_dir, experiment_name=experiment_name, project_name=project_name)
         EVENT_WRITERS.append(curr_writer)
         using_event_writer = True
     if is_tensorboard_enabled:
@@ -282,13 +286,8 @@ class TimeWriter:
 class WandbWriter(Writer):
     """WandDB Writer Class"""
 
-    def __init__(self, log_dir: Path):
-        wandb.init(
-            project=os.environ.get("WANDB_PROJECT", "nerfstudio-project"),
-            dir=os.environ.get("WANDB_DIR", str(log_dir)),
-            name=os.environ.get("WANDB_NAME", log_dir.name),
-            reinit=True,
-        )
+    def __init__(self, log_dir: Path, experiment_name: str, project_name: str = "nerfstudio-project"):
+        wandb.init(project=project_name, dir=str(log_dir), reinit=True, name=experiment_name)
 
     def write_image(self, name: str, image: TensorType["H", "W", "C"], step: int) -> None:
         image = torch.permute(image, (2, 0, 1))


### PR DESCRIPTION
This PR fixes a consistent ordering for eval images when using a random seed. It also gives functionality for setting the wandb project name, setting the experiment name, and loading from a checkpoint path.