### PR TITLE
Fix start_train option

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -131,6 +131,9 @@ class ViewerConfig(PrintableConfig):
 
     relative_log_filename: str = "viewer_log_filename.txt"
     """Filename to use for the log file."""
+    start_train: bool = True
+    """whether to immediately start training upon loading viewer
+    if False, will just visualize dataset but you can toggle training in viewer"""
     websocket_port: Optional[int] = None
     """The websocket port to connect to. If None, find an available port."""
     websocket_port_default: int = 7007

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -322,7 +322,7 @@ class Trainer:
         assert self.viewer_state and self.pipeline.datamanager.train_dataset
         self.viewer_state.init_scene(
             dataset=self.pipeline.datamanager.train_dataset,
-            train_state="training",
+            train_state="training" if self.config.viewer.start_train else "paused",
         )
 
     @check_viewer_enabled


### PR DESCRIPTION
The `--viewer.start-train False` option is used in the docs but not available due to regressions in #1702.

This commit simply adds back the option.

Related: #1813