### PR TITLE
Implement gradient scaling

### DIFF
--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -513,17 +513,18 @@ class GradientScaler(torch.autograd.Function):  # typing: ignore, pylint: disabl
     """
 
     @staticmethod
-    def forward(ctx, field_outputs, ray_dist):  # pylint: disable=arguments-differ
+    def forward(ctx, field_outputs, ray_samples):  # pylint: disable=arguments-differ
+        ray_dist = ray_samples.frustums.starts + ray_samples.frustums.ends / 2
         ctx.save_for_backward(ray_dist)
         return field_outputs, ray_dist
 
     @staticmethod
-    def backward(ctx, grad_field_outputs, grad_output_ray_dist):  # pylint: disable=arguments-differ
+    def backward(ctx, grad_field_outputs, grad_output_ray_samples):  # pylint: disable=arguments-differ
         (ray_dist,) = ctx.saved_tensors
         scaling = torch.square(ray_dist).clamp(0, 1)
         output_grad = dict(grad_field_outputs.items())
         for key in output_grad.keys():
             output_grad[key] = output_grad[key] * scaling
-        return output_grad, grad_output_ray_dist
+        return output_grad, grad_output_ray_samples
 
     vjp = backward

--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -513,12 +513,15 @@ class GradientScaler(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, colors, sigmas, ray_dist):
+    def forward(ctx, field_outputs, ray_dist):
         ctx.save_for_backward(ray_dist)
-        return colors, sigmas, ray_dist
+        return field_outputs, ray_dist
 
     @staticmethod
-    def backward(ctx, grad_output_colors, grad_output_sigmas, grad_output_ray_dist):
+    def backward(ctx, grad_field_outputs, grad_output_ray_dist):
         (ray_dist,) = ctx.saved_tensors
         scaling = torch.square(ray_dist).clamp(0, 1)
-        return grad_output_colors * scaling, grad_output_sigmas * scaling, grad_output_ray_dist
+        output_grad = dict(grad_field_outputs.items())
+        for key in output_grad.keys():
+            output_grad[key] = output_grad[key] * scaling
+        return output_grad, grad_output_ray_dist

--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -504,7 +504,7 @@ def tv_loss(grids: TensorType["grids", "feature_dim", "row", "column"]) -> Tenso
     return 2 * (h_tv / h_tv_count + w_tv / w_tv_count) / number_of_grids
 
 
-class GradientScaler(torch.autograd.Function):
+class GradientScaler(torch.autograd.Function):  # typing: ignore, pylint: disable=abstract-method
     """
     Scale gradients by the ray distance to the pixel
     as suggested in `Radiance Field Gradient Scaling for Unbiased Near-Camera Training` paper
@@ -513,15 +513,17 @@ class GradientScaler(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, field_outputs, ray_dist):
+    def forward(ctx, field_outputs, ray_dist):  # pylint: disable=arguments-differ
         ctx.save_for_backward(ray_dist)
         return field_outputs, ray_dist
 
     @staticmethod
-    def backward(ctx, grad_field_outputs, grad_output_ray_dist):
+    def backward(ctx, grad_field_outputs, grad_output_ray_dist):  # pylint: disable=arguments-differ
         (ray_dist,) = ctx.saved_tensors
         scaling = torch.square(ray_dist).clamp(0, 1)
         output_grad = dict(grad_field_outputs.items())
         for key in output_grad.keys():
             output_grad[key] = output_grad[key] * scaling
         return output_grad, grad_output_ray_dist
+
+    vjp = backward

--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -520,7 +520,9 @@ class _GradientScaler(torch.autograd.Function):  # typing: ignore, pylint: disab
         return output_grad * scaling, grad_scaling
 
 
-def scale_gradients_by_distance_squared(field_outputs: Dict[str, torch.Tensor], ray_samples: RaySamples) -> Dict[str, torch.Tensor]:
+def scale_gradients_by_distance_squared(
+    field_outputs: Dict[str, torch.Tensor], ray_samples: RaySamples
+) -> Dict[str, torch.Tensor]:
     """
     Scale gradients by the ray distance to the pixel
     as suggested in `Radiance Field Gradient Scaling for Unbiased Near-Camera Training` paper

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -39,12 +39,12 @@ from nerfstudio.field_components.spatial_distortions import SceneContraction
 from nerfstudio.fields.density_fields import HashMLPDensityField
 from nerfstudio.fields.nerfacto_field import TCNNNerfactoField
 from nerfstudio.model_components.losses import (
-    GradientScaler,
     MSELoss,
     distortion_loss,
     interlevel_loss,
     orientation_loss,
     pred_normal_loss,
+    scale_gradients_by_distance_squared,
 )
 from nerfstudio.model_components.ray_samplers import (
     ProposalNetworkSampler,
@@ -269,7 +269,7 @@ class NerfactoModel(Model):
         ray_samples, weights_list, ray_samples_list = self.proposal_sampler(ray_bundle, density_fns=self.density_fns)
         field_outputs = self.field(ray_samples, compute_normals=self.config.predict_normals)
         if self.config.use_gradient_scaling:
-            field_outputs, _ = GradientScaler.apply(field_outputs, ray_samples)
+            field_outputs = scale_gradients_by_distance_squared(field_outputs, ray_samples)
 
         weights = ray_samples.get_weights(field_outputs[FieldHeadNames.DENSITY])
         weights_list.append(weights)

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -269,9 +269,7 @@ class NerfactoModel(Model):
         ray_samples, weights_list, ray_samples_list = self.proposal_sampler(ray_bundle, density_fns=self.density_fns)
         field_outputs = self.field(ray_samples, compute_normals=self.config.predict_normals)
         if self.config.use_gradient_scaling:
-            field_outputs, _ = GradientScaler.apply(
-                field_outputs, (ray_samples.frustums.starts + ray_samples.frustums.ends) / 2
-            )
+            field_outputs, _ = GradientScaler.apply(field_outputs, ray_samples)
 
         weights = ray_samples.get_weights(field_outputs[FieldHeadNames.DENSITY])
         weights_list.append(weights)

--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -181,11 +181,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
         """
         self.absolute_colmap_path.mkdir(parents=True, exist_ok=True)
 
-        (
-            sfm_tool,
-            feature_type,
-            matcher_type,
-        ) = process_data_utils.find_tool_feature_matcher_combination(
+        (sfm_tool, feature_type, matcher_type,) = process_data_utils.find_tool_feature_matcher_combination(
             self.sfm_tool, self.feature_type, self.matcher_type
         )
         # check that sfm_tool is hloc if using refine_pixsfm

--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -181,7 +181,11 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
         """
         self.absolute_colmap_path.mkdir(parents=True, exist_ok=True)
 
-        (sfm_tool, feature_type, matcher_type,) = process_data_utils.find_tool_feature_matcher_combination(
+        (
+            sfm_tool,
+            feature_type,
+            matcher_type,
+        ) = process_data_utils.find_tool_feature_matcher_combination(
             self.sfm_tool, self.feature_type, self.matcher_type
         )
         # check that sfm_tool is hloc if using refine_pixsfm


### PR DESCRIPTION
This PR implements gradient scaling from [Radiance Field Gradient Scaling for Unbiased Near-Camera Training](https://gradient-scaling.github.io/)

GradientScaling is added to the nerfacto model and enabled using flag `--use-gradient-scaling=True`