### PR TITLE
#1732 fix sdf dataparser no mono paths

### DIFF
--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -87,16 +87,16 @@ class SDFStudio(DataParser):
                 continue
 
             image_filename = self.config.data / frame["rgb_path"]
-            depth_filename = self.config.data / frame["mono_depth_path"]
-            normal_filename = self.config.data / frame["mono_normal_path"]
+            depth_filename = self.config.data / frame.get("mono_depth_path", [])
+            normal_filename = self.config.data / frame.get("mono_normal_path", [])
 
             intrinsics = torch.tensor(frame["intrinsics"])
             camtoworld = torch.tensor(frame["camtoworld"])
 
             # append data
             image_filenames.append(image_filename)
-            depth_filenames.append(depth_filename)
-            normal_filenames.append(normal_filename)
+            depth_filenames.extend(depth_filename)
+            normal_filenames.extend(normal_filename)
             fx.append(intrinsics[0, 0])
             fy.append(intrinsics[1, 1])
             cx.append(intrinsics[0, 2])

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -87,16 +87,17 @@ class SDFStudio(DataParser):
                 continue
 
             image_filename = self.config.data / frame["rgb_path"]
-            depth_filename = self.config.data / frame.get("mono_depth_path", [])
-            normal_filename = self.config.data / frame.get("mono_normal_path", [])
+            depth_filename = frame.get("mono_depth_path")
+            normal_filename = frame.get("mono_normal_path")
 
             intrinsics = torch.tensor(frame["intrinsics"])
             camtoworld = torch.tensor(frame["camtoworld"])
 
             # append data
             image_filenames.append(image_filename)
-            depth_filenames.extend(depth_filename)
-            normal_filenames.extend(normal_filename)
+            if depth_filename is not None and normal_filename is not None:
+                depth_filenames.append(self.config.data / depth_filename)
+                normal_filenames.append(self.config.data / normal_filename)
             fx.append(intrinsics[0, 0])
             fy.append(intrinsics[1, 1])
             cx.append(intrinsics[0, 2])


### PR DESCRIPTION
Related to issue: https://github.com/nerfstudio-project/nerfstudio/issues/1732
Related comment: https://github.com/nerfstudio-project/nerfstudio/issues/1732#issuecomment-1543654312

In summary, the [conversion script](https://github.com/autonomousvision/sdfstudio/blob/master/scripts/datasets/process_nerfstudio_to_sdfstudio.py) that is used before training Neus(facto) does not include the `mono_depth_path` and `mono_normal_path` keys for the frames by default. If monocular depth and normal cues are not extracted, some errors will be generated.

There are several ways in which this can be solved.
If another style/approach is preferred, please let me know, so I can change the PR accordingly.