### PR TITLE
fix pytorch 2.0 optimizer no inf check error

### DIFF
--- a/nerfstudio/engine/optimizers.py
+++ b/nerfstudio/engine/optimizers.py
@@ -127,7 +127,7 @@ class Optimizers:
             if max_norm is not None:
                 grad_scaler.unscale_(optimizer)
                 torch.nn.utils.clip_grad_norm_(self.parameters[param_group], max_norm)
-            if optimizer.param_groups[0]["params"][0].grad is not None:
+            if any(any(p.grad is not None for p in g["params"]) for g in optimizer.param_groups):
                 grad_scaler.step(optimizer)
 
     def optimizer_step_all(self) -> None:


### PR DESCRIPTION
fix #1883 #1613.

The reason why there's no inf check is because proposal network did not compute gradient at some iteration step. And there is no need to do optimizer.step for proposal network's parameter.