### PR TITLE
Add "on_train_end" method logic similar to Pytorch Lightning

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -284,6 +284,9 @@ class Trainer:
         # save checkpoint at the end of training
         self.save_checkpoint(step)
 
+        # optional model method called at the end of training
+        self.on_train_end()
+
         # write out any remaining events (e.g., total train time)
         writer.write_out_storage()
 
@@ -503,3 +506,11 @@ class Trainer:
         if step_check(step, self.config.steps_per_eval_all_images):
             metrics_dict = self.pipeline.get_average_eval_image_metrics(step=step)
             writer.put_dict(name="Eval Images Metrics Dict (all images)", scalar_dict=metrics_dict, step=step)
+
+    def on_train_end(self) -> None:
+        """Calls optional on_train_end() model method at training end"""
+        if callable(self.pipeline.model.on_train_end()):
+            try:
+                self.pipeline.model.on_train_end()
+            except RuntimeError:
+                CONSOLE.log("Optional on_train_end() method failed in model class.")

--- a/nerfstudio/models/base_model.py
+++ b/nerfstudio/models/base_model.py
@@ -219,3 +219,6 @@ class Model(nn.Module):
         Args:
             step: training step of the loaded checkpoint
         """
+
+    def on_train_end(self) -> None:
+        """Optional method called at the end of training"""


### PR DESCRIPTION
- Added on_train_end() optional custom user method to BaseModel.
- Added on train end logic to trainer. 

Let me know if there are perhaps further use cases similar to this method that could be added to either the model or trainer logic and whether or not my implementation is the best option. Happy to learn and get some feedback. 