### PR TITLE
[WIP] Reducing the time for RayGenerator 

### DIFF
--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -497,6 +497,7 @@ class VanillaDataManager(DataManager, Generic[TDataset]):
         assert isinstance(image_batch, dict)
         batch = self.train_pixel_sampler.sample(image_batch)
         ray_indices = batch["indices"]
+        # this takes some time to run
         ray_bundle = self.train_ray_generator(ray_indices)
         return ray_bundle, batch
 


### PR DESCRIPTION
Profiling with PyTorch profiler give:
![image](https://github.com/nerfstudio-project/nerfstudio/assets/90344978/7ed2766e-d335-49f6-b3e8-6693ec9f93e1) 
A lot of time is spent inside https://github.com/nerfstudio-project/nerfstudio/blob/9584fa9b39bd276c97830a4753791a94afd8e9f3/nerfstudio/model_components/ray_generators.py#L56
2 ideas for reducing the time needed to run this:
- precompute ray bundle and load from disk 
- multithreading with torch dataloader


