### PR TITLE
Fix Viewer Recursion: StackOverflow in Server Setup

### DIFF
--- a/nerfstudio/viewer/server/gui_utils.py
+++ b/nerfstudio/viewer/server/gui_utils.py
@@ -60,6 +60,10 @@ def parse_object(
         if isinstance(v, type_check):
             add(ret, new_tree_stub, v)
         elif isinstance(v, nn.Module):
+            if v is obj:
+                # some nn.Modules might contain infinite references, e.g. consider foo = nn.Module(), foo.bar = foo
+                # to stop infinite recursion, we skip such attributes
+                continue
             lower_rets = parse_object(v, type_check, new_tree_stub)
             # check that the values aren't already in the tree
             for ts, o in lower_rets:


### PR DESCRIPTION
This PR fixes the following bug:

**Describe the bug**

1. `ViewerState` is initialized in the trainer: https://github.com/nerfstudio-project/nerfstudio/blob/160abde6ad0a496aff0b2d7a5fdec90a0f9f6909/nerfstudio/engine/trainer.py#L162

2. This eventually makes a call to `parse_objects` to construct the model tree: https://github.com/nerfstudio-project/nerfstudio/blob/160abde6ad0a496aff0b2d7a5fdec90a0f9f6909/nerfstudio/viewer/server/gui_utils.py#L24

3. If part of the model contains an infinite recursion (e.g. a `torch.nn.Module` that links back to its parent for completely valid implementation reasons), then `parse_objects` will result in a StackOverflow since recursion is repeated indefinitely.

**To Reproduce**
Steps to reproduce the behavior:
1. Create a custom pipeline
2. The custom pipeline should have a `torch.nn.Module` with such a recursion. In my case I use [torchmetrics.ClipScore](https://torchmetrics.readthedocs.io/en/stable/multimodal/clip_score.html), but any module with that attribute works.
4. Use the custom pipeline normally in `ns-train`

**Expected behavior**
The recursion should stop..
