### PR TITLE
Update metashape_utils.py

### DIFF
--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -68,7 +68,7 @@ def metashape_to_json(
     if sensor_type.count(sensor_type[0]) != len(sensor_type):
         raise ValueError(
             "All Metashape sensors do not have the same sensor type. "
-            "nerfstudio does not support per-frame camera_model."
+            "nerfstudio does support per-frame camera intrinsics, but at this current time the utility does not account for this."
         )
     data = {}
     if sensor_type[0] == "frame":


### PR DESCRIPTION
Changed the ValueError message when using a camera.xml that contains multiple sensors. Per-frame intrinsics can be defined, the previous message said that they were not supported.