### PR TITLE
add transparency carving to nerfacto

### DIFF
--- a/nerfstudio/data/dataparsers/base_dataparser.py
+++ b/nerfstudio/data/dataparsers/base_dataparser.py
@@ -57,6 +57,8 @@ class DataparserOutputs:
     """Camera object storing collection of camera information in dataset."""
     alpha_color: Optional[Float[Tensor, "3"]] = None
     """Color of dataset background."""
+    use_alpha_channel: bool = False
+    """Keep the alpha channel if present (or add one) when loading image data"""
     scene_box: SceneBox = SceneBox(aabb=torch.tensor([[-1, -1, -1], [1, 1, 1]]))
     """Scene box of dataset. Used to bound the scene or provide the scene scale depending on model."""
     mask_filenames: Optional[List[Path]] = None

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -26,11 +26,7 @@ from PIL import Image
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.io import load_from_json
 from nerfstudio.utils.rich_utils import CONSOLE
@@ -296,9 +292,15 @@ class Nerfstudio(DataParser):
             applied_scale = float(meta["applied_scale"])
             scale_factor *= applied_scale
 
+        if "use_alpha_channel" in meta:
+            use_alpha_channel = bool(meta["use_alpha_channel"])
+        else:
+            use_alpha_channel = False
+
         dataparser_outputs = DataparserOutputs(
             image_filenames=image_filenames,
             cameras=cameras,
+            use_alpha_channel=use_alpha_channel,
             scene_box=scene_box,
             mask_filenames=mask_filenames if len(mask_filenames) > 0 else None,
             dataparser_scale=scale_factor,
@@ -306,6 +308,7 @@ class Nerfstudio(DataParser):
             metadata={
                 "depth_filenames": depth_filenames if len(depth_filenames) > 0 else None,
                 "depth_unit_scale_factor": self.config.depth_unit_scale_factor,
+                "use_alpha_channel": use_alpha_channel,
             },
         )
         return dataparser_outputs

--- a/nerfstudio/model_components/renderers.py
+++ b/nerfstudio/model_components/renderers.py
@@ -121,6 +121,7 @@ class RGBRenderer(nn.Module):
         weights: Float[Tensor, "*bs num_samples 1"],
         ray_indices: Optional[Int[Tensor, "num_samples"]] = None,
         num_rays: Optional[int] = None,
+        background_color: Union[Float[Tensor, "3"], BackgroundColor, None] = None,
     ) -> Float[Tensor, "*bs 3"]:
         """Composite samples along ray and render color image
 
@@ -133,11 +134,13 @@ class RGBRenderer(nn.Module):
         Returns:
             Outputs of rgb values.
         """
+        if background_color is None:
+            background_color = self.background_color
 
         if not self.training:
             rgb = torch.nan_to_num(rgb)
         rgb = self.combine_rgb(
-            rgb, weights, background_color=self.background_color, ray_indices=ray_indices, num_rays=num_rays
+            rgb, weights, background_color=background_color, ray_indices=ray_indices, num_rays=num_rays
         )
         if not self.training:
             torch.clamp_(rgb, min=0.0, max=1.0)


### PR DESCRIPTION
there is a very simple trick not implemented in Nerfacto that significantly reduces floaters in synthetic scenes with few cameras. I implemented it, below is a small comparison with and without this addition.

Without:
![plant-no-alpha-carve](https://github.com/nerfstudio-project/nerfstudio/assets/11174777/02359d66-a345-4386-bc62-318795207e42)

With:
![plant-with-alpha-carve](https://github.com/nerfstudio-project/nerfstudio/assets/11174777/203519f8-61c8-46d9-a818-2fe9d881e833)

The trick only works if you have foreground masks, it works as follows:

1. Make everything except for the foreground object transparent in each image.
2. While rendering, pick a random color in each iteration, then use this random color as background during alpha compositing.
3. When computing the RGB loss, make the color of transparent pixels match the randomly chosen color of the current iteration used for rendering.

The end result is that floaters will get punished because then can't keep up with the constantly changing background color, therefore pushing them towards transparency. 