### PR TITLE
installation.md: Use https instead of ssh for git clone.

### DIFF
--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -94,7 +94,7 @@ pip install nerfstudio
 Optional, use this command if you want the latest development version.
 
 ```bash
-git clone https://github.com/nerfstudio-project/nerfstudio
+git clone https://github.com/nerfstudio-project/nerfstudio.git
 cd nerfstudio
 pip install --upgrade pip setuptools
 pip install -e .

--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -94,7 +94,7 @@ pip install nerfstudio
 Optional, use this command if you want the latest development version.
 
 ```bash
-git clone git@github.com:nerfstudio-project/nerfstudio.git
+git clone https://github.com/nerfstudio-project/nerfstudio
 cd nerfstudio
 pip install --upgrade pip setuptools
 pip install -e .


### PR DESCRIPTION
Https git clone can be run by anyone directly, without account, whereas ssh git on Github requires having a Github account set up.