### PR TITLE
Add antialias parameter as default None

### DIFF
--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -838,7 +838,7 @@ class Cameras(TensorDataclass):
             image_uint8 = (image * 255).detach().type(torch.uint8)
             if max_size is not None:
                 image_uint8 = image_uint8.permute(2, 0, 1)
-                image_uint8 = torchvision.transforms.functional.resize(image_uint8, max_size)  # type: ignore
+                image_uint8 = torchvision.transforms.functional.resize(image_uint8, max_size, antialias=None)  # type: ignore
                 image_uint8 = image_uint8.permute(1, 2, 0)
             image_uint8 = image_uint8.cpu().numpy()
             data = cv2.imencode(".jpg", image_uint8)[1].tobytes()  # type: ignore


### PR DESCRIPTION
I was getting some annoying warning messages about the functional.resize() function. Apparently pytorch is changing the default value of the 'antialias' parameter from None to True. Adding the parameter as None might be useful.

Link: https://pytorch.org/vision/main/generated/torchvision.transforms.functional.resize.html'

> "The current default is None but will change to True in v0.17 for the PIL and Tensor backends to be consistent."