### PR TITLE
nerfstudio dataparser: avoid loading images at inference time

### DIFF
--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -388,6 +388,8 @@ class VanillaDataManager(DataManager, Generic[TDataset]):
         else:
             self.config.data = self.config.dataparser.data
         self.dataparser = self.dataparser_config.setup()
+        if test_mode == "inference":
+            self.dataparser.downscale_factor = 1  # Avoid opening images
         self.includes_time = self.dataparser.includes_time
         self.train_dataparser_outputs: DataparserOutputs = self.dataparser.get_dataparser_outputs(split="train")
 

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -85,7 +85,6 @@ class Nerfstudio(DataParser):
         mask_filenames = []
         depth_filenames = []
         poses = []
-        num_skipped_image_filenames = 0
 
         fx_fixed = "fl_x" in meta
         fy_fixed = "fl_y" in meta
@@ -109,9 +108,6 @@ class Nerfstudio(DataParser):
         for frame in meta["frames"]:
             filepath = Path(frame["file_path"])
             fname = self._get_fname(filepath, data_dir)
-            if not fname.exists():
-                num_skipped_image_filenames += 1
-                continue
 
             if not fx_fixed:
                 assert "fl_x" in frame, "fx not specified in frame"
@@ -159,14 +155,6 @@ class Nerfstudio(DataParser):
                 depth_fname = self._get_fname(depth_filepath, data_dir, downsample_folder_prefix="depths_")
                 depth_filenames.append(depth_fname)
 
-        if num_skipped_image_filenames >= 0:
-            CONSOLE.log(f"Skipping {num_skipped_image_filenames} files in dataset split {split}.")
-        assert (
-            len(image_filenames) != 0
-        ), """
-        No image files found. 
-        You should check the file_paths in the transforms.json file to make sure they are correct.
-        """
         assert len(mask_filenames) == 0 or (
             len(mask_filenames) == len(image_filenames)
         ), """


### PR DESCRIPTION
Also remove the image skipping logic, which seems to be a remnant of some old code (all images should exist).
This allows running inference (s-render or ns-export) without the images.
Fixes https://github.com/nerfstudio-project/nerfstudio/issues/2050