### PR TITLE
Fix get_num_frames_in_video

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -17,6 +17,7 @@
 import math
 import shutil
 import sys
+import re
 from enum import Enum
 from pathlib import Path
 from typing import List, Literal, Optional, OrderedDict, Tuple, Union
@@ -93,7 +94,7 @@ def get_num_frames_in_video(video: Path) -> int:
             -show_entries stream=nb_read_packets -of csv=p=0 "{video}"'
     output = run_command(cmd)
     assert output is not None
-    output = output.strip(" ,\t\n\r")
+    output = re.search(r"\d+", output)[0]
     return int(output)
 
 

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -96,7 +96,7 @@ def get_num_frames_in_video(video: Path) -> int:
     assert output is not None
     number_match = re.search(r"\d+", output)
     assert number_match is not None
-    return int(output[0])
+    return int(number_match[0])
 
 
 def convert_video_to_images(

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -94,8 +94,9 @@ def get_num_frames_in_video(video: Path) -> int:
             -show_entries stream=nb_read_packets -of csv=p=0 "{video}"'
     output = run_command(cmd)
     assert output is not None
-    output = re.search(r"\d+", output)[0]
-    return int(output)
+    number_match = re.search(r"\d+", output)
+    assert number_match is not None
+    return int(output[0])
 
 
 def convert_video_to_images(


### PR DESCRIPTION
Tests have shown that there can be 2 exact same numbers in the output, separated by non-digit symbols. I think it's better to just find the first number.