### PR TITLE
Fix quickstart doc for remote host viewing setup

### DIFF
--- a/docs/quickstart/viewer_quickstart.rst
+++ b/docs/quickstart/viewer_quickstart.rst
@@ -57,25 +57,19 @@ You should be able to click the link obtained while running a script to open the
 Training on a remote machine
 ----------------------------
 
-If you are training on a remote maching, the viewer will still let you view your trainings. 
-You will need to forward the port that the viewer is running on.
-
-For example, if you are running the viewer on port 7007, you will need to forward that port to your local machine. 
-You can (without needing to modify router port settings) simply do this by opening a new terminal window and sshing into the remote machine with the following command:
+If you are training on a remote machine, the viewer will still let you view your trainings. You will need to forward traffic from your viewing host to the listening port on the host running ns-train (7007 by default). You can achieve this by securely tunneling traffic on the specified port through an ssh session. In a terminal window on the viewing host, issue the following command:
 
 ..  code-block:: bash
 
-    ssh -L 7007:localhost:7007 <username>@<remote-machine-ip>
+   ssh -L 7007:<training-host-ip>:7007 <username>@<training-host-ip>
 
 
 ..  admonition:: Note
 
-    So long as you don't close this terminal window with this specific active ssh connection, the port will remain open for all your other ssh sessions. 
+    You can now simply open the link (same one shown in image above) in your browser on your local machine and it should connect!. So long as you don't close this terminal window with this specific active ssh connection, the port will remain open for all your other ssh sessions. 
     
     For example, if you do this in a new terminal window, any existing ssh sessions (terminal windows, VSCode remote connection, etc) will still be able to access the port, but if you close this terminal window, the port will be closed.
 
-
-You can now simply open the link (same ones shown in image above) in your browser on your local machine and it should connect!
 
 ..  warning::
     If the port is being used, you will need to switch the port using the `--viewer.websocket-port` flag tied to the model subcommand.


### PR DESCRIPTION
SSH command should specific localport:remotehost:remoteport rather than localport:localhost:remoteport in -L switch.  Also changed description for clarity.