### PR TITLE
Allow newer pycolmap for newer python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dev = [
     "typeguard==2.13.3",
     "ruff==0.0.267",
     "sshconf==0.2.5",
-    "pycolmap==0.3.0",
+    "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions
     "diffusers==0.16.1",
     "opencv-stubs==0.0.7",
     "transformers==4.29.2",


### PR DESCRIPTION
PyColmap version 0.3.0 seems not to be supported in Python >=3.10, preventing nerfstudio[dev] from installing. This PR allows the newer version 0.4.0 to be installed instead.