### PR TITLE
allow ns-process-data to use CR2 raw images

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -38,6 +38,7 @@ ALLOWED_RAW_EXTS = [".cr2"]
 """Suffix to use for converted images from raw."""
 RAW_CONVERTED_SUFFIX = ".tiff"
 
+
 class CameraModel(Enum):
     """Enum for camera types."""
 

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -24,6 +24,9 @@ from typing import List, Literal, Optional, OrderedDict, Tuple, Union
 import cv2
 import numpy as np
 
+import imageio
+import rawpy
+
 from nerfstudio.utils.rich_utils import CONSOLE, status
 from nerfstudio.utils.scripts import run_command
 
@@ -53,7 +56,7 @@ def list_images(data: Path) -> List[Path]:
     Returns:
         Paths to images contained in the directory
     """
-    allowed_exts = [".jpg", ".jpeg", ".png", ".tif", ".tiff"]
+    allowed_exts = [".jpg", ".jpeg", ".png", ".tif", ".tiff", ".cr2"]
     image_paths = sorted([p for p in data.glob("[!.]*") if p.suffix.lower() in allowed_exts])
     return image_paths
 
@@ -207,7 +210,15 @@ def copy_images_list(
             CONSOLE.log(f"Copying image {idx + 1} of {len(image_paths)}...")
         copied_image_path = image_dir / f"frame_{idx + 1:05d}{image_path.suffix}"
         try:
-            shutil.copy(image_path, copied_image_path)
+            # if CR2 raw, we want to read raw and write TIFF, and change the file suffix for downstream processing
+            if str(image_path).lower().endswith(".cr2"):
+                copied_image_path = image_dir / f"frame_{idx + 1:05d}.tiff"
+                with rawpy.imread(str(image_path)) as raw:
+                    rgb = raw.postprocess()
+                imageio.imsave(copied_image_path, rgb)
+                image_paths[idx] = copied_image_path
+            else:
+                shutil.copy(image_path, copied_image_path)
         except shutil.SameFileError:
             pass
         copied_image_paths.append(copied_image_path)

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -33,6 +33,10 @@ from nerfstudio.utils.scripts import run_command
 
 POLYCAM_UPSCALING_TIMES = 2
 
+"""Lowercase suffixes to treat as raw image."""
+ALLOWED_RAW_EXTS = [".cr2"]
+"""Suffix to use for converted images from raw."""
+RAW_CONVERTED_SUFFIX = ".tiff"
 
 class CameraModel(Enum):
     """Enum for camera types."""
@@ -57,7 +61,7 @@ def list_images(data: Path) -> List[Path]:
     Returns:
         Paths to images contained in the directory
     """
-    allowed_exts = [".jpg", ".jpeg", ".png", ".tif", ".tiff", ".cr2"]
+    allowed_exts = [".jpg", ".jpeg", ".png", ".tif", ".tiff"] + ALLOWED_RAW_EXTS
     image_paths = sorted([p for p in data.glob("[!.]*") if p.suffix.lower() in allowed_exts])
     return image_paths
 
@@ -213,8 +217,8 @@ def copy_images_list(
         copied_image_path = image_dir / f"frame_{idx + 1:05d}{image_path.suffix}"
         try:
             # if CR2 raw, we want to read raw and write TIFF, and change the file suffix for downstream processing
-            if str(image_path).lower().endswith(".cr2"):
-                copied_image_path = image_dir / f"frame_{idx + 1:05d}.tiff"
+            if image_path.suffix.lower() in ALLOWED_RAW_EXTS:
+                copied_image_path = image_dir / f"frame_{idx + 1:05d}{RAW_CONVERTED_SUFFIX}"
                 with rawpy.imread(str(image_path)) as raw:
                     rgb = raw.postprocess()
                 imageio.imsave(copied_image_path, rgb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "pyngrok>=5.1.0",
     "python-socketio>=5.7.1",
     "pyquaternion>=0.9.9",
+    "rawpy>=0.18.1",
     "requests",
     "rich>=12.5.1",
     "scikit-image>=0.19.3",


### PR DESCRIPTION
(Note, this may allow other raw image formats to work as well, but I only have some CR2 that I can't share at present.)