### PR TITLE
Merge video image extraction and downscaling

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -182,13 +182,14 @@ def convert_video_to_images(
 
         if spacing > 1:
             CONSOLE.print("Number of frames to extract:", math.ceil(num_frames / spacing))
+            ffmpeg_cmd += " -vsync vfr -r1"
             select_cmd = f"thumbnail={spacing},setpts=N/TB,"
         else:
             CONSOLE.print("[bold red]Can't satisfy requested number of frames. Extracting all frames.")
             ffmpeg_cmd += " -pix_fmt bgr8"
             select_cmd = ""
 
-        downscale_cmd = f' -filter_complex "{select_cmd}{crop_cmd}{downscale_chain}" -vsync vfr -r 1' + "".join(
+        downscale_cmd = f' -filter_complex "{select_cmd}{crop_cmd}{downscale_chain}"' + "".join(
             [f' -map "[out{i}]" "{downscale_paths[i]}"' for i in range(num_downscales + 1)]
         )
 

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -161,7 +161,7 @@ def convert_video_to_images(
             width = 1 - crop_factor[2] - crop_factor[3]
             start_x = crop_factor[2]
             start_y = crop_factor[0]
-            crop_cmd = f'crop=w=iw*{width}:h=ih*{height}:x=iw*{start_x}:y=ih*{start_y},'
+            crop_cmd = f"crop=w=iw*{width}:h=ih*{height}:x=iw*{start_x}:y=ih*{start_y},"
 
         num_frames = get_num_frames_in_video(video_path)
         spacing = num_frames // num_frames_target
@@ -173,8 +173,12 @@ def convert_video_to_images(
         for dir in downscale_dirs:
             dir.mkdir(parents=True, exist_ok=True)
 
-        downscale_chain = f'split={num_downscales + 1}' + ''.join([f'[t{i}]' for i in range(num_downscales + 1)]) + ';' \
-                          + ';'.join(downscale_chains)
+        downscale_chain = (
+            f"split={num_downscales + 1}"
+            + "".join([f"[t{i}]" for i in range(num_downscales + 1)])
+            + ";"
+            + ";".join(downscale_chains)
+        )
 
         if spacing > 1:
             CONSOLE.print("Number of frames to extract:", math.ceil(num_frames / spacing))
@@ -184,8 +188,9 @@ def convert_video_to_images(
             ffmpeg_cmd += " -pix_fmt bgr8"
             select_cmd = ""
 
-        downscale_cmd = f' -filter_complex "{select_cmd}{crop_cmd}{downscale_chain}" -vsync vfr -r 1' \
-                        + ''.join([f' -map "[out{i}]" "{downscale_paths[i]}"' for i in range(num_downscales + 1)])
+        downscale_cmd = f' -filter_complex "{select_cmd}{crop_cmd}{downscale_chain}" -vsync vfr -r 1' + "".join(
+            [f' -map "[out{i}]" "{downscale_paths[i]}"' for i in range(num_downscales + 1)]
+        )
 
         ffmpeg_cmd += downscale_cmd
 
@@ -198,6 +203,7 @@ def convert_video_to_images(
         CONSOLE.log("[bold green]:tada: Done converting video to images.")
 
         return summary_log, num_final_frames
+
 
 def copy_images_list(
     image_paths: List[Path],

--- a/nerfstudio/process_data/video_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/video_to_nerfstudio_dataset.py
@@ -97,7 +97,6 @@ class VideoToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
                 process_data_utils.downscale_images(self.image_dir, self.num_downscales, verbose=self.verbose)
             )
 
-
         # # Create mask
         mask_path = process_data_utils.save_mask(
             image_dir=self.image_dir,

--- a/nerfstudio/process_data/video_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/video_to_nerfstudio_dataset.py
@@ -30,9 +30,8 @@ class VideoToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
 
     This script does the following:
 
-    1. Converts the video into images.
-    2. Scales images to a specified size.
-    3. Calculates the camera poses for each image using `COLMAP <https://colmap.github.io/>`_.
+    1. Converts the video into images and downscales them.
+    2. Calculates the camera poses for each image using `COLMAP <https://colmap.github.io/>`_.
     """
 
     num_frames_target: int = 300
@@ -53,14 +52,17 @@ class VideoToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
                 self.data,
                 image_dir=temp_image_dir,
                 num_frames_target=self.num_frames_target,
+                num_downscales=0,
                 crop_factor=(0.0, 0.0, 0.0, 0.0),
                 verbose=self.verbose,
             )
         else:
+            # If we're not dealing with equirects we can downscale in one step.
             summary_log, num_extracted_frames = process_data_utils.convert_video_to_images(
                 self.data,
                 image_dir=self.image_dir,
                 num_frames_target=self.num_frames_target,
+                num_downscales=self.num_downscales,
                 crop_factor=self.crop_factor,
                 verbose=self.verbose,
             )
@@ -90,6 +92,12 @@ class VideoToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
 
             self.camera_type = "perspective"
 
+            # # Downscale images
+            summary_log.append(
+                process_data_utils.downscale_images(self.image_dir, self.num_downscales, verbose=self.verbose)
+            )
+
+
         # # Create mask
         mask_path = process_data_utils.save_mask(
             image_dir=self.image_dir,
@@ -99,11 +107,6 @@ class VideoToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
         )
         if mask_path is not None:
             summary_log.append(f"Saved mask to {mask_path}")
-
-        # # Downscale images
-        summary_log.append(
-            process_data_utils.downscale_images(self.image_dir, self.num_downscales, verbose=self.verbose)
-        )
 
         # Run Colmap
         if not self.skip_colmap:


### PR DESCRIPTION
Disclaimer: Parts of this code were written by ChatGPT-4, albeit with my strict guidance.

This PR merges the thumbnail extraction step and the image downscaling step for `ns-process-data video` into a single ffmpeg pipeline.
This results in the overhead for downscaling almost completely vanishing.
On my machine, on Linux, the difference is very clear: 
Old:
```
(0) sebastiaan@AlmaLinux:nerf $ time ns-process-data video --data /home/sebastiaan/src/nerf/work/kitchen/kitchen_home_long_uwa.mp4 --output-dir /home/sebastiaan/src/nerf/work/out/colmaps/kitchen_home_long_uwa/1500 --camera-type perspective --num-frames-target 1500 --gpu --sfm-tool hloc --matching-method sequential
Number of frames in video: 17942
Number of frames to extract: 1632
[21:07:38] 🎉 Done converting video to images.                                                 process_data_utils.py:182
[21:25:25] 🎉 Done downscaling images.                                                         process_data_utils.py:380

real    19m38.797s
user    28m2.938s
sys     3m2.102s
```

New:
```
(0) sebastiaan@AlmaLinux:nerf $ time ns-process-data video --data /home/sebastiaan/src/nerf/work/kitchen/kitchen_home_long_uwa.mp4 --output-dir /home/sebastiaan/src/nerf/work/out/colmaps/kitchen_home_long_uwa/1500 --camera-type perspective --num-frames-target 1500 --gpu --sfm-tool hloc --matching-method sequential                                       
Number of frames in video: 17942
Number of frames to extract: 1632
[20:55:11] 🎉 Done converting video to images.                                                 process_data_utils.py:197

real    1m53.805s
user    13m3.816s
sys     0m14.801s
```

On Windows, the difference is likely orders of manitude largers, since spawning new processes on Windows can take up to 2 seconds, and this saves, in my example, 4895 executions of ffmpeg.


This should only affect the `ns-process-data video` pipeline, with the exception of equirectangular perspective.  
Equirectangular perspective follows the old flow, as it needed an extra step before downscaling.

It currently drops the possibility to enable nearest neighbor, which is not used by `ns-process-data video` command at all currently. If desirable I can easily add that in as well.

Note: I have not yet been able to fully test this or to compare the resulting images.
The results seemed fine when I prodded at them but I have not yet been able to test every scenario, nor completed a full training yet. Some more testing is recommended before merging.
I will be testing it further myself as well, but I'm less equipped for fully comparing all the edge cases.
Partially fixes issue #1811 for all videos but equirects.
Individual downscaling from images may be further enhanced too, but I haven't looked into this yet.