### PR TITLE
Correct path notation for Windows in documentation

### DIFF
--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -106,8 +106,8 @@ cd vcpkg
 ```bash
 git clone https://github.com/microsoft/vcpkg
 cd vcpkg
-./bootstrap-vcpkg.bat
-./vcpkg install colmap[cuda]:x64-windows
+.\bootstrap-vcpkg.bat
+.\vcpkg install colmap[cuda]:x64-windows
 ```
 
 :::
@@ -116,8 +116,8 @@ cd vcpkg
 ```bash
 git clone https://github.com/microsoft/vcpkg
 cd vcpkg
-./bootstrap-vcpkg.sh
-./vcpkg install colmap:x64-windows
+.\bootstrap-vcpkg.sh
+.\vcpkg install colmap:x64-windows
 ```
 
 :::


### PR DESCRIPTION
## Summary

This pull request is intended to correct an issue found in the project's documentation. The previous version of the documentation used Unix-style "./" notation for file paths, which could potentially confuse or cause issues for Windows users who are expected to use ".\".

## Changes Made

- Replaced all instances of "./" path notation with ".\" in the relevant areas of the documentation.

## Justification

Many developers use Windows systems and the previous documentation would have led to incorrect path usage. With this change, the instructions in the documentation become clearer and more accurate for Windows users, preventing possible confusion and path-related issues.

Please consider merging this pull request to ensure the documentation is correct and clear for all users, irrespective of their operating system. I look forward to your feedback.
