### PR TITLE
Remove pytorch hash table if tcnn implementation is used

### DIFF
--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -274,7 +274,7 @@ class HashEncoding(Encoding):
         self.hash_table_size = 2**log2_hashmap_size
 
         levels = torch.arange(num_levels)
-        growth_factor = np.exp((np.log(max_res) - np.log(min_res)) / (num_levels - 1))
+        growth_factor = np.exp((np.log(max_res) - np.log(min_res)) / (num_levels - 1)) if num_levels > 1 else 1
         self.scalings = torch.floor(min_res * growth_factor**levels)
 
         self.hash_offset = levels * self.hash_table_size

--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -280,7 +280,7 @@ class HashEncoding(Encoding):
         self.hash_offset = levels * self.hash_table_size
 
         self.tcnn_encoding = None
-        self.hash_table = None
+        self.hash_table = torch.empty(0)
         if implementation == "tcnn" and not TCNN_EXISTS:
             print_tcnn_speed_warning("HashEncoding")
             implementation = "torch"

--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -27,8 +27,7 @@ from jaxtyping import Float, Int, Shaped
 from torch import Tensor, nn
 
 from nerfstudio.field_components.base_field_component import FieldComponent
-from nerfstudio.utils.math import (components_from_spherical_harmonics,
-                                   expected_sin)
+from nerfstudio.utils.math import components_from_spherical_harmonics, expected_sin
 from nerfstudio.utils.printing import print_tcnn_speed_warning
 
 try:


### PR DESCRIPTION
When selecting tcnn implementation for HashEncoding, a PyTorch version was still initialized and held in memory, but never used. Now, the PyTorch hash table is only created when selecting PyTorch implementation, or if tcnn is not available.