### PR TITLE
fix index out of bounds exception when using variable resolution with mask

### DIFF
--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -144,7 +144,7 @@ class PixelSampler:
                     num_rays_in_batch = num_rays_per_batch - (num_images - 1) * num_rays_in_batch
 
                 indices = self.sample_method(
-                    num_rays_in_batch, 1, image_height, image_width, mask=batch["mask"][i], device=device
+                    num_rays_in_batch, 1, image_height, image_width, mask=batch["mask"][i][None, ...], device=device
                 )
                 indices[:, 0] = i
                 all_indices.append(indices)


### PR DESCRIPTION
Hi,
When using variable resolution images with masks, an `IndexError` exception will be thrown from [nerfstudio/data/pixel_samplers.py#L151](https://github.com/nerfstudio-project/nerfstudio/blob/c7def8ce8cb42fc2869a31ec886e5797e076489a/nerfstudio/data/pixel_samplers.py#L151).

Because `collate_image_dataset_batch_list()` requires `indices` to be a `nx3` tensor, but calling `self.sample_method()` with `mask=batch["mask"][i]` makes it become a `nx2` one.

This pull request will fix it.