### PR TITLE
Fixing Colmap VocabTreeMatching command to support spaces in Filename 

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -138,7 +138,7 @@ def run_colmap(
     ]
     if matching_method == "vocab_tree":
         vocab_tree_filename = get_vocab_tree()
-        feature_matcher_cmd.append(f"--VocabTreeMatching.vocab_tree_path {vocab_tree_filename}")
+        feature_matcher_cmd.append(f"--VocabTreeMatching.vocab_tree_path '{vocab_tree_filename}'")
     feature_matcher_cmd = " ".join(feature_matcher_cmd)
     with status(msg="[bold yellow]Running COLMAP feature matcher...", spinner="runner", verbose=verbose):
         run_command(feature_matcher_cmd, verbose=verbose)


### PR DESCRIPTION
For macOS the `vocab_tree.fbow`  is stored in `Application Support` since the filepath is directly pasted without apostrophes Colmap is searching the file in the `Application` folder rather than going down the full path. Wich results in the following error:

─────────────────────────────────────────────────────────
Error running command: colmap vocab_tree_matcher --database_path austria/colmap/database.db --SiftMatching.use_gpu 1 --VocabTreeMatching.vocab_tree_path /Users/.../Library/Application Support/nerfstudio/vocab_tree.fbow
─────────────────────────────────────────────────────────
F20230711 08:17:11.650357 24696676 visual_index.h:570] Check failed: file.is_open() /Users/.../Library/Application
*** Check failure stack trace: ***
    @        0x10510f304  google::LogMessage::Flush()
    @        0x105112c9c  google::LogMessageFatal::~LogMessageFatal()
    @        0x105110070  google::LogMessageFatal::~LogMessageFatal()
    @        0x10472a5d8  colmap::retrieval::VisualIndex<>::Read()
    @        0x1048b1480  colmap::VocabTreeFeatureMatcher::Run()
    @        0x1049d2f64  colmap::Thread::RunFunc()
    @        0x1049d468c  std::__1::__thread_proxy<>()
    @        0x1a3da906c  _pthread_start