### PR TITLE
Pin versions of pyceres+pixsfm, up pycolmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN CUDA_VER=${CUDA_VERSION%.*} && CUDA_VER=${CUDA_VER//./} && python3.10 -m pip
 ENV TCNN_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
 RUN python3.10 -m pip install git+https://github.com/NVlabs/tiny-cuda-nn.git@v1.6#subdirectory=bindings/torch
 
-# Install pycolmap 0.3.0, required by hloc.
+# Install pycolmap, required by hloc.
 RUN git clone --branch v0.4.0 --recursive https://github.com/colmap/pycolmap.git && \
     cd pycolmap && \
     python3.10 -m pip install . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,8 +126,7 @@ ENV TCNN_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
 RUN python3.10 -m pip install git+https://github.com/NVlabs/tiny-cuda-nn.git@v1.6#subdirectory=bindings/torch
 
 # Install pycolmap 0.3.0, required by hloc.
-# TODO(https://github.com/colmap/pycolmap/issues/111) use wheel when available for Python 3.10
-RUN git clone --branch v0.3.0 --recursive https://github.com/colmap/pycolmap.git && \
+RUN git clone --branch v0.4.0 --recursive https://github.com/colmap/pycolmap.git && \
     cd pycolmap && \
     python3.10 -m pip install . && \
     cd ..
@@ -139,13 +138,13 @@ RUN git clone --branch master --recursive https://github.com/cvg/Hierarchical-Lo
     cd ..
 
 # Install pyceres from source
-RUN git clone --branch main --recursive https://github.com/cvg/pyceres.git && \
+RUN git clone --branch v1.0 --recursive https://github.com/cvg/pyceres.git && \
     cd pyceres && \
     python3.10 -m pip install -e . && \
     cd ..
 
 # Install pixel perfect sfm.
-RUN git clone --branch main --recursive https://github.com/cvg/pixel-perfect-sfm.git && \
+RUN git clone --branch v1.0 --recursive https://github.com/cvg/pixel-perfect-sfm.git && \
     cd pixel-perfect-sfm && \
     python3.10 -m pip install -e . && \
     cd ..


### PR DESCRIPTION
With pycolmap, pyceres, and pixsfm we're trying to closely track the dev branch of COLMAP. It's safer to use pined versions when building docker images.