### PR TITLE
Affine transform from appearance embedding

### DIFF
--- a/nerfstudio/fields/nerfacto_field.py
+++ b/nerfstudio/fields/nerfacto_field.py
@@ -259,6 +259,10 @@ class NerfactoField(Field):
             # output = trunc_exp(output)
             scale, shift = torch.split(output, [self.geo_feat_dim, self.geo_feat_dim], dim=-1)
             scale = trunc_exp(scale)
+
+            #AdaIN normalization
+            # shift = torch.mean(embedded_appearance, dim=-1).view(-1, 1)
+            # scale = torch.std(embedded_appearance, dim=-1).view(-1, 1)
         else:
             if self.use_average_appearance_embedding:
                 embedded_appearance = torch.ones(
@@ -306,10 +310,12 @@ class NerfactoField(Field):
             x = self.mlp_pred_normals(pred_normals_inp).view(*outputs_shape, -1).to(directions)
             outputs[FieldHeadNames.PRED_NORMALS] = self.field_head_pred_normals(x)
 
+        density_embedding_resized = density_embedding.view(-1, self.geo_feat_dim)
         h = torch.cat(
             [
                 d,
-                density_embedding.view(-1, self.geo_feat_dim) * scale + shift,
+                # density_embedding.view(-1, self.geo_feat_dim) * scale + shift,
+                # ((density_embedding_resized - torch.mean(density_embedding_resized, dim=-1)[..., None])/torch.std(density_embedding_resized, dim=-1)[..., None]) * scale + shift,
                 # density_embedding.view(-1, self.geo_feat_dim),
                 # embedded_appearance.view(-1, self.appearance_embedding_dim),
             ],

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -132,6 +132,8 @@ class NerfactoModelConfig(ModelConfig):
     """Use gradient scaler where the gradients are lower for points closer to the camera."""
     implementation: Literal["tcnn", "torch"] = "tcnn"
     """Which implementation to use for the model."""
+    use_appearance_embedding: bool = True
+    """Whether to use appearance embedding or to predict a scale an shift from it à la Zip-NeRF."""
 
 
 class NerfactoModel(Model):
@@ -165,6 +167,7 @@ class NerfactoModel(Model):
             num_images=self.num_train_data,
             use_pred_normals=self.config.predict_normals,
             use_average_appearance_embedding=self.config.use_average_appearance_embedding,
+            use_appearance_embedding=self.config.use_appearance_embedding,
             implementation=self.config.implementation,
         )
 


### PR DESCRIPTION
Changes:

- I added a flag `--pipeline.model.use-appearance-embedding` that defaults to True
- When set to false the appearance embedding is not passed into the rgb mlp but is instead used to predict a scale and shift for the bottleneck vector. ([Zip-Nerf](https://jonbarron.info/zipnerf/))

Notes:

- Results are variable
- Overall seems to reduce floaters slightly and up the contrast of the scenes
- Sometimes it can cause some extra noise
- It also pushed up the ceiling in the Giannini Hall scene

Comparison:
[Video](https://drive.google.com/file/d/1nkIrV-WDdcLPWEqyWNNlyMkAPexKYdEl/view?usp=sharing)
<img width="1505" alt="Screen Shot 2023-07-13 at 3 33 15 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/71362382/20a5552a-929e-499a-bb77-9c7ca589e3c3">
<img width="1503" alt="Screen Shot 2023-07-13 at 3 33 31 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/71362382/2c4d4b50-2f20-480d-b186-e9a3d56c787b">
<img width="1503" alt="Screen Shot 2023-07-13 at 3 34 17 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/71362382/8765b889-e365-4449-b892-f29c73e77de6">
<img width="1504" alt="Screen Shot 2023-07-13 at 3 34 32 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/71362382/27b44422-1def-454c-b254-2d91d33b9989">
<img width="1503" alt="Screen Shot 2023-07-13 at 3 35 16 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/71362382/bc5af1c7-1db7-41f2-acec-46eb599f4998">
<img width="1503" alt="Screen Shot 2023-07-13 at 3 35 30 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/71362382/1e6ef584-4115-4ed3-be59-77be2ca60210">
