### PR TITLE
Load schedulers from ckpt in a backward-compatible manner

### DIFF
--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -76,6 +76,8 @@ class ExperimentConfig(InstantiateConfig):
     """Alias for --pipeline.model.prompt"""
     relative_model_dir: Path = Path("nerfstudio_models/")
     """Relative path to save all checkpoints."""
+    load_scheduler: bool = True
+    """Whether to load the scheduler state_dict to resume training, if exists"""
 
     def is_viewer_enabled(self) -> bool:
         """Checks if a viewer is enabled."""

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -406,7 +406,8 @@ class Trainer:
             # load the checkpoints for pipeline, optimizers, and gradient scalar
             self.pipeline.load_pipeline(loaded_state["pipeline"], loaded_state["step"])
             self.optimizers.load_optimizers(loaded_state["optimizers"])
-            self.optimizers.load_schedulers(loaded_state["schedulers"])
+            if "schedulers" in loaded_state and self.config.load_scheduler:
+                self.optimizers.load_schedulers(loaded_state["schedulers"])
             self.grad_scaler.load_state_dict(loaded_state["scalers"])
             CONSOLE.print(f"Done loading Nerfstudio checkpoint from {load_path}")
         elif load_checkpoint is not None:
@@ -416,6 +417,8 @@ class Trainer:
             # load the checkpoints for pipeline, optimizers, and gradient scalar
             self.pipeline.load_pipeline(loaded_state["pipeline"], loaded_state["step"])
             self.optimizers.load_optimizers(loaded_state["optimizers"])
+            if "schedulers" in loaded_state and self.config.load_scheduler:
+                self.optimizers.load_schedulers(loaded_state["schedulers"])
             self.grad_scaler.load_state_dict(loaded_state["scalers"])
             CONSOLE.print(f"Done loading Nerfstudio checkpoint from {load_checkpoint}")
         else:


### PR DESCRIPTION
- The loading behavior is similar to that in sdfstudio.
- Allow loading old checkpoints without the schedulers key.
- Versions <= 0.3.2 don't support loading schedulers state_dict, because the states of schedulers are not saved in Trainer.save_checkpoint(). Specifically, commits older than https://github.com/nerfstudio-project/nerfstudio/commit/cebe787bedffd4966fdcb067682da64e168b5565 don't support schedulers loading/saving.
These changes in the commit will save the states of schedulers by default, i.e. creating a schedulers key. Were the checkpoints from previous versions loaded, the loader will check whether the schedulers key exist before loading schedulers.