### PR TITLE
[Bug fix ]Update pixel_samplers.py, tensor on different device, unpredictable behavior at assignment

### DIFF
--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -105,6 +105,7 @@ class PixelSampler:
         assert collated_batch["image"].shape[0] == num_rays_per_batch
 
         # Needed to correct the random indices to their actual camera idx locations.
+        indices = indices.to(batch["image_idx"].device)
         indices[:, 0] = batch["image_idx"][c]
         collated_batch["indices"] = indices  # with the abs camera indices
 


### PR DESCRIPTION
"indices" and "batch["image_idx"]" can be on different devices. The assignment between them, though will allow the model to converge correctly, have unpredictable behaviors. Namely, indices[:, 0] - batch["image_idx"][c].cpu() != 0. Putting them on the same device to have correct behavior.

It is a mystery to me why nerfstudio can work correctly with this unpredictable behavior.