### PR TITLE
Use correct pixel area in volumetric sampler

### DIFF
--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -505,14 +505,13 @@ class VolumetricSampler(Sampler):
         if camera_indices is not None:
             camera_indices = camera_indices[ray_indices]
 
-        zeros = torch.zeros_like(origins[:, :1])
         ray_samples = RaySamples(
             frustums=Frustums(
                 origins=origins,
                 directions=dirs,
                 starts=starts[..., None],
                 ends=ends[..., None],
-                pixel_area=zeros,
+                pixel_area=ray_bundle[ray_indices].pixel_area,
             ),
             camera_indices=camera_indices,
         )


### PR DESCRIPTION
The existing volumetric sampler code returns 0 as the pixel areas. This PR returns the correct values instead.