### PR TITLE
More robust install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,20 @@ Nerfstudio requires `python >= 3.8`. We recommend using conda to manage dependen
 ```bash
 conda create --name nerfstudio -y python=3.8
 conda activate nerfstudio
-python -m pip install --upgrade pip
+pip install --upgrade pip
 ```
 
 ### Dependencies
 
-Install pytorch with CUDA (this repo has been tested with CUDA 11.7 and CUDA 11.8) and [tiny-cuda-nn](https://github.com/NVlabs/tiny-cuda-nn)
+Install PyTorch with CUDA (this repo has been tested with CUDA 11.7 and CUDA 11.8) and [tiny-cuda-nn](https://github.com/NVlabs/tiny-cuda-nn).
+`cuda-toolkit` is required for building `tiny-cuda-nn`.
 
 For CUDA 11.7:
 
 ```bash
 pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
+
+conda install -c "nvidia/label/cuda-11.7.1" cuda-toolkit
 pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
 ```
 
@@ -110,6 +113,8 @@ For CUDA 11.8:
 
 ```bash
 pip install torch==2.0.1+cu118 torchvision==0.15.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+
+conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit
 pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
 ```
 

--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -33,42 +33,45 @@ python -m pip install --upgrade pip
 
 (pytorch)=
 
-### pytorch
+### PyTorch
 
-::::{tab-set}
-:::{tab-item} Torch 2.0.1 with CUDA 11.8
-
-- To install 2.0.1 with CUDA 11.8:
-
-Note that if a pytorch version prior to 2.0.1 is installed,
+Note that if a PyTorch version prior to 2.0.1 is installed,
 the previous version of pytorch, functorch, and tiny-cuda-nn should be uninstalled.
 
 ```bash
 pip uninstall torch torchvision functorch tinycudann
 ```
 
-Install pytorch 2.0.1 with CUDA and [tiny-cuda-nn](https://github.com/NVlabs/tiny-cuda-nn)
+::::{tab-set}
+:::{tab-item} Torch 2.0.1 with CUDA 11.8
+
+Install PyTorch 2.0.1 with CUDA 11.8:
 
 ```bash
 pip install torch==2.0.1+cu118 torchvision==0.15.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
 ```
 
+To build the necessary CUDA extensions, `cuda-toolkit` is also required. We
+recommend installing with conda:
+
+```bash
+conda install -c "nvidia/label/cuda-11.7.1" cuda-toolkit
+```
+
 :::
 :::{tab-item} Torch 2.0.1 with CUDA 11.7
 
-- To install 2.0.1 with CUDA 11.7:
-
-Note that if a pytorch version prior to 2.0.1 is installed,
-the previous version of pytorch, functorch, and tiny-cuda-nn should be uninstalled.
-
-```bash
-pip uninstall torch torchvision functorch tinycudann
-```
-
-Install pytorch 2.0.1 with CUDA and [tiny-cuda-nn](https://github.com/NVlabs/tiny-cuda-nn)
+Install PyTorch 2.0.1 with CUDA 11.7:
 
 ```bash
 pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
+```
+
+To build the necessary CUDA extensions, `cuda-toolkit` is also required. We
+recommend installing with conda:
+
+```bash
+conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit
 ```
 
 :::
@@ -258,7 +261,7 @@ While installing tiny-cuda, you run into: `The detected CUDA version mismatches 
 
 **Solution**:
 
-Reinstall pytorch with the correct CUDA version.
+Reinstall PyTorch with the correct CUDA version.
 See [pytorch](pytorch) under Dependencies, above.
 
  <br />


### PR DESCRIPTION
I just tried an installation on a fresh Ubuntu 22.04 machine, with no system-level CUDA installation.

Unsurprisingly (and as mentioned by @kpertsch), the `tiny-cuda-nn` install step fails without `cuda-toolkit` installed. Running the extra install for `cuda-toolkit` fixes it. I think we should add it to the setup instructions.

A few bits of uncertainty before merging:
- Will a system-level CUDA install break anything here?
- Possibly related: a few people have mentioned needing to fuss with environment variables for all of the linking etc to work. I've never needed to, what's expected here?
- @kpertsch also reported needing to update `gcc` via `conda install -c conda-forge gcc=11.2 gxx=11.2`. We may want to add this to the FAQ.
- Perhaps we should add a note about supported NVIDIA driver versions? The current state of which NVIDIA drivers are compatible which CUDA versions is not entirely clear even to myself... (can a driver be "too new" for CUDA 11.7 etc)