### PR TITLE
Option to process images on GPU for speed at the expense of memory

### DIFF
--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -117,6 +117,8 @@ class DataManagerConfig(InstantiateConfig):
     """Specifies the camera pose optimizer used during training. Helpful if poses are noisy."""
     masks_on_gpu: Optional[bool] = None
     """Process masks on GPU for speed at the expense of memory, if True."""
+    images_on_gpu: Optional[bool] = None
+    """Process images on GPU for speed at the expense of memory, if True."""
 
 
 class DataManager(nn.Module):
@@ -403,6 +405,8 @@ class VanillaDataManager(DataManager, Generic[TDataset]):
         self.exclude_batch_keys_from_device = self.train_dataset.exclude_batch_keys_from_device
         if self.config.masks_on_gpu is True:
             self.exclude_batch_keys_from_device.remove("mask")
+        if self.config.images_on_gpu is True:
+            self.exclude_batch_keys_from_device.remove("image")
 
         if self.train_dataparser_outputs is not None:
             cameras = self.train_dataparser_outputs.cameras

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -115,9 +115,9 @@ class DataManagerConfig(InstantiateConfig):
     """Source of data, may not be used by all models."""
     camera_optimizer: Optional[CameraOptimizerConfig] = None
     """Specifies the camera pose optimizer used during training. Helpful if poses are noisy."""
-    masks_on_gpu: Optional[bool] = None
+    masks_on_gpu: bool = False
     """Process masks on GPU for speed at the expense of memory, if True."""
-    images_on_gpu: Optional[bool] = None
+    images_on_gpu: bool = False
     """Process images on GPU for speed at the expense of memory, if True."""
 
 

--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -42,7 +42,7 @@ class InputDataset(Dataset):
         scale_factor: The scaling factor for the dataparser outputs
     """
 
-    exclude_batch_keys_from_device: List[str] = ["mask"]
+    exclude_batch_keys_from_device: List[str] = ["image", "mask"]
     cameras: Cameras
 
     def __init__(self, dataparser_outputs: DataparserOutputs, scale_factor: float = 1.0):

--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -42,7 +42,7 @@ class InputDataset(Dataset):
         scale_factor: The scaling factor for the dataparser outputs
     """
 
-    exclude_batch_keys_from_device: List[str] = ["image", "mask"]
+    exclude_batch_keys_from_device: List[str] = ["mask"]
     cameras: Cameras
 
     def __init__(self, dataparser_outputs: DataparserOutputs, scale_factor: float = 1.0):


### PR DESCRIPTION
Analogous to #2110. This fix speeds up training by over 3x when using multi-gpu DDP.

The observation that prompted this PR: training with `--num-devices=2` is significantly slower than training with single gpu, with extremely high cpu usage (~2600% on a 28-core cpu).

Profiling with `--logging.profiler=pytorch` reveals that `collate_image_dataset_batch()` in `pixel_samplers.py` takes 70ms with `--num-devices=2` and 30ms with single gpu. The batch image tensors are stored on the cpu, so the indexing operation is cpu-intensive.

<img width="675" alt="Profile" src="https://github.com/nerfstudio-project/nerfstudio/assets/36831950/e8ac20bb-86de-4edd-af37-eb23583a163f">

This PR adds an option to remove `"image"` from `exclude_batch_keys_from_device` to keep the image tensor on the gpu. Using the option with suitable hardware reduces cpu usage from 2600% to 200%, and speeds up 2-gpu training **from ~70 Krays/s to ~250 Krays/s**. Single-gpu training is also sped up from 100 to 140 Krays/s. VRAM usage is increased from 2gb to 5gb.

Profiling the 2-gpu training with this fix confirms that the pixel sampler is no longer a bottleneck.

<img width="893" alt="ProfileAfter" src="https://github.com/nerfstudio-project/nerfstudio/assets/36831950/b304b402-d572-48a2-b553-3c48164ca859">

---
Training configuration: nerfacto default params, on F2Nerf grass scene
Machine: 2x Xeon Gold 5120 (disabled HT), 2x Titan RTX