### PR TITLE
Allow same dimensions optimizations to be disabled

### DIFF
--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -96,6 +96,8 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     """If True, export and use depth maps induced from SfM points."""
     include_depth_debug: bool = False
     """If --use-sfm-depth and this flag is True, also export debug images showing Sf overlaid upon input images."""
+    same_dimensions: bool = True
+    """Whether to assume all images are same dimensions and so to use fast downscaling with no autorotation."""
 
     @staticmethod
     def default_colmap_path() -> Path:

--- a/nerfstudio/process_data/images_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/images_to_nerfstudio_dataset.py
@@ -65,6 +65,7 @@ class ImagesToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
                 crop_factor=self.crop_factor,
                 verbose=self.verbose,
                 num_downscales=self.num_downscales,
+                same_dimensions=self.same_dimensions,
             )
             image_rename_map = dict((a.name, b.name) for a, b in image_rename_map_paths.items())
             num_frames = len(image_rename_map)


### PR DESCRIPTION
Use `ns-process-data images --no-same-dimensions` ... to handle image sets with different dimensions properly, by disabling same-dimensions optimizations.  (Fast downscaling assumes image dimensions are the same.)

Fixes #2293 when --no-same-dimensions is specified, which behaves correctly but unfortunately runs slower.