### PR TITLE
Ddp docs

### DIFF
--- a/docs/quickstart/first_nerf.md
+++ b/docs/quickstart/first_nerf.md
@@ -123,7 +123,7 @@ ns-download-data nerfstudio --capture-name=aspen
 ```python
 # 1 GPU (8192 rays per GPU per batch)
 export CUDA_VISIBLE_DEVICES=0
-ns-train nerfacto-big --vis viewer+wandb --machine.num-gpus 1 --pipeline.datamanager.train-num-rays-per-batch 4096 --data data/nerfstudio/aspen
+ns-train nerfacto-big --vis viewer+wandb --machine.num-devices 1 --pipeline.datamanager.train-num-rays-per-batch 4096 --data data/nerfstudio/aspen
 ```
 
 You would observe about ~70k rays / sec on NVIDIA V100.
@@ -148,7 +148,7 @@ By having more GPUs in the training, you can allocate batch size to multiple GPU
 ```python
 # 2 GPUs (4096 rays per GPU per batch, effectively 8192 rays per batch)
 export CUDA_VISIBLE_DEVICES=0,1
-ns-train nerfacto --vis viewer+wandb --machine.num-gpus 2 --pipeline.datamanager.train-num-rays-per-batch 4096 --data data/nerfstudio/aspen
+ns-train nerfacto --vis viewer+wandb --machine.num-devices 2 --pipeline.datamanager.train-num-rays-per-batch 4096 --data data/nerfstudio/aspen
 ```
 
 You would get improved throughput (~100k rays / sec on two NVIDIA V100).

--- a/tests/data/configs/test_config1.yml
+++ b/tests/data/configs/test_config1.yml
@@ -37,7 +37,7 @@ logging: !!python/object:nerfstudio.configs.base_config.LoggingConfig
 machine: !!python/object:nerfstudio.configs.base_config.MachineConfig
   dist_url: auto
   machine_rank: 0
-  num_gpus: 1
+  num_devices: 1
   num_machines: 1
   seed: 42
 max_num_iterations: 30000

--- a/tests/data/configs/test_config2.yml
+++ b/tests/data/configs/test_config2.yml
@@ -32,7 +32,7 @@ logging: !!python/object:nerfstudio.configs.base_config.LoggingConfig
 machine: !!python/object:nerfstudio.configs.base_config.MachineConfig
   dist_url: auto
   machine_rank: 0
-  num_gpus: 1
+  num_devices: 1
   num_machines: 1
   seed: 42
 max_num_iterations: 30000


### PR DESCRIPTION
Looks like `num_gpus` was renamed to `num_devices` in #1936, fixing the remaining usage of the old name 
