### PR TITLE
Update pyproject.toml: force IPython<=8.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "imageio>=2.21.1",
     'importlib-metadata>=6.0.0; python_version < "3.10"',
     "ipywidgets>=7.6",
+    "ipython<=8.12.0",
     "jaxtyping>=0.2.15",
     "jupyterlab>=3.3.4",
     "matplotlib>=3.5.3",


### PR DESCRIPTION
Hi everyone,
## Background
`IPython` package is not a direct dependency of `nerfstudio`, but required by `ipywidgets`.

## Description of the problem:
With a fresh installation of nerfstudio, the latest `IPython 8.13.0` is installed, which is not compatible with `python 3.8`
```
...
File "/opt/miniconda3/envs/nerf/lib/python3.8/site-packages/IPython/__init__.py", line 30, in <module>
    raise ImportError(
ImportError: 
IPython 8.13+ supports Python 3.9 and above, following NEP 29.
IPython 8.0-8.12 supports Python 3.8 and above, following NEP 29.
When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
Python 3.3 and 3.4 were supported up to IPython 6.x.
Python 3.5 was supported with IPython 7.0 to 7.9.
Python 3.6 was supported with IPython up to 7.16.
Python 3.7 was still supported with the 7.x branch.

See IPython `README.rst` file for more information:

    https://github.com/ipython/ipython/blob/main/README.rst
...
```