### PR TITLE
viser 0.1.0, fix type checker errors

### DIFF
--- a/nerfstudio/viewer_beta/control_panel.py
+++ b/nerfstudio/viewer_beta/control_panel.py
@@ -141,31 +141,31 @@ class ControlPanel:
 
         self.add_element(self._train_speed)
         self.add_element(self._train_util)
-        with self.viser_server.gui_folder("Render Options"):
+        with self.viser_server.add_gui_folder("Render Options"):
             self.add_element(self._max_res)
             self.add_element(self._output_render)
             self.add_element(self._colormap)
             # colormap options
-            with self.viser_server.gui_folder(" "):
+            with self.viser_server.add_gui_folder(" "):
                 self.add_element(self._invert, additional_tags=("colormap",))
                 self.add_element(self._normalize, additional_tags=("colormap",))
                 self.add_element(self._min, additional_tags=("colormap",))
                 self.add_element(self._max, additional_tags=("colormap",))
 
         # split options
-        with self.viser_server.gui_folder("Split Screen"):
+        with self.viser_server.add_gui_folder("Split Screen"):
             self.add_element(self._split)
 
             self.add_element(self._split_percentage, additional_tags=("split",))
             self.add_element(self._split_output_render, additional_tags=("split",))
             self.add_element(self._split_colormap, additional_tags=("split",))
-            with self.viser_server.gui_folder("  "):
+            with self.viser_server.add_gui_folder("  "):
                 self.add_element(self._split_invert, additional_tags=("split_colormap",))
                 self.add_element(self._split_normalize, additional_tags=("split_colormap",))
                 self.add_element(self._split_min, additional_tags=("split_colormap",))
                 self.add_element(self._split_max, additional_tags=("split_colormap",))
 
-        with self.viser_server.gui_folder("Crop Viewport"):
+        with self.viser_server.add_gui_folder("Crop Viewport"):
             self.add_element(self._crop_viewport)
 
             # Crop options

--- a/nerfstudio/viewer_beta/viewer_elements.py
+++ b/nerfstudio/viewer_beta/viewer_elements.py
@@ -100,7 +100,7 @@ class ViewerButton(ViewerElement[bool]):
         super().__init__(name, disabled=disabled, cb_hook=cb_hook)
 
     def _create_gui_handle(self, viser_server: ViserServer) -> None:
-        self.gui_handle = viser_server.add_gui_button(name=self.name, disabled=self.disabled)
+        self.gui_handle = viser_server.add_gui_button(self.name, disabled=self.disabled)
 
     def install(self, viser_server: ViserServer) -> None:
         self._create_gui_handle(viser_server)

--- a/nerfstudio/viewer_beta/viewer_elements.py
+++ b/nerfstudio/viewer_beta/viewer_elements.py
@@ -26,7 +26,7 @@ from viser import (
     GuiButtonGroupHandle,
     GuiButtonHandle,
     GuiDropdownHandle,
-    GuiHandle,
+    GuiInputHandle,
     ViserServer,
 )
 
@@ -49,14 +49,14 @@ class ViewerElement(Generic[TValue]):
         cb_hook: Callable = lambda element: None,
     ) -> None:
         self.name = name
-        self.gui_handle: Optional[Union[GuiHandle[TValue], GuiButtonHandle, GuiButtonGroupHandle]] = None
+        self.gui_handle: Optional[Union[GuiInputHandle[TValue], GuiButtonHandle, GuiButtonGroupHandle]] = None
         self.disabled = disabled
         self.cb_hook = cb_hook
 
     @abstractmethod
     def _create_gui_handle(self, viser_server: ViserServer) -> None:
         """
-        Returns the GuiHandle object which actually controls the parameter in the gui.
+        Returns the GuiInputHandle object which actually controls the parameter in the gui.
 
         Args:
             viser_server: The server to install the gui element into.
@@ -119,7 +119,7 @@ class ViewerParameter(ViewerElement[TValue], Generic[TValue]):
         cb_hook: Callback to call on update
     """
 
-    gui_handle: GuiHandle
+    gui_handle: GuiInputHandle
 
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "torchvision>=0.14.1",
     "torchmetrics[image]>=1.0.1",
     "typing_extensions>=4.4.0",
-    "viser>=0.0.12",
+    "viser==0.1.0",
     "nuscenes-devkit>=1.1.1",
     "wandb>=0.13.3",
     "xatlas",


### PR DESCRIPTION
The latest release of `viser` renames `GuiHandle` to `GuiInputHandle`, since there are now non-input GUI handles. I added a shim so it shouldn't produce any runtime errors (and/or actually break any `nerfstudio` installations), but it's hidden to the type checker and will produce a `pyright` error.