### PR TITLE
Optimizers.scheduler_step() bug fix

### DIFF
--- a/nerfstudio/engine/optimizers.py
+++ b/nerfstudio/engine/optimizers.py
@@ -108,7 +108,7 @@ class Optimizers:
         Args:
             param_group_name: name of scheduler to step forward
         """
-        if self.config.param_group_name.scheduler:  # type: ignore
+        if "scheduler" in self.config[param_group_name]:
             self.schedulers[param_group_name].step()
 
     def zero_grad_all(self) -> None:


### PR DESCRIPTION
I believe there is a bug in the Optimizers.scheduler_step() method:

Calling Optimizers.scheduler_step() results in the error:

> 'dict' object has no attribute 'param_group_name'

Here is a minimal script to produce the error:

```
import torch
from nerfstudio.engine.optimizers import Optimizers, AdamOptimizerConfig
from nerfstudio.engine.schedulers import ExponentialDecaySchedulerConfig

optimizers_config = {
    "fields": {
        "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
        "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
    }
}

dummy_params = [torch.tensor([42.0])]
param_groups = {"fields": dummy_params}

optimizer = Optimizers(optimizers_config, param_groups)
optimizer.optimizer_step("fields")
optimizer.scheduler_step("fields")
```