### PR TITLE
Switching Nerfstudio Dataset data to GDrive URLs

### DIFF
--- a/nerfstudio/scripts/downloads/download_data.py
+++ b/nerfstudio/scripts/downloads/download_data.py
@@ -190,7 +190,12 @@ def download_capture_name(save_dir: Path, dataset_name: str, capture_name: str, 
 
 @dataclass
 class NerfstudioDownload(DatasetDownload):
-    """Download the nerfstudio dataset."""
+    """
+    Download data in the Nerfstudio format.
+    If you are interested in the Nerfstudio Dataset subset from the SIGGRAPH 2023 paper,
+    you can obtain that by using --capture-name nerfstudio-dataset or by visiting Google Drive directly at:
+    https://drive.google.com/drive/folders/19TV6kdVGcmg3cGZ1bNIUnBBMD-iQjRbG?usp=drive_link.
+    """
 
     capture_name: NerfstudioCaptureName = "bww_entrance"
 

--- a/nerfstudio/scripts/downloads/download_data.py
+++ b/nerfstudio/scripts/downloads/download_data.py
@@ -121,16 +121,22 @@ nerfstudio_file_ids = {
     "redwoods2": grab_file_id("https://drive.google.com/file/d/1rg-4NoXT8p6vkmbWxMOY6PSG4j3rfcJ8/view?usp=sharing"),
     "storefront": grab_file_id("https://drive.google.com/file/d/16b792AguPZWDA_YC4igKCwXJqW0Tb21o/view?usp=sharing"),
     "vegetation": grab_file_id("https://drive.google.com/file/d/1wBhLQ2odycrtU39y2akVurXEAt9SsVI3/view?usp=sharing"),
-    "Egypt": "https://data.nerf.studio/nerfstudio/Egypt.zip",
-    "person": "https://data.nerf.studio/nerfstudio/person.zip",
-    "kitchen": "https://data.nerf.studio/nerfstudio/kitchen.zip",
-    "plane": "https://data.nerf.studio/nerfstudio/plane.zip",
-    "dozer": "https://data.nerf.studio/nerfstudio/dozer.zip",
-    "floating-tree": "https://data.nerf.studio/nerfstudio/floating-tree.zip",
-    "aspen": "https://data.nerf.studio/nerfstudio/aspen.zip",
-    "stump": "https://data.nerf.studio/nerfstudio/stump.zip",
-    "sculpture": "https://data.nerf.studio/nerfstudio/sculpture.zip",
-    "Giannini-Hall": "https://data.nerf.studio/nerfstudio/Giannini-Hall.zip",
+    "Egypt": grab_file_id("https://drive.google.com/file/d/1YktD85afw7uitC3nPamusk0vcBdAfjlF/view?view?usp=sharing"),
+    "person": grab_file_id("https://drive.google.com/file/d/1HsGMwkPu-R7oU7ySMdoo6Eppq8pKhHF3/view?view?usp=sharing"),
+    "kitchen": grab_file_id("https://drive.google.com/file/d/1IRmNyNZSNFidyj93Tt5DtaEU9h6eJdi1/view?view?usp=sharing"),
+    "plane": grab_file_id("https://drive.google.com/file/d/1tnv2NC2Iwz4XRYNtziUWvLJjObkZNo2D/view?view?usp=sharing"),
+    "dozer": grab_file_id("https://drive.google.com/file/d/1jQJPz5PhzTH--LOcCxvfzV_SDLEp1de3/view?view?usp=sharing"),
+    "floating-tree": grab_file_id(
+        "https://drive.google.com/file/d/1mVEHcO2ep13WPx92IPDvdQg66vLQwFSy/view?view?usp=sharing"
+    ),
+    "aspen": grab_file_id("https://drive.google.com/file/d/1X1PQcji_QpxGfMxbETKMeK8aOnWCkuSB/view?view?usp=sharing"),
+    "stump": grab_file_id("https://drive.google.com/file/d/1yZFAAEvtw2hs4MXrrkvhVAzEliLLXPB7/view?view?usp=sharing"),
+    "sculpture": grab_file_id(
+        "https://drive.google.com/file/d/1CUU_k0Et2gysuBn_R5qenDMfYXEhNsd1/view?view?usp=sharing"
+    ),
+    "Giannini-Hall": grab_file_id(
+        "https://drive.google.com/file/d/1UkjWXLN4qybq_a-j81FsTKghiXw39O8E/view?view?usp=sharing"
+    ),
     "all": None,
     "nerfstudio-dataset": nerfstudio_dataset,
 }


### PR DESCRIPTION
Changing the location of where the Nerfstudio Dataset is hosted. The prior URLs will be deleted from their location upon merge into main.