### PR TITLE
BARF scheduling for gradients

### DIFF
--- a/nerfstudio/fields/nerfacto_field.py
+++ b/nerfstudio/fields/nerfacto_field.py
@@ -200,6 +200,9 @@ class NerfactoField(Field):
             implementation=implementation,
         )
 
+    def set_step(self, step: int) -> None:
+        self.mlp_base_grid.set_step(step)
+
     def get_density(self, ray_samples: RaySamples) -> Tuple[Tensor, Tensor]:
         """Computes and returns the densities."""
         if self.spatial_distortion is not None:

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -275,6 +275,14 @@ class NerfactoModel(Model):
                     func=self.proposal_sampler.step_cb,
                 )
             )
+            # callback for hash encoding
+            callbacks.append(
+                TrainingCallback(
+                    where_to_run=[TrainingCallbackLocation.AFTER_TRAIN_ITERATION],
+                    update_every_num_iters=1,
+                    func=self.field.set_step,
+                )
+            )
         return callbacks
 
     def get_outputs(self, ray_bundle: RayBundle):


### PR DESCRIPTION
Some papers say that instead of turning hashgrids on over time, weighting the gradients for the hashgrids results in better performance for NGP BARF implementations. This implements that.
See: https://arxiv.org/abs/2302.01571, https://camp-nerf.github.io/