### PR TITLE
cast background to device

### DIFF
--- a/nerfstudio/model_components/renderers.py
+++ b/nerfstudio/model_components/renderers.py
@@ -116,8 +116,7 @@ class RGBRenderer(nn.Module):
             background_color = rgb[..., -1, :]
 
         assert isinstance(background_color, torch.Tensor)
-        background_color = background_color.to(comp_rgb.device)
-        comp_rgb = comp_rgb + background_color * (1.0 - accumulated_weight)
+        comp_rgb = comp_rgb + background_color.to(comp_rgb.device) * (1.0 - accumulated_weight)
         return comp_rgb
 
     @classmethod

--- a/nerfstudio/model_components/renderers.py
+++ b/nerfstudio/model_components/renderers.py
@@ -116,6 +116,7 @@ class RGBRenderer(nn.Module):
             background_color = rgb[..., -1, :]
 
         assert isinstance(background_color, torch.Tensor)
+        background_color = background_color.to(comp_rgb.device)
         comp_rgb = comp_rgb + background_color * (1.0 - accumulated_weight)
         return comp_rgb
 


### PR DESCRIPTION
running `ns-train vanilla-nerf` resulted in the following error:
```bash
Traceback (most recent call last):
  File "/usr/local/bin/ns-train", line 8, in <module>
    sys.exit(entrypoint())                                 
  File "/project_ghent/projects/nerfstudio/nerfstudio/scripts/train.py", line 261, in entrypoint
    main(                                                  
  File "/project_ghent/projects/nerfstudio/nerfstudio/scripts/train.py", line 246, in main
    launch(                                                
  File "/project_ghent/projects/nerfstudio/nerfstudio/scripts/train.py", line 189, in launch
    main_func(local_rank=0, world_size=world_size, config=config)
  File "/project_ghent/projects/nerfstudio/nerfstudio/scripts/train.py", line 100, in train_loop
    trainer.train()                                        
  File "/project_ghent/projects/nerfstudio/nerfstudio/engine/trainer.py", line 255, in train
    loss, loss_dict, metrics_dict = self.train_iteration(step)
  File "/project_ghent/projects/nerfstudio/nerfstudio/utils/profiler.py", line 127, in inner
    out = func(*args, **kwargs)
  File "/project_ghent/projects/nerfstudio/nerfstudio/engine/trainer.py", line 474, in train_iteration
    _, loss_dict, metrics_dict = self.pipeline.get_train_loss_dict(step=step)
  File "/project_ghent/projects/nerfstudio/nerfstudio/utils/profiler.py", line 127, in inner
    out = func(*args, **kwargs)
  File "/project_ghent/projects/nerfstudio/nerfstudio/pipelines/base_pipeline.py", line 299, in get_train_loss_dict
    model_outputs = self._model(ray_bundle)  # train distributed data parallel model if world_size > 1
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1533, in _call_impl
    return forward_call(*args, **kwargs)
  File "/project_ghent/projects/nerfstudio/nerfstudio/models/base_model.py", line 142, in forward
    return self.get_outputs(ray_bundle)
  File "/project_ghent/projects/nerfstudio/nerfstudio/models/vanilla_nerf.py", line 156, in get_outputs
    rgb_coarse = self.renderer_rgb(
  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1533, in _call_impl
    return forward_call(*args, **kwargs)
  File "/project_ghent/projects/nerfstudio/nerfstudio/model_components/renderers.py", line 229, in forward
    rgb = self.combine_rgb(                                
  File "/project_ghent/projects/nerfstudio/nerfstudio/model_components/renderers.py", line 119, in combine_rgb
    comp_rgb = comp_rgb + background_color * (1.0 - accumulated_weight)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```
This pull request fixes this error by casting the background_color to the same device as the comp_rgb.

