### PR TITLE
test_train tmp_path

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -29,7 +29,7 @@ BLACKLIST = [
 ]
 
 
-def set_reduced_config(config: TrainerConfig):
+def set_reduced_config(config: TrainerConfig, tmp_path):
     """Reducing the config settings to speedup test"""
     config.machine.device_type = "cpu"
     if hasattr(config.pipeline.model, "implementation"):
@@ -56,11 +56,15 @@ def set_reduced_config(config: TrainerConfig):
     # remove viewer
     config.viewer.quit_on_train_completion = True
 
+    # timestamp & output directory
+    config.set_timestamp()
+    config.output_dir = tmp_path / "outputs"
+
     return config
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_train():
+def test_train(tmp_path):
     """test run train script works properly"""
     all_config_names = method_configs.keys()
     for config_name in all_config_names:
@@ -69,16 +73,16 @@ def test_train():
             continue
         print(f"testing run for: {config_name}")
         config = method_configs[config_name]
-        config = set_reduced_config(config)
+        config = set_reduced_config(config, tmp_path)
 
         train_loop(local_rank=0, world_size=0, config=config)
 
 
-def test_simple_io():
+def test_simple_io(tmp_path):
     """test to check minimal data IO works correctly"""
     config = method_configs["vanilla-nerf"]
     config.pipeline.datamanager.dataparser = MinimalDataParserConfig(data=Path("tests/data/minimal_parser"))
-    config = set_reduced_config(config)
+    config = set_reduced_config(config, tmp_path)
     train_loop(local_rank=0, world_size=0, config=config)
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -29,7 +29,7 @@ BLACKLIST = [
 ]
 
 
-def set_reduced_config(config: TrainerConfig, tmp_path):
+def set_reduced_config(config: TrainerConfig, tmp_path: Path):
     """Reducing the config settings to speedup test"""
     config.machine.device_type = "cpu"
     if hasattr(config.pipeline.model, "implementation"):
@@ -64,7 +64,7 @@ def set_reduced_config(config: TrainerConfig, tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_train(tmp_path):
+def test_train(tmp_path: Path):
     """test run train script works properly"""
     all_config_names = method_configs.keys()
     for config_name in all_config_names:
@@ -78,7 +78,7 @@ def test_train(tmp_path):
         train_loop(local_rank=0, world_size=0, config=config)
 
 
-def test_simple_io(tmp_path):
+def test_simple_io(tmp_path: Path):
     """test to check minimal data IO works correctly"""
     config = method_configs["vanilla-nerf"]
     config.pipeline.datamanager.dataparser = MinimalDataParserConfig(data=Path("tests/data/minimal_parser"))


### PR DESCRIPTION
Use `tmp_path` [pytest fixture](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmp-path-fixture) during `test_train` to direct the config `output_dir` to temporary pytest subdirectory. Also call to `config.set_timestamp()` to set timestamp on config training directory.
