### PR TITLE
Fix the problem that camera will be freezed when moving forward

### DIFF
--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -133,6 +133,21 @@ export function get_scene_tree() {
     }
   }
 
+  function translateForward(moveDistance) {
+    const curPos = camera_controls.getPosition();
+    const distance = camera_controls.getTarget()
+      .sub(curPos)
+      .normalize()
+      .multiplyScalar(moveDistance);
+    const to = camera_controls.getTarget().add(distance);
+    camera_controls.moveTo(
+      to.x,
+      to.y,
+      to.z,
+      {enableTransition:true}
+    )
+  }
+
   function translate() {
     if (keyMap.KeyD === true) {
       camera_controls.truck(moveSpeed, 0, {enableTransition:true});
@@ -141,22 +156,10 @@ export function get_scene_tree() {
       camera_controls.truck(-moveSpeed, 0, {enableTransition:true});
     }
     if (keyMap.KeyW === true) {
-      const curPos = camera_controls.getPosition();
-      const newTar = camera_controls.getTarget();
-      const newDiff = newTar
-        .sub(curPos)
-        .normalize()
-        .multiplyScalar(curPos.length());
-      camera_controls.setTarget(
-        curPos.x + newDiff.x,
-        curPos.y + newDiff.y,
-        curPos.z + newDiff.z,
-        {enableTransition:true}
-      );
-      camera_controls.dolly(moveSpeed, {enableTransition:true});
+      translateForward(moveSpeed);
     }
     if (keyMap.KeyS === true) {
-      camera_controls.dolly(-moveSpeed, {enableTransition:true});
+      translateForward(-moveSpeed);
     }
     if (keyMap.KeyQ === true) {
       camera_controls.truck(0, moveSpeed, {enableTransition:true});

--- a/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
+++ b/nerfstudio/viewer/app/src/modules/Scene/Scene.jsx
@@ -133,13 +133,13 @@ export function get_scene_tree() {
     }
   }
 
-  function translateForward(moveDistance) {
-    const curPos = camera_controls.getPosition();
-    const distance = camera_controls.getTarget()
-      .sub(curPos)
-      .normalize()
-      .multiplyScalar(moveDistance);
-    const to = camera_controls.getTarget().add(distance);
+  function translateForward(distance) {
+    const to = camera_controls.getTarget().add(
+      camera_controls.getTarget()
+        .sub(camera_controls.getPosition())
+        .normalize()
+        .multiplyScalar(distance)
+    );
     camera_controls.moveTo(
       to.x,
       to.y,


### PR DESCRIPTION
Hi, 
In the web viewer, rotate up/down via mouse drage not work when pressing `w`:

https://github.com/nerfstudio-project/nerfstudio/assets/564361/981b5daa-52b8-4c1d-b007-3941dc49d027

and the camera will be freezed after pressing `w` for a while:

https://github.com/nerfstudio-project/nerfstudio/assets/564361/199eadfa-50b4-48cd-8bd9-a6f7ece54b9f

Current implementation will led to `position` === `target`: https://stackoverflow.com/questions/47503286/why-do-three-js-trackball-controls-freeze-if-camera-position-controls-target

This modification can fix these problems:

https://github.com/nerfstudio-project/nerfstudio/assets/564361/bb04bc71-909d-4555-9221-7f65889f74c3

https://github.com/nerfstudio-project/nerfstudio/assets/564361/b842d754-2714-442d-908c-47ab91ce993a





