### PR TITLE
engine docs

### DIFF
--- a/docs/developer_guides/new_methods.md
+++ b/docs/developer_guides/new_methods.md
@@ -88,7 +88,7 @@ from nerfstudio.engine.trainer import TrainerConfig
 from nerfstudio.plugins.types import MethodSpecification
 
 def MyMethodFunc():
-    return = MethodSpecification(
+    return MethodSpecification(
       config=TrainerConfig(...)
       description="Custom description"
     )

--- a/docs/reference/api/optimizers.rst
+++ b/docs/reference/api/optimizers.rst
@@ -16,3 +16,17 @@ Schedulers
 .. automodule:: nerfstudio.engine.schedulers
    :members:
    :show-inheritance:
+
+Trainer
+----------------
+
+.. automodule:: nerfstudio.engine.trainer
+   :members:
+   :show-inheritance:
+
+Callbacks
+----------------
+
+.. automodule:: nerfstudio.engine.callbacks
+   :members:
+   :show-inheritance:


### PR DESCRIPTION
Build API docs for `nerfstudio.engine.trainer` and `nerfstudio.engine.callbacks`.  

Additional minor correction in `docs/developer_guides/new_methods.md`.