### PR TITLE
Fix issue when extracting all frames from a video.

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -167,7 +167,6 @@ def convert_video_to_images(
             start_y = crop_factor[0]
             crop_cmd = f"crop=w=iw*{width}:h=ih*{height}:x=iw*{start_x}:y=ih*{start_y},"
 
-        num_frames = get_num_frames_in_video(video_path)
         spacing = num_frames // num_frames_target
 
         downscale_chains = [f"[t{i}]scale=iw/{2**i}:ih/{2**i}[out{i}]" for i in range(num_downscales + 1)]

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -183,9 +183,10 @@ def convert_video_to_images(
             + ";".join(downscale_chains)
         )
 
+        ffmpeg_cmd += " -vsync vfr"
+
         if spacing > 1:
             CONSOLE.print("Number of frames to extract:", math.ceil(num_frames / spacing))
-            ffmpeg_cmd += " -vsync vfr"
             select_cmd = f"thumbnail={spacing},setpts=N/TB,"
         else:
             CONSOLE.print("[bold red]Can't satisfy requested number of frames. Extracting all frames.")


### PR DESCRIPTION
We should always be using `-vsync vfr`, even when extracting all frames.
Not doing so results in many times more frames extracted than we expect (i.e. 37891 vs 4143 in my case), and they're not even "real" useful frames.
Not something you would normally run into if you're doing things right, but in doing some A/B testing of different methods of preprocessing, I ran into it anyway.