### PR TITLE
Allow the option for timestamp to be generated for `ns-train --load-config`

### DIFF
--- a/nerfstudio/scripts/train.py
+++ b/nerfstudio/scripts/train.py
@@ -237,7 +237,7 @@ def main(config: TrainerConfig) -> None:
     if config.load_config:
         CONSOLE.log(f"Loading pre-set config from: {config.load_config}")
         config = yaml.load(config.load_config.read_text(), Loader=yaml.Loader)
-        
+
     config.set_timestamp()
 
     # print and save config

--- a/nerfstudio/scripts/train.py
+++ b/nerfstudio/scripts/train.py
@@ -226,7 +226,6 @@ def launch(
 def main(config: TrainerConfig) -> None:
     """Main function."""
 
-    config.set_timestamp()
     if config.data:
         CONSOLE.log("Using --data alias for --data.pipeline.datamanager.data")
         config.pipeline.datamanager.data = config.data
@@ -238,6 +237,8 @@ def main(config: TrainerConfig) -> None:
     if config.load_config:
         CONSOLE.log(f"Loading pre-set config from: {config.load_config}")
         config = yaml.load(config.load_config.read_text(), Loader=yaml.Loader)
+        
+    config.set_timestamp()
 
     # print and save config
     config.print_to_terminal()


### PR DESCRIPTION
When running `ns-train --load-config $CONFIG_PATH` currently the timestamp is fixed to what was in the config file, which is probably fine. But when I omit the `timestamp` parameter from the config file, it would be nice to have a new timestamp be set. Instead, the current implementation leaves the timestamp value as the default string value "{timestamp}" instead of a new valid timestamp. 

I believe we can fix this with a single line change, by moving the call to `config.set_timestamp()` to after loading the config file. I don't see how this will impact anything else.

This won't affect people who want their timestamp fixed to what the config file reads because `config.set_timestamp()` only sets the value if it is set to the default value "{timestamp}" due to the if statement here: 

https://github.com/nerfstudio-project/nerfstudio/blob/ef2fd3dbe1d5b6f35781716b747ea142fe21f5e9/nerfstudio/configs/experiment_config.py#L97-L100

I think this behavior is probably was what was intended originally but got lost overtime. 

I have tested this locally on an ubuntu computer.

Please consider this PR

Cheers