### PR TITLE
[Open for discussion] Rework/remove `density_fn` to support Gaussians.

### DIFF
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -25,6 +25,8 @@ from jaxtyping import Float
 from numpy.typing import NDArray
 from torch import Tensor
 
+from nerfstudio.utils import torch_compile
+
 _EPS = np.finfo(float).eps * 4.0
 
 
@@ -405,7 +407,7 @@ def _compute_residual_and_jacobian(
     return fx, fy, fx_x, fx_y, fy_x, fy_y
 
 
-# @torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
+@torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
 def radial_and_tangential_undistort(
     coords: torch.Tensor,
     distortion_params: torch.Tensor,

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -25,8 +25,6 @@ from jaxtyping import Float
 from numpy.typing import NDArray
 from torch import Tensor
 
-from nerfstudio.utils.misc import torch_compile
-
 _EPS = np.finfo(float).eps * 4.0
 
 
@@ -407,7 +405,7 @@ def _compute_residual_and_jacobian(
     return fx, fy, fx_x, fx_y, fy_x, fy_y
 
 
-@torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
+# @torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
 def radial_and_tangential_undistort(
     coords: torch.Tensor,
     distortion_params: torch.Tensor,

--- a/nerfstudio/fields/base_field.py
+++ b/nerfstudio/fields/base_field.py
@@ -24,7 +24,7 @@ import torch
 from jaxtyping import Float, Shaped
 from torch import Tensor, nn
 
-from nerfstudio.cameras.rays import Frustums, RaySamples
+from nerfstudio.cameras.rays import RaySamples
 from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.field_components.field_heads import FieldHeadNames
 
@@ -44,28 +44,6 @@ class Field(nn.Module):
         super().__init__()
         self._sample_locations = None
         self._density_before_activation = None
-
-    def density_fn(
-        self, positions: Shaped[Tensor, "*bs 3"], times: Optional[Shaped[Tensor, "*bs 1"]] = None
-    ) -> Shaped[Tensor, "*bs 1"]:
-        """Returns only the density. Used primarily with the density grid.
-
-        Args:
-            positions: the origin of the samples/frustums
-        """
-        del times
-        # Need to figure out a better way to describe positions with a ray.
-        ray_samples = RaySamples(
-            frustums=Frustums(
-                origins=positions,
-                directions=torch.ones_like(positions),
-                starts=torch.zeros_like(positions[..., :1]),
-                ends=torch.zeros_like(positions[..., :1]),
-                pixel_area=torch.ones_like(positions[..., :1]),
-            )
-        )
-        density, _ = self.get_density(ray_samples)
-        return density
 
     @abstractmethod
     def get_density(

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -419,14 +419,15 @@ class VolumetricSampler(Sampler):
         density_fn = self.density_fn
 
         def sigma_fn(t_starts, t_ends, ray_indices):
-            filtered_ray_bundle = RayBundle(
-                origins=ray_bundle.origins[ray_indices],
-                directions=ray_bundle.directions[ray_indices],
-                pixel_area=ray_bundle.pixel_area[ray_indices],
-                times=ray_bundle.times[ray_indices] if ray_bundle.times is not None else None,
+            ray_samples = RaySamples(
+                frustums=Frustums(
+                    origins=ray_bundle.origins[ray_indices],
+                    directions=ray_bundle.directions[ray_indices],
+                    starts=t_starts[..., None],
+                    ends=t_ends[..., None],
+                    pixel_area=ray_bundle.pixel_area[ray_indices],
+                ),
             )
-            breakpoint()
-            ray_samples = filtered_ray_bundle.get_ray_samples(t_starts, t_ends)
 
             density, _ = density_fn(ray_samples)
             return density.squeeze(-1)

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -20,7 +20,7 @@ from abc import abstractmethod
 from typing import Any, Callable, List, Optional, Protocol, Tuple, Union
 
 import torch
-from jaxtyping import Float
+from jaxtyping import Float, Shaped
 from nerfacc import OccGridEstimator
 from torch import Tensor, nn
 
@@ -378,8 +378,8 @@ class DensityFn(Protocol):
     """
 
     def __call__(
-        self, positions: Float[Tensor, "*batch 3"], times: Optional[Float[Tensor, "*batch 1"]] = None
-    ) -> Float[Tensor, "*batch 1"]:
+        self, ray_samples: RaySamples
+    ) -> Tuple[Shaped[Tensor, "*batch 1"], Float[Tensor, "*batch num_features"]]:
         ...
 
 
@@ -404,13 +404,11 @@ class VolumetricSampler(Sampler):
         self.density_fn = density_fn
         self.occupancy_grid = occupancy_grid
 
-    def get_sigma_fn(self, origins, directions, times=None) -> Optional[Callable]:
+    def get_sigma_fn(self, ray_bundle: RayBundle) -> Optional[Callable]:
         """Returns a function that returns the density of a point.
 
         Args:
-            origins: Origins of rays
-            directions: Directions of rays
-            times: Times at which rays are sampled
+            ray_bundle: Rays to generate samples for
         Returns:
             Function that returns the density of a point or None if a density function is not provided.
         """
@@ -421,12 +419,17 @@ class VolumetricSampler(Sampler):
         density_fn = self.density_fn
 
         def sigma_fn(t_starts, t_ends, ray_indices):
-            t_origins = origins[ray_indices]
-            t_dirs = directions[ray_indices]
-            positions = t_origins + t_dirs * (t_starts + t_ends)[:, None] / 2.0
-            if times is None:
-                return density_fn(positions).squeeze(-1)
-            return density_fn(positions, times[ray_indices]).squeeze(-1)
+            filtered_ray_bundle = RayBundle(
+                origins=ray_bundle.origins[ray_indices],
+                directions=ray_bundle.directions[ray_indices],
+                pixel_area=ray_bundle.pixel_area[ray_indices],
+                times=ray_bundle.times[ray_indices] if ray_bundle.times is not None else None,
+            )
+            breakpoint()
+            ray_samples = filtered_ray_bundle.get_ray_samples(t_starts, t_ends)
+
+            density, _ = density_fn(ray_samples)
+            return density.squeeze(-1)
 
         return sigma_fn
 
@@ -462,7 +465,6 @@ class VolumetricSampler(Sampler):
 
         rays_o = ray_bundle.origins.contiguous()
         rays_d = ray_bundle.directions.contiguous()
-        times = ray_bundle.times
 
         if ray_bundle.nears is not None and ray_bundle.fars is not None:
             t_min = ray_bundle.nears.contiguous().reshape(-1)
@@ -484,7 +486,7 @@ class VolumetricSampler(Sampler):
             rays_d=rays_d,
             t_min=t_min,
             t_max=t_max,
-            sigma_fn=self.get_sigma_fn(rays_o, rays_d, times),
+            sigma_fn=self.get_sigma_fn(ray_bundle),
             render_step_size=render_step_size,
             near_plane=near_plane,
             far_plane=far_plane,

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -599,10 +599,10 @@ class ProposalNetworkSampler(Sampler):
             if is_prop:
                 if updated:
                     # always update on the first step or the inf check in grad scaling crashes
-                    density = density_fns[i_level](ray_samples.frustums.get_positions())
+                    density, _ = density_fns[i_level](ray_samples)
                 else:
                     with torch.no_grad():
-                        density = density_fns[i_level](ray_samples.frustums.get_positions())
+                        density, _ = density_fns[i_level](ray_samples)
                 weights = ray_samples.get_weights(density)
                 weights_list.append(weights)  # (num_rays, num_samples)
                 ray_samples_list.append(ray_samples)

--- a/nerfstudio/models/generfacto.py
+++ b/nerfstudio/models/generfacto.py
@@ -35,9 +35,9 @@ from nerfstudio.engine.callbacks import (
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.fields.density_fields import HashMLPDensityField
 from nerfstudio.fields.generfacto_field import GenerfactoField
-from nerfstudio.generative.stable_diffusion import StableDiffusion
 from nerfstudio.generative.deepfloyd import DeepFloyd
 from nerfstudio.generative.positional_text_embeddings import PositionalTextEmbeddings
+from nerfstudio.generative.stable_diffusion import StableDiffusion
 from nerfstudio.model_components.losses import (
     MSELoss,
     distortion_loss,
@@ -232,7 +232,7 @@ class GenerfactoModel(Model):
                 self.scene_box.aabb, **prop_net_args, implementation=self.config.implementation
             )
             self.proposal_networks.append(network)
-        self.density_fns.extend([network.density_fn for network in self.proposal_networks])
+        self.density_fns.extend([network.get_density for network in self.proposal_networks])
 
         def update_schedule(step):
             return np.clip(

--- a/nerfstudio/models/instant_ngp.py
+++ b/nerfstudio/models/instant_ngp.py
@@ -132,7 +132,7 @@ class NGPModel(Model):
         # Sampler
         self.sampler = VolumetricSampler(
             occupancy_grid=self.occupancy_grid,
-            density_fn=self.field.density_fn,
+            density_fn=self.field.get_density,
         )
 
         # renderers

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -29,7 +29,11 @@ from torchmetrics.image import PeakSignalNoiseRatio
 from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
 
 from nerfstudio.cameras.rays import RayBundle, RaySamples
-from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
+from nerfstudio.engine.callbacks import (
+    TrainingCallback,
+    TrainingCallbackAttributes,
+    TrainingCallbackLocation,
+)
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.field_components.spatial_distortions import SceneContraction
 from nerfstudio.fields.density_fields import HashMLPDensityField
@@ -42,8 +46,16 @@ from nerfstudio.model_components.losses import (
     pred_normal_loss,
     scale_gradients_by_distance_squared,
 )
-from nerfstudio.model_components.ray_samplers import ProposalNetworkSampler, UniformSampler
-from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, NormalsRenderer, RGBRenderer
+from nerfstudio.model_components.ray_samplers import (
+    ProposalNetworkSampler,
+    UniformSampler,
+)
+from nerfstudio.model_components.renderers import (
+    AccumulationRenderer,
+    DepthRenderer,
+    NormalsRenderer,
+    RGBRenderer,
+)
 from nerfstudio.model_components.scene_colliders import NearFarCollider
 from nerfstudio.model_components.shaders import NormalsShader
 from nerfstudio.models.base_model import Model, ModelConfig
@@ -179,7 +191,7 @@ class NerfactoModel(Model):
                 implementation=self.config.implementation,
             )
             self.proposal_networks.append(network)
-            self.density_fns.extend([network.density_fn for _ in range(num_prop_nets)])
+            self.density_fns.extend([network.get_density for _ in range(num_prop_nets)])
         else:
             for i in range(num_prop_nets):
                 prop_net_args = self.config.proposal_net_args_list[min(i, len(self.config.proposal_net_args_list) - 1)]
@@ -190,7 +202,7 @@ class NerfactoModel(Model):
                     implementation=self.config.implementation,
                 )
                 self.proposal_networks.append(network)
-            self.density_fns.extend([network.density_fn for network in self.proposal_networks])
+            self.density_fns.extend([network.get_density for network in self.proposal_networks])
 
         # Samplers
         def update_schedule(step):

--- a/nerfstudio/models/neus_facto.py
+++ b/nerfstudio/models/neus_facto.py
@@ -106,7 +106,7 @@ class NeuSFactoModel(NeuSModel):
                 self.scene_box.aabb, spatial_distortion=self.scene_contraction, **prop_net_args
             )
             self.proposal_networks.append(network)
-            self.density_fns.extend([network.density_fn for _ in range(num_prop_nets)])
+            self.density_fns.extend([network.get_density for _ in range(num_prop_nets)])
         else:
             for i in range(num_prop_nets):
                 prop_net_args = self.config.proposal_net_args_list[min(i, len(self.config.proposal_net_args_list) - 1)]
@@ -116,7 +116,7 @@ class NeuSFactoModel(NeuSModel):
                     **prop_net_args,
                 )
                 self.proposal_networks.append(network)
-            self.density_fns.extend([network.density_fn for network in self.proposal_networks])
+            self.density_fns.extend([network.get_density for network in self.proposal_networks])
 
         # update proposal network every iterations
         def update_schedule(_):

--- a/nerfstudio/models/semantic_nerfw.py
+++ b/nerfstudio/models/semantic_nerfw.py
@@ -109,12 +109,12 @@ class SemanticNerfWModel(Model):
         if self.config.use_same_proposal_network:
             network = HashMLPDensityField(self.scene_box.aabb, spatial_distortion=scene_contraction)
             self.proposal_networks.append(network)
-            self.density_fns = [network.density_fn for _ in range(self.config.num_proposal_iterations)]
+            self.density_fns = [network.get_density for _ in range(self.config.num_proposal_iterations)]
         else:
             for _ in range(self.config.num_proposal_iterations):
                 network = HashMLPDensityField(self.scene_box.aabb, spatial_distortion=scene_contraction)
                 self.proposal_networks.append(network)
-            self.density_fns = [network.density_fn for network in self.proposal_networks]
+            self.density_fns = [network.get_density for network in self.proposal_networks]
 
         # Collider
         self.collider = NearFarCollider(near_plane=self.config.near_plane, far_plane=self.config.far_plane)


### PR DESCRIPTION
### issue
The `density_fn` in `class Field` takes different arguments than `get_density` (it takes positions instead of RaySamples).
As a result, it is not possible to use the ProposalNetworkSampler with networks that do not take positions as arguments. One example is: MipNerf360, which uses Gaussians in the proposal network.
More generally, I don't think it makes sense to have a function that is nearly identical to `get_density`, but that takes in non-standard arguments.

### Proposed fix
deprecate `density_fn` it can nearly always be replaced with `get_density`. In places where it is not straightforward to replace it with `get_density` (e.g. the occupancy grid) use a custom wrapper function.

#### Problem with the fix
It is a breaking change, but a breaking change will be necessary if you want to support e.g. mipnerf360.
I don't know the policy for breaking changes, but one could always not immediately remove the `density_fn` and put a deprecation warning on it.