### PR TITLE
.vscode settings match move to ms-python.black-formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,7 @@
   "editor.formatOnSave": true,
   "python.envFile": "${workspaceFolder}/.env",
   "python.formatting.provider": "none",
-  "python.formatting.blackArgs": ["--line-length=120"],
+  "black-formatter.args": ["--line-length=120"],
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": false,
   "python.linting.enabled": true,


### PR DESCRIPTION
in #2086 @kerrj  changed the vscode settings to ms-python.black-formatter but should have also changed the way the arguments are passed to it.
