### PR TITLE
Track all viser GUI folders to avoid folder duplicates (viewer-beta)

### DIFF
--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -161,22 +161,39 @@ class Viewer:
         with tabs.add_tab("Export", viser.Icon.PACKAGE_EXPORT):
             populate_export_tab(self.viser_server, self.control_panel, config_path)
 
-        def nested_folder_install(folder_labels: List[str], element: ViewerElement):
+        # Keep track of the pointers to generated GUI folders, because each generated folder holds a unique ID. 
+        viewer_gui_folders = dict()
+        def nested_folder_install(folder_labels: List[str], prev_labels: List[str], element: ViewerElement):
             if len(folder_labels) == 0:
                 element.install(self.viser_server)
                 # also rewire the hook to rerender
                 prev_cb = element.cb_hook
                 element.cb_hook = lambda element: [prev_cb(element), self._interrupt_render(element)]
             else:
-                with self.viser_server.add_gui_folder(folder_labels[0]):
-                    nested_folder_install(folder_labels[1:], element)
+                # recursively create folders
+                # If the folder name is "Custom Elements/a/b", then:
+                #   in the beginning: folder_path will be 
+                #       "/".join([] + ["Custom Elements"]) --> "Custom Elements"
+                #   later, folder_path will be 
+                #       "/".join(["Custom Elements"] + ["a"]) --> "Custom Elements/a"
+                #       "/".join(["Custom Elements", "a"] + ["b"]) --> "Custom Elements/a/b"
+                #  --> the element will be installed in the folder "Custom Elements/a/b"
+                # 
+                # Note that the gui_folder is created only when the folder is not in viewer_gui_folders,
+                # and we use the folder_path as the key to check if the folder is already created.
+                # Otherwise, use the existing folder as context manager.
+                folder_path = "/".join(prev_labels + [folder_labels[0]])
+                if folder_path not in viewer_gui_folders:
+                    viewer_gui_folders[folder_path] = self.viser_server.add_gui_folder(folder_labels[0])
+                with viewer_gui_folders[folder_path]:
+                    nested_folder_install(folder_labels[1:], prev_labels + [folder_labels[0]], element)
 
         with control_tab:
             self.viewer_elements = []
             self.viewer_elements.extend(parse_object(pipeline, ViewerElement, "Custom Elements"))
             for param_path, element in self.viewer_elements:
                 folder_labels = param_path.split("/")[:-1]
-                nested_folder_install(folder_labels, element)
+                nested_folder_install(folder_labels, [], element)
 
             # scrape the trainer/pipeline for any ViewerControl objects to initialize them
             self.viewer_controls: List[ViewerControl] = [

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -161,8 +161,9 @@ class Viewer:
         with tabs.add_tab("Export", viser.Icon.PACKAGE_EXPORT):
             populate_export_tab(self.viser_server, self.control_panel, config_path)
 
-        # Keep track of the pointers to generated GUI folders, because each generated folder holds a unique ID. 
+        # Keep track of the pointers to generated GUI folders, because each generated folder holds a unique ID.
         viewer_gui_folders = dict()
+
         def nested_folder_install(folder_labels: List[str], prev_labels: List[str], element: ViewerElement):
             if len(folder_labels) == 0:
                 element.install(self.viser_server)
@@ -172,13 +173,13 @@ class Viewer:
             else:
                 # recursively create folders
                 # If the folder name is "Custom Elements/a/b", then:
-                #   in the beginning: folder_path will be 
+                #   in the beginning: folder_path will be
                 #       "/".join([] + ["Custom Elements"]) --> "Custom Elements"
-                #   later, folder_path will be 
+                #   later, folder_path will be
                 #       "/".join(["Custom Elements"] + ["a"]) --> "Custom Elements/a"
                 #       "/".join(["Custom Elements", "a"] + ["b"]) --> "Custom Elements/a/b"
                 #  --> the element will be installed in the folder "Custom Elements/a/b"
-                # 
+                #
                 # Note that the gui_folder is created only when the folder is not in viewer_gui_folders,
                 # and we use the folder_path as the key to check if the folder is already created.
                 # Otherwise, use the existing folder as context manager.


### PR DESCRIPTION
With the current "Custom Elements" folder generation, you end up with duplicate folder structures like below:

Given this ViewerText in nerfacto.py
<img width="462" alt="image" src="https://github.com/nerfstudio-project/nerfstudio/assets/10284938/c77b06f1-0710-4c14-a0a0-ad7e54c3c294">
The folder appears as
<img width="311" alt="image" src="https://github.com/nerfstudio-project/nerfstudio/assets/10284938/c838c15b-02ce-40aa-bf3f-a31b9aa44b38">

This is because viser's `gui_add_folder` creates a unique ID for every folder -- there can exist two folders with the exact same names, but with different IDs --> duplicate structures. 
https://github.com/nerfstudio-project/nerfstudio/blob/53037ba8a790a7aa089c8a4983c2aa210e01111c/nerfstudio/viewer_beta/viewer.py#L171

This PR changes the viewer element population code to keep track of all the generated folders (with their respective paths), so that the previously folder contexts are used instead of re-generating them (if applicable).

With the PR the structure should be fixed:
<img width="307" alt="image" src="https://github.com/nerfstudio-project/nerfstudio/assets/10284938/2ae4d0c6-bb99-4d11-8e7b-59d6435a737e">
, with it also working for nested structures as expected (adding ViewerTexts in nerfacto_field.py):
<img width="300" alt="image" src="https://github.com/nerfstudio-project/nerfstudio/assets/10284938/fb043dab-5e68-4df2-8121-ae2577fc0483">
