### PR TITLE
Add support of using both Comet and Viewer at the same time

### DIFF
--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -83,7 +83,7 @@ class ExperimentConfig(InstantiateConfig):
 
     def is_viewer_enabled(self) -> bool:
         """Checks if a viewer is enabled."""
-        return ("viewer" == self.vis) | ("viewer+wandb" == self.vis) | ("viewer+tensorboard" == self.vis)
+        return self.vis in ("viewer", "viewer+wandb", "viewer+tensorboard", "viewer+comet")
 
     def is_viewer_beta_enabled(self) -> bool:
         """Checks if a viewer beta is enabled."""


### PR DESCRIPTION
In our previous PR https://github.com/nerfstudio-project/nerfstudio/pull/2431, we forgot to update the is_viewer_enabled function, causing an issue where Comet and the Viewer could not be used simultaneously. This issue has now been resolved. Additionally, I took the opportunity to slightly refactor the function, making it easier to update in the future.