### PR TITLE
(minor) Align upsampling in TensorCPEncoding with TensorVMEncoding

### DIFF
--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -482,9 +482,10 @@ class TensorCPEncoding(Encoding):
             resolution: Target resolution.
         """
 
-        self.line_coef.data = F.interpolate(
+        line_coef = F.interpolate(
             self.line_coef.data, size=(resolution, 1), mode="bilinear", align_corners=True
         )
+        self.line_coef = torch.nn.Parameter(line_coef)
 
         self.resolution = resolution
 

--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -482,9 +482,7 @@ class TensorCPEncoding(Encoding):
             resolution: Target resolution.
         """
 
-        line_coef = F.interpolate(
-            self.line_coef.data, size=(resolution, 1), mode="bilinear", align_corners=True
-        )
+        line_coef = F.interpolate(self.line_coef.data, size=(resolution, 1), mode="bilinear", align_corners=True)
         self.line_coef = torch.nn.Parameter(line_coef)
 
         self.resolution = resolution


### PR DESCRIPTION
The previous implementation caused a training crash. Fix it according to VMEncoding.