### PR TITLE
Add scannetpp dataparser

### DIFF
--- a/nerfstudio/configs/dataparser_configs.py
+++ b/nerfstudio/configs/dataparser_configs.py
@@ -35,6 +35,7 @@ from nerfstudio.data.dataparsers.phototourism_dataparser import PhototourismData
 from nerfstudio.data.dataparsers.scannet_dataparser import ScanNetDataParserConfig
 from nerfstudio.data.dataparsers.sdfstudio_dataparser import SDFStudioDataParserConfig
 from nerfstudio.data.dataparsers.sitcoms3d_dataparser import Sitcoms3DDataParserConfig
+from nerfstudio.data.dataparsers.scannetpp_dataparser import ScanNetppDataParserConfig
 from nerfstudio.plugins.registry_dataparser import discover_dataparsers
 
 dataparsers = {
@@ -51,6 +52,7 @@ dataparsers = {
     "sdfstudio-data": SDFStudioDataParserConfig(),
     "nerfosr-data": NeRFOSRDataParserConfig(),
     "sitcoms3d-data": Sitcoms3DDataParserConfig(),
+    "scannetpp-data": ScanNetppDataParserConfig(),
     "colmap": ColmapDataParserConfig(),
 }
 

--- a/nerfstudio/data/dataparsers/scannetpp_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannetpp_dataparser.py
@@ -22,11 +22,8 @@ from typing import Literal, Type
 import numpy as np
 import torch
 from nerfstudio.cameras import camera_utils
-from nerfstudio.cameras.cameras import (CAMERA_MODEL_TO_TYPE, Cameras,
-                                        CameraType)
-from nerfstudio.data.dataparsers.base_dataparser import (DataParser,
-                                                         DataParserConfig,
-                                                         DataparserOutputs)
+from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras, CameraType
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.io import load_from_json
 from nerfstudio.utils.rich_utils import CONSOLE

--- a/nerfstudio/data/dataparsers/scannetpp_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannetpp_dataparser.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Optional, Type
+from typing import Literal, Type
 
 import numpy as np
 import torch

--- a/nerfstudio/data/dataparsers/scannetpp_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannetpp_dataparser.py
@@ -22,11 +22,8 @@ from typing import Literal, Optional, Type
 import numpy as np
 import torch
 from nerfstudio.cameras import camera_utils
-from nerfstudio.cameras.cameras import (CAMERA_MODEL_TO_TYPE, Cameras,
-                                        CameraType)
-from nerfstudio.data.dataparsers.base_dataparser import (DataParser,
-                                                         DataParserConfig,
-                                                         DataparserOutputs)
+from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras, CameraType
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.io import load_from_json
 from nerfstudio.utils.rich_utils import CONSOLE

--- a/nerfstudio/data/dataparsers/scannetpp_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannetpp_dataparser.py
@@ -1,0 +1,244 @@
+# Copyright 2022 the Regents of the University of California, Nerfstudio Team and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Data parser for ScanNet++ datasets. """
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Optional, Type
+
+import numpy as np
+import torch
+from nerfstudio.cameras import camera_utils
+from nerfstudio.cameras.cameras import (CAMERA_MODEL_TO_TYPE, Cameras,
+                                        CameraType)
+from nerfstudio.data.dataparsers.base_dataparser import (DataParser,
+                                                         DataParserConfig,
+                                                         DataparserOutputs)
+from nerfstudio.data.scene_box import SceneBox
+from nerfstudio.utils.io import load_from_json
+from nerfstudio.utils.rich_utils import CONSOLE
+
+
+@dataclass
+class ScanNetppDataParserConfig(DataParserConfig):
+    """ScanNet++ dataset config."""
+
+    _target: Type = field(default_factory=lambda: ScanNetpp)
+    """target class to instantiate"""
+    data: Path = Path()
+    """Directory to the root of the data."""
+    scene_id: str = ""
+    """The scene id to load."""
+    scale_factor: float = 1.0
+    """How much to scale the camera origins by."""
+    scene_scale: float = 1.0
+    """How much to scale the region of interest by."""
+    orientation_method: Literal["pca", "up", "vertical", "none"] = "up"
+    """The method to use for orientation."""
+    center_method: Literal["poses", "focus", "none"] = "poses"
+    """The method to use to center the poses."""
+    auto_scale_poses: bool = True
+    """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
+
+
+@dataclass
+class ScanNetpp(DataParser):
+    """ScanNet++ DatasetParser"""
+
+    config: ScanNetppDataParserConfig
+
+    def _generate_dataparser_outputs(self, split="train"):
+        assert self.config.data.exists(), f"Data directory {self.config.data} does not exist."
+        meta = load_from_json(self.config.data / self.config.scene_id / "dslr/nerfstudio/transforms.json")
+        data_dir = self.config.data / self.config.scene_id / "dslr/resized_images"
+        mask_dir = self.config.data / self.config.scene_id / "dslr/resized_anon_masks"
+
+        image_filenames = []
+        mask_filenames = []
+        poses = []
+
+        fx_fixed = "fl_x" in meta
+        fy_fixed = "fl_y" in meta
+        cx_fixed = "cx" in meta
+        cy_fixed = "cy" in meta
+        height_fixed = "h" in meta
+        width_fixed = "w" in meta
+        distort_fixed = False
+        for distort_key in ["k1", "k2", "k3", "p1", "p2"]:
+            if distort_key in meta:
+                distort_fixed = True
+                break
+        fx = []
+        fy = []
+        cx = []
+        cy = []
+        height = []
+        width = []
+        distort = []
+
+        i_train = []
+        i_eval = []
+        # sort the frames by fname
+        frames = meta["frames"] + meta["test_frames"]
+        test_frames = [f["file_path"] for f in meta["test_frames"]]
+        frames.sort(key=lambda x: x["file_path"])
+
+        for idx, frame in enumerate(frames):
+            filepath = Path(frame["file_path"])
+            fname = data_dir / filepath
+
+            if not fx_fixed:
+                assert "fl_x" in frame, "fx not specified in frame"
+                fx.append(float(frame["fl_x"]))
+            if not fy_fixed:
+                assert "fl_y" in frame, "fy not specified in frame"
+                fy.append(float(frame["fl_y"]))
+            if not cx_fixed:
+                assert "cx" in frame, "cx not specified in frame"
+                cx.append(float(frame["cx"]))
+            if not cy_fixed:
+                assert "cy" in frame, "cy not specified in frame"
+                cy.append(float(frame["cy"]))
+            if not height_fixed:
+                assert "h" in frame, "height not specified in frame"
+                height.append(int(frame["h"]))
+            if not width_fixed:
+                assert "w" in frame, "width not specified in frame"
+                width.append(int(frame["w"]))
+            if not distort_fixed:
+                distort.append(
+                    camera_utils.get_distortion_params(
+                        k1=float(frame["k1"]) if "k1" in frame else 0.0,
+                        k2=float(frame["k2"]) if "k2" in frame else 0.0,
+                        k3=float(frame["k3"]) if "k3" in frame else 0.0,
+                        k4=float(frame["k4"]) if "k4" in frame else 0.0,
+                        p1=float(frame["p1"]) if "p1" in frame else 0.0,
+                        p2=float(frame["p2"]) if "p2" in frame else 0.0,
+                    )
+                )
+
+            image_filenames.append(fname)
+            poses.append(np.array(frame["transform_matrix"]))
+            if "mask_path" in frame:
+                mask_filepath = Path(frame["mask_path"])
+                mask_fname = mask_dir / mask_filepath
+                mask_filenames.append(mask_fname)
+
+            if frame["file_path"] in test_frames:
+                i_eval.append(idx)
+            else:
+                i_train.append(idx)
+
+        assert len(mask_filenames) == 0 or (
+            len(mask_filenames) == len(image_filenames)
+        ), """
+        Different number of image and mask filenames.
+        You should check that mask_path is specified for every frame (or zero frames) in transforms.json.
+        """
+
+        if split == "train":
+            indices = i_train
+        elif split in ["val", "test"]:
+            indices = i_eval
+        else:
+            raise ValueError(f"Unknown dataparser split {split}")
+
+        if "orientation_override" in meta:
+            orientation_method = meta["orientation_override"]
+            CONSOLE.log(f"[yellow] Dataset is overriding orientation method to {orientation_method}")
+        else:
+            orientation_method = self.config.orientation_method
+
+        poses = torch.from_numpy(np.array(poses).astype(np.float32))
+        poses, transform_matrix = camera_utils.auto_orient_and_center_poses(
+            poses,
+            method=orientation_method,
+            center_method=self.config.center_method,
+        )
+
+        # Scale poses
+        scale_factor = 1.0
+        if self.config.auto_scale_poses:
+            scale_factor /= float(torch.max(torch.abs(poses[:, :3, 3])))
+        scale_factor *= self.config.scale_factor
+
+        poses[:, :3, 3] *= scale_factor
+
+        # Choose image_filenames and poses based on split, but after auto orient and scaling the poses.
+        image_filenames = [image_filenames[i] for i in indices]
+        mask_filenames = [mask_filenames[i] for i in indices] if len(mask_filenames) > 0 else []
+
+        idx_tensor = torch.tensor(indices, dtype=torch.long)
+        poses = poses[idx_tensor]
+
+        # in x,y,z order
+        # assumes that the scene is centered at the origin
+        if not self.config.auto_scale_poses:
+            # Set aabb_scale to scene_scale * the max of the absolute values of the poses
+            aabb_scale = self.config.scene_scale * float(torch.max(torch.abs(poses[:, :3, 3])))
+        else:
+            aabb_scale = self.config.scene_scale
+        scene_box = SceneBox(
+            aabb=torch.tensor(
+                [[-aabb_scale, -aabb_scale, -aabb_scale], [aabb_scale, aabb_scale, aabb_scale]], dtype=torch.float32
+            )
+        )
+
+        if "camera_model" in meta:
+            camera_type = CAMERA_MODEL_TO_TYPE[meta["camera_model"]]
+        else:
+            camera_type = CameraType.PERSPECTIVE
+
+        fx = float(meta["fl_x"]) if fx_fixed else torch.tensor(fx, dtype=torch.float32)[idx_tensor]
+        fy = float(meta["fl_y"]) if fy_fixed else torch.tensor(fy, dtype=torch.float32)[idx_tensor]
+        cx = float(meta["cx"]) if cx_fixed else torch.tensor(cx, dtype=torch.float32)[idx_tensor]
+        cy = float(meta["cy"]) if cy_fixed else torch.tensor(cy, dtype=torch.float32)[idx_tensor]
+        height = int(meta["h"]) if height_fixed else torch.tensor(height, dtype=torch.int32)[idx_tensor]
+        width = int(meta["w"]) if width_fixed else torch.tensor(width, dtype=torch.int32)[idx_tensor]
+        if distort_fixed:
+            distortion_params = camera_utils.get_distortion_params(
+                k1=float(meta["k1"]) if "k1" in meta else 0.0,
+                k2=float(meta["k2"]) if "k2" in meta else 0.0,
+                k3=float(meta["k3"]) if "k3" in meta else 0.0,
+                k4=float(meta["k4"]) if "k4" in meta else 0.0,
+                p1=float(meta["p1"]) if "p1" in meta else 0.0,
+                p2=float(meta["p2"]) if "p2" in meta else 0.0,
+            )
+        else:
+            distortion_params = torch.stack(distort, dim=0)[idx_tensor]
+
+        cameras = Cameras(
+            fx=fx,
+            fy=fy,
+            cx=cx,
+            cy=cy,
+            distortion_params=distortion_params,
+            height=height,
+            width=width,
+            camera_to_worlds=poses[:, :3, :4],
+            camera_type=camera_type,
+        )
+
+        dataparser_outputs = DataparserOutputs(
+            image_filenames=image_filenames,
+            cameras=cameras,
+            scene_box=scene_box,
+            mask_filenames=mask_filenames if len(mask_filenames) > 0 else None,
+            dataparser_scale=scale_factor,
+            dataparser_transform=transform_matrix,
+            metadata={},
+        )
+        return dataparser_outputs

--- a/nerfstudio/data/dataparsers/scannetpp_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannetpp_dataparser.py
@@ -31,7 +31,21 @@ from nerfstudio.utils.rich_utils import CONSOLE
 
 @dataclass
 class ScanNetppDataParserConfig(DataParserConfig):
-    """ScanNet++ dataset config."""
+    """ScanNet++ dataset config.
+    ScanNet++ dataset (https://kaldir.vc.in.tum.de/scannetpp/) is a large scale 3D indoor dataset for semantics understanding and novel view synthesis.
+    This dataparser follow the file structure of the dataset.
+    Expected structure of the directory:
+
+    .. code-block:: text
+
+        root/
+        ├── SCENE_ID0/
+            ├── resized_images
+            ├── resized_anon_masks
+            ├── dslr/nerfstudio/transforms.json
+        ├── SCENE_ID1/
+        ...
+    """
 
     _target: Type = field(default_factory=lambda: ScanNetpp)
     """target class to instantiate"""


### PR DESCRIPTION
Dataparser for the [ScanNet++](https://kaldir.vc.in.tum.de/scannetpp/) dataset adapted from the nerfstudio dataset. The dataset parser follows the dataset file structure and can be used by specifying the dataset root and the scene ID.

Example usage
```shell
DATA_ROOT=SCANNETPP_DATASET_ROOT
SCENE_ID=036bce3393

ns-train nerfacto \
     --max_num_iterations 100000 \
     --pipeline.datamanager.train_num_rays_per_batch 8192 \
     --pipeline.datamanager.train_num_images_to_sample_from 400 \
     --pipeline.datamanager.train_num_times_to_repeat_images 100 \
     --vis viewer+tensorboard \
     scannetpp-data \
     --data ${DATA_ROOT} \
     --scene-id ${SCENE_ID} \
     --scene_scale 1.5
```
The scene contain more than 1k images. Set `train_num_images_to_sample_from` and `train_num_times_to_repeat_images` to avoid cpu out-of-memory.

Training with the viewer. The images with red borders are the predefined testing images by the dataset
![image](https://github.com/nerfstudio-project/nerfstudio/assets/8998128/62707d85-a2c4-40cf-b588-0f6ccd3575fe)

The result rendering
https://github.com/nerfstudio-project/nerfstudio/assets/8998128/e4c01178-cafa-4e28-837c-6b0bdf5538d5

