### PR TITLE
Integrate scene click capability from original viewer

### DIFF
--- a/docs/developer_guides/viewer/viewer_control.md
+++ b/docs/developer_guides/viewer/viewer_control.md
@@ -62,7 +62,7 @@ class MyModel(nn.Module):  # Must inherit from nn.Module
         self.viewer_button = ViewerButton(name="Dummy Button",cb_hook=button_cb)
 ```
 
-## Double-click Callbacks
+## Scene Click Callbacks
 We forward *single* clicks inside the viewer to the ViewerControl object, which you can use to interact with the scene. To do this, register a callback using `register_click_cb()`. The click is defined to be a ray that starts at the camera origin and passes through the click point on the screen, in world coordinates. 
 
 ```python

--- a/docs/developer_guides/viewer/viewer_control.md
+++ b/docs/developer_guides/viewer/viewer_control.md
@@ -63,7 +63,7 @@ class MyModel(nn.Module):  # Must inherit from nn.Module
 ```
 
 ## Double-click Callbacks
-We forward *double* clicks inside the viewer to the ViewerControl object, which you can use to interact with the scene. To do this, register a callback using `register_click_cb()`. The click is defined to be a ray that starts at the camera origin and passes through the click point on the screen, in world coordinates. 
+We forward *single* clicks inside the viewer to the ViewerControl object, which you can use to interact with the scene. To do this, register a callback using `register_click_cb()`. The click is defined to be a ray that starts at the camera origin and passes through the click point on the screen, in world coordinates. 
 
 ```python
 from nerfstudio.viewer.server.viewer_elements import ViewerControl,ViewerClick
@@ -74,6 +74,16 @@ class MyModel(nn.Module):  # must inherit from nn.Module
         self.viewer_control = ViewerControl()  # no arguments
         def click_cb(click: ViewerClick):
             print(f"Click at {click.origin} in direction {click.direction}")
+        self.viewer_control.register_click_cb(click_cb)
+```
+
+You can also use `unregister_click_cb()` to remove callbacks that are no longer needed. A good example is a "Click on Scene" button, that when pressed, would register a callback that would wait for the next click, and then unregister itself.
+```python
+    ...
+    def button_cb(button: ViewerButton):
+        def click_cb(click: ViewerClick):
+            print(f"Click at {click.origin} in direction {click.direction}")
+            self.viewer_control.unregister_click_cb(click_cb)
         self.viewer_control.register_click_cb(click_cb)
 ```
 

--- a/nerfstudio/viewer_beta/viewer_elements.py
+++ b/nerfstudio/viewer_beta/viewer_elements.py
@@ -152,12 +152,19 @@ class ViewerControl:
             cb: The callback to call when a click is detected.
                 The callback should take a ViewerClick object as an argument
         """
+        from nerfstudio.viewer_beta.viewer import VISER_NERFSTUDIO_SCALE_RATIO
 
         def wrapped_cb(scene_pointer_msg: ScenePointerEvent):
             # only call the callback if the event is a click
             if scene_pointer_msg.event != "click":
                 return
-            click = ViewerClick(origin=scene_pointer_msg.ray_origin, direction=scene_pointer_msg.ray_direction)
+            origin = scene_pointer_msg.ray_origin
+            direction = scene_pointer_msg.ray_direction
+
+            origin = tuple([x / VISER_NERFSTUDIO_SCALE_RATIO for x in origin])
+            assert len(origin) == 3
+
+            click = ViewerClick(origin, direction)
             cb(click)
 
         self._click_cbs[cb] = wrapped_cb

--- a/nerfstudio/viewer_beta/viewer_elements.py
+++ b/nerfstudio/viewer_beta/viewer_elements.py
@@ -31,6 +31,7 @@ from viser import (
     GuiButtonHandle,
     GuiDropdownHandle,
     GuiInputHandle,
+    ScenePointerEvent,
     ViserServer,
 )
 
@@ -68,7 +69,7 @@ class ViewerControl:
 
     def __init__(self):
         # this should be a user-facing constructor, since it will be used inside the model/pipeline class
-        self.click_cbs = []
+        self._click_cbs = {}
 
     def _setup(self, viewer: Viewer):
         """
@@ -146,13 +147,25 @@ class ViewerControl:
             cb: The callback to call when a click is detected.
                 The callback should take a ViewerClick object as an argument
         """
-        self.click_cbs.append(cb)
+        def wrapped_cb(scene_pointer_msg: ScenePointerEvent):
+            click = ViewerClick(
+                origin=scene_pointer_msg.ray_origin, direction=scene_pointer_msg.ray_direction
+            )
+            cb(click)
+        self._click_cbs[cb] = wrapped_cb
+        self.viser_server.on_scene_click(wrapped_cb)
 
-    def on_click(self, msg):
+    def unregister_click_cb(self, cb: Callable):
         """
-        Internal use only, register a click in the viewer which propagates to all self.click_cbs
+        Remove a callback which will be called when a click is detected in the viewer.
+
+        Args:
+            cb: The callback to remove
         """
-        raise NotImplementedError()
+        if cb not in self._click_cbs:
+            raise ValueError(f"Callback {cb} not registered, cannot remove")
+        self.viser_server.remove_scene_click_callback(self._click_cbs[cb])
+        self._click_cbs.pop(cb)
 
     @property
     def server(self):

--- a/nerfstudio/viewer_beta/viewer_elements.py
+++ b/nerfstudio/viewer_beta/viewer_elements.py
@@ -148,6 +148,9 @@ class ViewerControl:
                 The callback should take a ViewerClick object as an argument
         """
         def wrapped_cb(scene_pointer_msg: ScenePointerEvent):
+            # only call the callback if the event is a click
+            if scene_pointer_msg.event != "click":
+                return
             click = ViewerClick(
                 origin=scene_pointer_msg.ray_origin, direction=scene_pointer_msg.ray_direction
             )

--- a/nerfstudio/viewer_beta/viewer_elements.py
+++ b/nerfstudio/viewer_beta/viewer_elements.py
@@ -152,14 +152,14 @@ class ViewerControl:
             cb: The callback to call when a click is detected.
                 The callback should take a ViewerClick object as an argument
         """
+
         def wrapped_cb(scene_pointer_msg: ScenePointerEvent):
             # only call the callback if the event is a click
             if scene_pointer_msg.event != "click":
                 return
-            click = ViewerClick(
-                origin=scene_pointer_msg.ray_origin, direction=scene_pointer_msg.ray_direction
-            )
+            click = ViewerClick(origin=scene_pointer_msg.ray_origin, direction=scene_pointer_msg.ray_direction)
             cb(click)
+
         self._click_cbs[cb] = wrapped_cb
         self.viser_server.on_scene_click(wrapped_cb)
 


### PR DESCRIPTION
In the original viewer, a user could click on a point in the screen, to specify a "ray"-like interaction (akin to a pointer finger stick originating from the client camera, going through the clicked pixel on the image plane).

This replicates the original capability in viewer_beta, with a few differences:
 - Functionality to remove scene click listeners, once instantiated (`unregister_click_cb`)
 - Wraps the scene click events (which take as input nerfstudio's `ViewerClicks`) inside a function that takes as input `ScenePointerEvent`, for viser-nerfstudio compatibility.

(Implementation based on the recently integrated viser PR https://github.com/nerfstudio-project/viser/pull/106) 