### PR TITLE
Add camera_type dropdown in new viewer

### DIFF
--- a/nerfstudio/viewer_beta/render_panel.py
+++ b/nerfstudio/viewer_beta/render_panel.py
@@ -297,6 +297,13 @@ def populate_render_tab(
         """Update the aspect ratio for all cameras when the resolution changes."""
         camera_path.update_aspect(resolution.value[0] / resolution.value[1])
 
+    camera_type = server.add_gui_dropdown(
+        "Camera Type",
+        ("Perspective", "Fisheye", "Equirectangular"),
+        initial_value="Perspective",
+        hint="Camera model to render with.",
+    )
+
     add_button = server.add_gui_button(
         "Add keyframe",
         icon=viser.Icon.PLUS,
@@ -584,7 +591,7 @@ def populate_render_tab(
                 }
             )
         json_data["keyframes"] = keyframes
-        json_data["camera_type"] = "perspective"
+        json_data["camera_type"] = camera_type.value.lower()
         json_data["render_height"] = resolution.value[1]
         json_data["render_width"] = resolution.value[0]
         json_data["fps"] = framerate_slider.value

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -124,8 +124,8 @@ class Viewer:
             ),
         )
         image = viser.theme.TitlebarImage(
-            image_url_light="https://docs.nerf.studio/en/latest/_static/imgs/logo.png",
-            image_url_dark="https://docs.nerf.studio/en/latest/_static/imgs/logo-dark.png",
+            image_url_light="https://docs.nerf.studio/_static/imgs/logo.png",
+            image_url_dark="https://docs.nerf.studio/_static/imgs/logo-dark.png",
             image_alt="NerfStudio Logo",
             href="https://docs.nerf.studio/",
         )


### PR DESCRIPTION
Added a gui dropdown menu for selecting the camera type in the viser viewer render panel. Currently, the render view doesn't update to preview the equirectangular or fisheye render but the user select the camera type which updates the camera_path json file.

Also updated image url of the nerfstudio logo in the viewer