### PR TITLE
Fix the bugs of mask input in gaussian-splatting branch

### DIFF
--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -173,7 +173,7 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                     mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, None)
                 else:
                     raise NotImplementedError("Only perspective and fisheye cameras are supported")
-                data["mask"] = torch.from_numpy(mask)
+                data["mask"] = torch.from_numpy(mask).bool()
 
             cached_train.append(data)
 
@@ -236,7 +236,8 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                     mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, None)
                 else:
                     raise NotImplementedError("Only perspective and fisheye cameras are supported")
-                data["mask"] = torch.from_numpy(mask)
+                print(mask.dtype)
+                data["mask"] = torch.from_numpy(mask).bool()
 
             cached_eval.append(data)
 

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -128,7 +128,8 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
             K = camera.get_intrinsics_matrices().numpy()
             distortion_params = camera.distortion_params.numpy()
             image = data["image"].numpy()
-
+            newK = K
+            
             if camera.camera_type.item() == CameraType.PERSPECTIVE.value:
                 distortion_params = np.array(
                     [
@@ -147,11 +148,9 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 # crop the image and update the intrinsics accordingly
                 x, y, w, h = roi
                 image = image[y : y + h, x : x + w]
-                if 'mask' in data:
-                    data['mask'] = data['mask'][y : y + h, x : x + w]
+                
                 if 'depth_image' in data:
                     data['depth_image'] = data['depth_image'][y : y + h, x : x + w]
-                K = newK
                 # update the width, height
                 self.train_dataset.cameras.width[i] = w
                 self.train_dataset.cameras.height[i] = h
@@ -168,7 +167,6 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 )
                 # and then remap:
                 image = cv2.remap(image, map1, map2, interpolation=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT)
-                K = newK
             else:
                 raise NotImplementedError("Only perspective and fisheye cameras are supported")
             data["image"] = torch.from_numpy(image)
@@ -177,14 +175,16 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 mask = data["mask"].numpy()
                 mask = mask.astype(np.uint8) * 255
                 if camera.camera_type.item() == CameraType.PERSPECTIVE.value:
-                    mask = cv2.undistort(mask, K, distortion_params, None, None)
+                    mask = cv2.undistort(mask, K, distortion_params, None, newK)
+                    mask = mask[y : y + h, x : x + w]
                 elif camera.camera_type.item() == CameraType.FISHEYE.value:
-                    mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, None)
+                    mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, newK)
                 else:
                     raise NotImplementedError("Only perspective and fisheye cameras are supported")
                 data["mask"] = torch.from_numpy(mask).bool()
 
             cached_train.append(data)
+            K = newK
 
             self.train_dataset.cameras.fx[i] = float(K[0, 0])
             self.train_dataset.cameras.fy[i] = float(K[1, 1])
@@ -200,6 +200,7 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
             K = camera.get_intrinsics_matrices().numpy()
             distortion_params = camera.distortion_params.numpy()
             image = data["image"].numpy()
+            newK = K
 
             if camera.camera_type.item() == CameraType.PERSPECTIVE.value:
                 distortion_params = np.array(
@@ -219,7 +220,6 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 # crop the image and update the intrinsics accordingly
                 x, y, w, h = roi
                 image = image[y : y + h, x : x + w]
-                K = newK
                 # update the width, height
                 self.eval_dataset.cameras.width[i] = w
                 self.eval_dataset.cameras.height[i] = h
@@ -235,7 +235,6 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 )
                 # and then remap:
                 image = cv2.remap(image, map1, map2, interpolation=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT)
-                K = newK
             else:
                 raise NotImplementedError("Only perspective and fisheye cameras are supported")
             data["image"] = torch.from_numpy(image)
@@ -244,14 +243,16 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 mask = data["mask"].numpy()
                 mask = mask.astype(np.uint8) * 255
                 if camera.camera_type.item() == CameraType.PERSPECTIVE.value:
-                    mask = cv2.undistort(mask, K, distortion_params, None, None)
+                    mask = cv2.undistort(mask, K, distortion_params, None, newK)
+                    mask = mask[y : y + h, x : x + w]
                 elif camera.camera_type.item() == CameraType.FISHEYE.value:
-                    mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, None)
+                    mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, newK)
                 else:
                     raise NotImplementedError("Only perspective and fisheye cameras are supported")
                 data["mask"] = torch.from_numpy(mask).bool()
 
             cached_eval.append(data)
+            K = newK
 
             self.eval_dataset.cameras.fx[i] = float(K[0, 0])
             self.eval_dataset.cameras.fy[i] = float(K[1, 1])

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -166,6 +166,7 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
 
             if "mask" in data:
                 mask = data["mask"].numpy()
+                mask = mask.astype(np.uint8) * 255
                 if camera.camera_type.item() == CameraType.PERSPECTIVE.value:
                     mask = cv2.undistort(mask, K, distortion_params, None, None)
                 elif camera.camera_type.item() == CameraType.FISHEYE.value:
@@ -228,6 +229,7 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
 
             if "mask" in data:
                 mask = data["mask"].numpy()
+                mask = mask.astype(np.uint8) * 255
                 if camera.camera_type.item() == CameraType.PERSPECTIVE.value:
                     mask = cv2.undistort(mask, K, distortion_params, None, None)
                 elif camera.camera_type.item() == CameraType.FISHEYE.value:

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -236,7 +236,6 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                     mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, None)
                 else:
                     raise NotImplementedError("Only perspective and fisheye cameras are supported")
-                print(mask.dtype)
                 data["mask"] = torch.from_numpy(mask).bool()
 
             cached_eval.append(data)

--- a/nerfstudio/models/gaussian_splatting.py
+++ b/nerfstudio/models/gaussian_splatting.py
@@ -667,6 +667,7 @@ class GaussianSplattingModel(Model):
             gt_img = TF.resize(batch["image"].permute(2, 0, 1), newsize).permute(1, 2, 0)
         else:
             gt_img = batch["image"]
+        
         gt_rgb = gt_img[..., :3]
         Ll1 = torch.abs(gt_rgb - outputs["rgb"]).mean()
         simloss = 1 - self.ssim(gt_rgb.permute(2, 0, 1)[None, ...], outputs["rgb"].permute(2, 0, 1)[None, ...])

--- a/nerfstudio/models/gaussian_splatting.py
+++ b/nerfstudio/models/gaussian_splatting.py
@@ -600,8 +600,9 @@ class GaussianSplattingModel(Model):
             gt_img = TF.resize(batch["image"].permute(2, 0, 1), newsize).permute(1, 2, 0)
         else:
             gt_img = batch["image"]
-        Ll1 = torch.abs(gt_img - outputs["rgb"]).mean()
-        simloss = 1 - self.ssim(gt_img.permute(2, 0, 1)[None, ...], outputs["rgb"].permute(2, 0, 1)[None, ...])
+        gt_rgb = gt_img[..., :3]
+        Ll1 = torch.abs(gt_rgb - outputs["rgb"]).mean()
+        simloss = 1 - self.ssim(gt_rgb.permute(2, 0, 1)[None, ...], outputs["rgb"].permute(2, 0, 1)[None, ...])
         return {"main_loss": (1 - self.config.ssim_lambda) * Ll1 + self.config.ssim_lambda * simloss}
 
     @torch.no_grad()


### PR DESCRIPTION
When I try to use the mask images in 3dgs branch of nerfstudio, I encounter the error 
> cv2.error: OpenCV(4.6.0) error: (-5:Bad argument) in function 'undistort'
> Overload resolution failed:
>  - src data type = 0 is not supported
>  - Expected Ptr<cv::UMat> for argument 'src'

I guess this is because we save the masks as bool somewhere in data_util and here we need to convert it back to uint8 before undistorting it.