### PR TITLE
Missing a space in base_datamanager.py

### DIFF
--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -342,7 +342,7 @@ class VanillaDataManagerConfig(DataManagerConfig):
     along with relevant information about camera intrinsics
     """
     patch_size: int = 1
-    """Size of patch to sample from. If >1, patch-based sampling will be used."""
+    """Size of patch to sample from. If > 1, patch-based sampling will be used."""
     camera_optimizer: Optional[CameraOptimizerConfig] = field(default=None)
     """Deprecated, has been moved to the model config."""
     pixel_sampler: PixelSamplerConfig = PixelSamplerConfig()


### PR DESCRIPTION
It's a small point, but I can't bear it after I see it many times. Every time I see it, I feel bad there misses a space, sorry so I changed it!
https://github.com/nerfstudio-project/nerfstudio/blob/e2060793705f8a6f2b0533dd844991050c6c1760/nerfstudio/data/datamanagers/base_datamanager.py#L345