### PR TITLE
Fix pixel-perfect-sfm installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,9 +149,9 @@ RUN git clone --branch v1.0 --recursive https://github.com/cvg/pyceres.git && \
 
 # Install pixel perfect sfm.
 RUN git clone --recursive https://github.com/cvg/pixel-perfect-sfm.git && \
+    cd pixel-perfect-sfm && \
     git reset --hard 40f7c1339328b2a0c7cf71f76623fb848e0c0357 && \
     git clean -df && \
-    cd pixel-perfect-sfm && \
     python3.10 -m pip install -e . && \
     cd ..
 


### PR DESCRIPTION
**Building the Dockerfile** of the current `main` branch **fails** with the error message

```
failed to solve: process "/bin/bash -c git clone --recursive https://github.com/cvg/pixel-perfect-sfm.git &&     git reset --hard 40f7c1339328b2a0c7cf71f76623fb848e0c0357 &&     git clean -df &&     cd pixel-perfect-sfm &&     python3.10 -m pip install -e . &&     cd .." did not complete successfully: exit code: 128
```

due to the [wrong order of the commands](https://github.com/ahmed-shariff/nerfstudio/blob/57c0693f94b0aa3f3e7aadd62c1b78888c747136/Dockerfile#L152-L154) introduced in https://github.com/nerfstudio-project/nerfstudio/pull/2446. This pull request fixes this by inverting their order.