### PR TITLE
Few viewer changes

### DIFF
--- a/nerfstudio/viewer_beta/render_state_machine.py
+++ b/nerfstudio/viewer_beta/render_state_machine.py
@@ -161,7 +161,7 @@ class RenderStateMachine(threading.Thread):
                 pts = (R @ (pts.view(-1, 3).T)).T.view(*camera_ray_bundle.directions.shape)
                 outputs["gl_z_buf_depth"] = -pts[..., 2:3]  # negative z axis is the coordinate convention
         render_time = vis_t.duration
-        if writer.is_initialized():
+        if writer.is_initialized() and render_time != 0:
             writer.put_time(
                 name=EventName.VIS_RAYS_PER_SEC, duration=num_rays / render_time, step=step, avg_over_steps=True
             )


### PR DESCRIPTION
Small changes for the new viewer including changing the FPS slider to a text entry and fixing the incorrect resolution text box description.

Added a check if render_time is non zero in the render_state_machine.py in the new viewer due to a divide by zero error occasionally causing the viewer to stop running. I noticed this usually happened when using nerfacto-huge.