### PR TITLE
Expose camera frustums size and occlusions to CLI

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -148,3 +148,7 @@ class ViewerConfig(PrintableConfig):
     """Quality tradeoff to use for jpeg compression."""
     make_share_url: bool = False
     """Viewer beta feature: print a shareable URL. `vis` must be set to viewer_beta; this flag is otherwise ignored."""
+    camera_frustum_scale: float = 0.1
+    """Scale for the camera frustums in the viewer."""
+    default_composite_depth: bool = True
+    """The default value for compositing depth. Turn off if you want to see the camera frustums without occlusions."""

--- a/nerfstudio/viewer_beta/control_panel.py
+++ b/nerfstudio/viewer_beta/control_panel.py
@@ -45,6 +45,7 @@ class ControlPanel:
             (eg train speed, max res, etc)
         crop_update_cb: a callback that will be called when the user changes the crop parameters
         update_output_cb: a callback that will be called when the user changes the output render
+        default_composite_depth: whether to default to compositing depth or not
     """
 
     def __init__(
@@ -58,11 +59,13 @@ class ControlPanel:
         update_split_output_cb: Callable,
         toggle_training_state_cb: Callable,
         camera_vis: Callable,
+        default_composite_depth: bool = True,
     ):
         self.viser_scale_ratio = scale_ratio
         # elements holds a mapping from tag: [elements]
         self.viser_server = viser_server
         self._elements_by_tag: DefaultDict[str, List[ViewerElement]] = defaultdict(lambda: [])
+        self.default_composite_depth = default_composite_depth
 
         self._train_speed = ViewerButtonGroup(
             name="Train Speed",
@@ -131,7 +134,10 @@ class ControlPanel:
             hint="Target training utilization, 0.0 is slow, 1.0 is fast. Doesn't affect final render quality",
         )
         self._layer_depth = ViewerCheckbox(
-            "Composite Depth", True, cb_hook=rerender_cb, hint="Allow NeRF to occlude 3D browser objects"
+            "Composite Depth",
+            self.default_composite_depth,
+            cb_hook=rerender_cb,
+            hint="Allow NeRF to occlude 3D browser objects",
         )
         self._max_res = ViewerSlider(
             "Max Res", 512, 64, 2048, 100, cb_hook=rerender_cb, hint="Maximum resolution to render in viewport"

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -154,6 +154,7 @@ class Viewer:
                 self._output_split_type_change,
                 self._toggle_training_state,
                 self.set_camera_visibility,
+                default_composite_depth=self.config.default_composite_depth,
             )
         config_path = self.log_filename.parents[0] / "config.yml"
         with tabs.add_tab("Render", viser.Icon.CAMERA):
@@ -331,7 +332,7 @@ class Viewer:
             camera_handle = self.viser_server.add_camera_frustum(
                 name=f"/cameras/camera_{idx:05d}",
                 fov=float(2 * np.arctan(camera.cx / camera.fx[0])),
-                scale=0.1,
+                scale=self.config.camera_frustum_scale,
                 aspect=float(camera.cx[0] / camera.cy[0]),
                 image=image_uint8,
                 wxyz=R.wxyz,


### PR DESCRIPTION
I added two parameters to the Viewer config. Now we can change the size of the training & eval camera frustums, and we can enable/disable rendering the scene with depth compositing. This is useful for (1) when the scene is small and frustums are too tiny or (2) when there are floaters or artifacts in the way and you still want to see the camera frustums.

**Default, trained for a little bit.**
```bash
ns-train nerfacto --data data/nerfstudio/plane --vis viewer_beta
```
<img width="1155" alt="Screenshot 2023-10-24 at 12 55 01 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/16965789/9b1e4851-21ec-4c5d-bb0d-f84cc7cdf833">

**Modifying the camera frustum scale from the default 0.1 to 1.0 (10x) and turning off depth compositing.**
```bash
ns-train nerfacto --data data/nerfstudio/plane --vis viewer_beta --viewer.camera_frustum_scale 1.0 --viewer.default_composite_depth False
```
<img width="1005" alt="Screenshot 2023-10-24 at 12 53 22 PM" src="https://github.com/nerfstudio-project/nerfstudio/assets/16965789/ecb12887-d234-4663-ae92-06a62ac8f6b1">

