### PR TITLE
ns-process-data images fix: multinerf uses equals sign

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -156,7 +156,7 @@ def run_colmap(
         f"--output_path {sparse_dir}",
     ]
     if colmap_version >= 3.7:
-        mapper_cmd.append("--Mapper.ba_global_function_tolerance 1e-6")
+        mapper_cmd.append("--Mapper.ba_global_function_tolerance=1e-6")
 
     mapper_cmd = " ".join(mapper_cmd)
 


### PR DESCRIPTION
(Bringing over the rest of #2554 to main.)