### PR TITLE
Print beta URL in banner correctly

### DIFF
--- a/nerfstudio/viewer_beta/control_panel.py
+++ b/nerfstudio/viewer_beta/control_panel.py
@@ -270,10 +270,9 @@ class ControlPanel:
             step: the train step to set the model to
         """
         with self.viser_server.atomic(), self.stat_folder:
-            # TODO change to a .value call instead of remove() and add, this makes it jittery
             with self.viser_server.atomic():
                 self.markdown.remove()
-                self.markdown = self.viser_server.add_gui_markdown(f"Step: {step}")
+                self.markdown.content = f"Step: {step}"
 
     def update_output_options(self, new_options: List[str]):
         """

--- a/nerfstudio/viewer_beta/control_panel.py
+++ b/nerfstudio/viewer_beta/control_panel.py
@@ -270,9 +270,10 @@ class ControlPanel:
             step: the train step to set the model to
         """
         with self.viser_server.atomic(), self.stat_folder:
+            # TODO change to a .value call instead of remove() and add, this makes it jittery
             with self.viser_server.atomic():
                 self.markdown.remove()
-                self.markdown.content = f"Step: {step}"
+                self.markdown = self.viser_server.add_gui_markdown(f"Step: {step}")
 
     def update_output_options(self, new_options: List[str]):
         """

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -105,6 +105,8 @@ class Viewer:
 
         self.viser_server = viser.ViserServer(host=config.websocket_host, port=websocket_port, share=share)
         # Set the name of the URL either to the share link if available, or the localhost
+        # TODO: we should revisit this once a public API for share URL status is exposed in viser.
+        # https://github.com/nerfstudio-project/viser/issues/124
         if share:
             assert self.viser_server._share_tunnel is not None
             while self.viser_server._share_tunnel._shared_state["status"] == "connecting":

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -95,8 +95,6 @@ class Viewer:
             websocket_port = self.config.websocket_port
         self.log_filename.parent.mkdir(exist_ok=True)
 
-        self.viewer_url = viewer_utils.get_viewer_url(websocket_port)
-
         # viewer specific variables
         self.output_type_changed = True
         self.output_split_type_changed = True
@@ -106,6 +104,19 @@ class Viewer:
         self.last_move_time = 0
 
         self.viser_server = viser.ViserServer(host=config.websocket_host, port=websocket_port, share=share)
+        # Set the name of the URL either to the share link if available, or the localhost
+        if share:
+            assert self.viser_server._share_tunnel is not None
+            while self.viser_server._share_tunnel._shared_state["status"] == "connecting":
+                # wait for connection before grabbing URL
+                time.sleep(0.01)
+            url_maybe = self.viser_server._share_tunnel.get_url()
+            if url_maybe is not None:
+                self.viewer_url = url_maybe
+            else:
+                self.viewer_url = f"http://{config.websocket_host}:{websocket_port}"
+        else:
+            self.viewer_url = f"http://{config.websocket_host}:{websocket_port}"
         buttons = (
             viser.theme.TitlebarButton(
                 text="Getting Started",


### PR DESCRIPTION
Prints the share URL or localhost port in the green banner at the bottom for the viewer beta, previously it was broken