### PR TITLE
`process_data` support multi-camera intrinsics

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -451,16 +451,16 @@ def colmap_to_json(
 
     if set(cam_id_to_camera.keys()) != {1}:
         cameras = {k: parse_colmap_camera_params(v) for k, v in cam_id_to_camera.items()}
-        model = list(set(x['camera_model'] for x in cameras.values()))
+        model = list(set(x["camera_model"] for x in cameras.values()))
         assert len(model) == 1, "All the camera model should be same for now."
         for i, frame in enumerate(frames):
-            frames[i] = {**frame, **cameras[frame['camera_id']]}
-            frames[i].pop('camera_id')
-            frames[i].pop('camera_model')
-        out = {'camera_model': model[0], 'frames': frames}
+            frames[i] = {**frame, **cameras[frame["camera_id"]]}
+            frames[i].pop("camera_id")
+            frames[i].pop("camera_model")
+        out = {"camera_model": model[0], "frames": frames}
     else:
         out = parse_colmap_camera_params(cam_id_to_camera[1])
-        out['frames'] = frames
+        out["frames"] = frames
 
     applied_transform = np.eye(4)[:3, :]
     applied_transform = applied_transform[np.array([1, 0, 2]), :]

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -440,7 +440,7 @@ def colmap_to_json(
             "file_path": name.as_posix(),
             "transform_matrix": c2w.tolist(),
             "colmap_im_id": im_id,
-            "camera_id": im_data.camera_id
+            "camera_id": im_data.camera_id,
         }
         if camera_mask_path is not None:
             frame["mask_path"] = camera_mask_path.relative_to(camera_mask_path.parent.parent).as_posix()

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -457,10 +457,9 @@ def colmap_to_json(
             frames[i] = {**frame, **cameras[frame['camera_id']]}
             frames[i].pop('camera_id')
             frames[i].pop('camera_model')
-        
         out = {'camera_model': model[0], 'frames': frames}
     else:
-        out: Dict[str, Any] = parse_colmap_camera_params(cam_id_to_camera[1])
+        out = parse_colmap_camera_params(cam_id_to_camera[1])
         out['frames'] = frames
 
     applied_transform = np.eye(4)[:3, :]


### PR DESCRIPTION
Allow multi-camera intrinsics (per-frame) when using `ns-process-data`.

After changes, when there are multiple camera founded in COLMAP database, it will export the `transforms.json` in [per-frame format](https://docs.nerf.studio/quickstart/data_conventions.html#camera-intrinsics).

It still doesn't support per-frame camera model for now.

