### PR TITLE
Fix torch.compile for torch 2.1

### DIFF
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -407,7 +407,7 @@ def _compute_residual_and_jacobian(
     return fx, fy, fx_x, fx_y, fy_x, fy_y
 
 
-@torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
+@torch_compile(dynamic=True, mode="reduce-overhead")
 def radial_and_tangential_undistort(
     coords: torch.Tensor,
     distortion_params: torch.Tensor,


### PR DESCRIPTION
Eager backend support in torch.compile seems not to support the reduce-overhead mode anymore. This PR switches to the default inductor backend. Some data points: https://github.com/nerfstudio-project/nerfstudio/pull/1922

@kerrj 
Adresses #2438.