### PR TITLE
Remove compile line in camera_utils

### DIFF
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -407,7 +407,7 @@ def _compute_residual_and_jacobian(
     return fx, fy, fx_x, fx_y, fy_x, fy_y
 
 
-@torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
+# @torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
 def radial_and_tangential_undistort(
     coords: torch.Tensor,
     distortion_params: torch.Tensor,

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -407,7 +407,7 @@ def _compute_residual_and_jacobian(
     return fx, fy, fx_x, fx_y, fy_x, fy_y
 
 
-@torch_compile(dynamic=True, mode="reduce-overhead")
+@torch_compile(dynamic=True, mode="reduce-overhead", backend="eager")
 def radial_and_tangential_undistort(
     coords: torch.Tensor,
     distortion_params: torch.Tensor,

--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -25,7 +25,6 @@ from jaxtyping import Float
 from numpy.typing import NDArray
 from torch import Tensor
 
-from nerfstudio.utils.misc import torch_compile
 
 _EPS = np.finfo(float).eps * 4.0
 


### PR DESCRIPTION
Re commit 85677d310fcb8700b284225de646c63bb02b83de, which caused the following when training nerfacto:

![Screenshot 2023-11-05 at 8 37 42 AM](https://github.com/nerfstudio-project/nerfstudio/assets/42229107/24e02e5f-9a40-43ee-b01e-995709a92f28)
![Screenshot 2023-11-05 at 8 37 58 AM](https://github.com/nerfstudio-project/nerfstudio/assets/42229107/07bfe8c6-c781-4273-bd21-20ca815840d7)
