### PR TITLE
Fix large dataset (> 512 images) training in viewer_beta

### DIFF
--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -260,17 +260,15 @@ class Viewer:
         with torch.no_grad():
             assert isinstance(camera_optimizer, CameraOptimizer)
             c2ws_delta = camera_optimizer(torch.tensor(idxs, device=camera_optimizer.device)).cpu().numpy()
-        for i, j in list(zip(idxs, list(range(len(idxs))))):
-            # i is the key with which camera_handles is indexed into
-            # j is the iterator number
+        for i, key in enumerate(idxs):
             # both are numpy arrays
-            c2w_orig = self.original_c2w[i]
-            c2w_delta = c2ws_delta[j, ...]
+            c2w_orig = self.original_c2w[key]
+            c2w_delta = c2ws_delta[i, ...]
             c2w = c2w_orig @ np.concatenate((c2w_delta, np.array([[0, 0, 0, 1]])), axis=0)
             R = vtf.SO3.from_matrix(c2w[:3, :3])  # type: ignore
             R = R @ vtf.SO3.from_x_radians(np.pi)
-            self.camera_handles[i].position = c2w[:3, 3] * VISER_NERFSTUDIO_SCALE_RATIO
-            self.camera_handles[i].wxyz = R.wxyz
+            self.camera_handles[key].position = c2w[:3, 3] * VISER_NERFSTUDIO_SCALE_RATIO
+            self.camera_handles[key].wxyz = R.wxyz
 
     def _interrupt_render(self, _) -> None:
         """Interrupt current render."""

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -260,15 +260,17 @@ class Viewer:
         with torch.no_grad():
             assert isinstance(camera_optimizer, CameraOptimizer)
             c2ws_delta = camera_optimizer(torch.tensor(idxs, device=camera_optimizer.device)).cpu().numpy()
-        for idx in idxs:
+        for i, j in list(zip(idxs, list(range(len(idxs))))):
+            # i is the key with which camera_handles is indexed into
+            # j is the iterator number
             # both are numpy arrays
-            c2w_orig = self.original_c2w[idx]
-            c2w_delta = c2ws_delta[idx, ...]
+            c2w_orig = self.original_c2w[i]
+            c2w_delta = c2ws_delta[j, ...]
             c2w = c2w_orig @ np.concatenate((c2w_delta, np.array([[0, 0, 0, 1]])), axis=0)
             R = vtf.SO3.from_matrix(c2w[:3, :3])  # type: ignore
             R = R @ vtf.SO3.from_x_radians(np.pi)
-            self.camera_handles[idx].position = c2w[:3, 3] * VISER_NERFSTUDIO_SCALE_RATIO
-            self.camera_handles[idx].wxyz = R.wxyz
+            self.camera_handles[i].position = c2w[:3, 3] * VISER_NERFSTUDIO_SCALE_RATIO
+            self.camera_handles[i].wxyz = R.wxyz
 
     def _interrupt_render(self, _) -> None:
         """Interrupt current render."""


### PR DESCRIPTION
Re #2542. Fix index bug by creating two different iterators in `update_camera_poses`, since `self.original_c2w`(dict) and `c2ws_delta`(np array) should be indexed into differently.