### PR TITLE
Make spherical harmonics test more forgiving

### DIFF
--- a/tests/utils/test_math.py
+++ b/tests/utils/test_math.py
@@ -13,4 +13,4 @@ def test_spherical_harmonics(components):
     dx = dx / torch.linalg.norm(dx, dim=-1, keepdim=True)
     sh = components_from_spherical_harmonics(components, dx)
     matrix = (sh.T @ sh) / N * 4 * torch.pi
-    torch.testing.assert_close(matrix, torch.eye(components**2), rtol=0, atol=1e-2)
+    torch.testing.assert_close(matrix, torch.eye(components**2), rtol=0, atol=1.5e-2)


### PR DESCRIPTION
This test is failing sporadically. It seems to be a floating point precision issue. (the issue goes away for me when I switch everything to float64)