### PR TITLE
Metashape Processing Script: "Cameras" may contain elements that are not cameras, and therefore no "labels" tag

### DIFF
--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -207,3 +207,4 @@ def metashape_to_json(
     summary.append(f"Final dataset is {len(data['frames'])} frames.")
 
     return summary
+    

--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -150,6 +150,14 @@ def metashape_to_json(
     for camera in cameras:
         frame = {}
         camera_label = camera.get("label")
+
+        # Added, as "cameras" element may contain
+        # entries other than actual cameras, and
+        # will not have a tag called "label",
+        # returning None.
+        if camera_label is None:
+            continue
+
         assert isinstance(camera_label, str)
         if camera_label not in image_filename_map:
             # Labels sometimes have a file extension. Try without the extension.


### PR DESCRIPTION
Hi,

This probably isn't worth a PR, but we use Metashape (and now NeRFs 😎) for underwater reconstructions. Because we already use Metashape, the processing script is very useful, which allows us to skip the redundant step of using colmap.

We use Metashape 2.0.X, and when exporting cameras as an XML file, "cameras" may contain  elements (children) that are not really cameras, and therefore they will not have a "label" tag. This results in the processing script to throw an error which checking:

```python
assert isinstance(camera_label, str)
```

Simple fix is just to check if the value returned in the previous line (`camera_label`) is `None`, since if `labels` does not exists it will return `None`; if `None` that iteration is the looped is skipped. This worked for us.

Below is the end portion of the xml file exported from Metashape 2.0.X:

```xml
      <camera id="64" sensor_id="0" component_id="0" label="T_S04920">
        <transform>0.39032194793077357 0.74216472892988283 -0.54483051685451722 3.7012935179350013 0.14664850872693375 -0.63433252101113768 -0.75902336438071649 4.910698514524003 -0.90892408475718844 0.21636489530441105 -0.35643125596420205 -3.9777394049343489 0 0 0 1</transform>
        <rotation_covariance>1.394591407696673e-06 -3.7607955822753534e-07 1.1867952488316718e-07 -3.7607955822753529e-07 7.7758664650666157e-07 1.0920034902583434e-07 1.1867952488316716e-07 1.0920034902583431e-07 2.4620179263634537e-07</rotation_covariance>
        <location_covariance>6.393339613270235e-05 1.5684529424959145e-05 -9.0286930149678477e-06 1.5684529424959145e-05 3.2236122010502187e-05 3.444842030555343e-06 -9.0286930149678477e-06 3.444842030555343e-06 3.6920228505667884e-05</location_covariance>
      </camera>
      <camera id="65" sensor_id="0" component_id="0" label="T_S04921">
        <transform>0.56545362962624202 0.70118479953823465 -0.43428339783951486 2.6437300931218672 0.092622773201603864 -0.57719846981802292 -0.81133405470507514 5.0063193906986267 -0.81956281920726037 0.41854725340904952 -0.39132465043335568 -3.6004257300682041 0 0 0 1</transform>
        <rotation_covariance>1.209912231499636e-06 -4.4062191099276087e-07 2.0903343133076167e-07 -4.4062191099276087e-07 8.6328746534497716e-07 6.2709444009263899e-08 2.0903343133076165e-07 6.2709444009263846e-08 2.8208165478935081e-07</rotation_covariance>
        <location_covariance>4.2212494553780979e-05 2.3469769781825893e-05 5.1680234333248182e-07 2.3469769781825893e-05 2.2473232564370221e-05 4.4297157515358392e-06 5.1680234333248182e-07 4.4297157515358392e-06 3.3530347492313847e-05</location_covariance>
      </camera>
      <camera id="66" sensor_id="0" component_id="0" label="T_S04922">
        <transform>0.64117720350252272 0.72149375025577123 -0.26141645328966501 1.5613630239847063 0.12154389829048877 -0.43183443847192948 -0.8937259638938464 5.3822534643500592 -0.7577063247043907 0.54126313941695392 -0.36457556063382468 -3.9451381019346581 0 0 0 1</transform>
        <rotation_covariance>1.2430414050643863e-06 -4.5452791721409356e-07 2.1446299263309236e-07 -4.5452791721409371e-07 9.545917766663648e-07 7.8385516624294453e-08 2.1446299263309241e-07 7.8385516624294426e-08 3.9795996173449087e-07</rotation_covariance>
        <location_covariance>3.0764706874131967e-05 2.7518646887297614e-05 8.8649240493325569e-07 2.7518646887297614e-05 3.5041290611447137e-05 9.0326111993099262e-06 8.8649240493325569e-07 9.0326111993099262e-06 3.6558310833773086e-05</location_covariance>
      </camera>
      <camera id="67" sensor_id="0" component_id="0" label="T_S04923"> # <---- Last actual camera in chunk
        <transform>0.6315650967128067 0.74141350874269529 -0.22678522365442563 1.2397219316611183 0.13016714853995587 -0.38974707713962597 -0.91167632924305742 5.4529344464741705 -0.76431802415952466 0.54626296315507528 -0.34265833278926217 -4.3576834429046816 0 0 0 1</transform>
        <rotation_covariance>1.3276245073228852e-06 -4.4641590558287118e-07 2.2027657676088766e-07 -4.4641590558287113e-07 9.6577120715844808e-07 1.0265997372360024e-07 2.2027657676088766e-07 1.0265997372360016e-07 4.294940980769791e-07</rotation_covariance>
        <location_covariance>2.4441292417832514e-05 2.9474714336166356e-05 2.9557108459981755e-07 2.9474714336166356e-05 3.8066356850846667e-05 1.0009325305418448e-05 2.9557108459981697e-07 1.0009325305418447e-05 3.6954974814697176e-05</location_covariance>
      </camera>
      <camera id="68" type="keyframe"> # <--- Other information stored in XML file
        <meta>
          <property name="PlanMission/AircraftAction" value="0"/>
        </meta>
        <transform>-0.99682412419370503 -0.017262323194525045 -0.077741093530906746 -0.3049857777952798 0.057388794930530479 -0.83253161300054657 -0.5509969506005723 10.659801178865708 -0.055210430553247314 -0.55370852039013796 0.83087825991867736 -21.587381935976197 0 0 0 1</transform>
      </camera>
      <camera id="69" type="keyframe">
        <meta>
          <property name="PlanMission/AircraftAction" value="0"/>
        </meta>
        <transform>-0.99905544537165425 -0.033548551524815381 -0.027617236716094801 -1.2537197036765357 0.043230317883591933 -0.83171056854943337 -0.55352386559105271 10.707630099695644 -0.0043996237259110805 -0.55419493398421193 0.83237528702941765 -21.615717353443586 0 0 0 1</transform>
      </camera>
      <camera id="70" type="keyframe">
        <meta>
          <property name="PlanMission/AircraftAction" value="0"/>
        </meta>
        <transform>-0.99850221983583265 -0.049848472990305176 0.022548763235492587 -2.2032513060763739 0.028951350187054671 -0.83112157152507093 -0.55533661203637752 10.741941386994524 0.046423445641852329 -0.55385202273371803 0.83131991471906097 -21.59574148608425 0 0 0 1</transform>
      </camera>
      <camera id="71" type="keyframe">
        <meta>
          <property name="PlanMission/AircraftAction" value="0"/>
        </meta>
        <transform>-0.99516598952503266 -0.066116656786366107 0.072617084684370434 -3.1509340701138302 0.014591689884920656 -0.83076626356780714 -0.55643013748707704 10.762639409050678 0.097117124540245015 -0.55268074239381559 0.82771508449952469 -21.527510010223331 0 0 0 1</transform>
      </camera>
```