### PR TITLE
Add support for Project Aria datasets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Have feedback? We'd love for you to fill out our [Nerfstudio Feedback Form](http
 We hope nerfstudio enables you to build faster :hammer: learn together :books: and contribute to our NeRF community :sparkling_heart:.
 
 ## Sponsors
+
 Sponsors of this work includes [Luma AI](https://lumalabs.ai/) and the [BAIR commons](https://bcommons.berkeley.edu/home).
 
 <p align="left">
@@ -96,7 +97,6 @@ Sponsors of this work includes [Luma AI](https://lumalabs.ai/) and the [BAIR com
         <!-- /pypi-strip -->
     </a>
 </p>
-
 
 # Quickstart
 
@@ -233,18 +233,19 @@ ns-export pointcloud --help
 
 Using an existing dataset is great, but likely you want to use your own data! We support various methods for using your own data. Before it can be used in nerfstudio, the camera location and orientations must be determined and then converted into our format using `ns-process-data`. We rely on external tools for this, instructions and information can be found in the documentation.
 
-| Data                                                                                                 | Capture Device | Requirements                                                      | `ns-process-data` Speed |
-| ---------------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- | ----------------------- |
-| 📷 [Images](https://docs.nerf.studio/quickstart/custom_dataset.html#images-or-video)      | Any            | [COLMAP](https://colmap.github.io/install.html)                   | 🐢                      |
-| 📹 [Video](https://docs.nerf.studio/quickstart/custom_dataset.html#images-or-video)       | Any            | [COLMAP](https://colmap.github.io/install.html)                   | 🐢                      |
-| 🌎 [360 Data](https://docs.nerf.studio/quickstart/custom_dataset.html#data-equirectangular)            | Any            | [COLMAP](https://colmap.github.io/install.html)                   | 🐢                      |
-| 📱 [Polycam](https://docs.nerf.studio/quickstart/custom_dataset.html#polycam-capture)      | IOS with LiDAR | [Polycam App](https://poly.cam/)                                  | 🐇                      |
-| 📱 [KIRI Engine](https://docs.nerf.studio/quickstart/custom_dataset.html#kiri-engine-capture)     | IOS or Android | [KIRI Engine App](https://www.kiriengine.com/)                    | 🐇                      |
-| 📱 [Record3D](https://docs.nerf.studio/quickstart/custom_dataset.html#record3d-capture)    | IOS with LiDAR | [Record3D app](https://record3d.app/)                             | 🐇                      |
-| 🖥 [Metashape](https://docs.nerf.studio/quickstart/custom_dataset.html#metashape)           | Any            | [Metashape](https://www.agisoft.com/)                             | 🐇                      |
-| 🖥 [RealityCapture](https://docs.nerf.studio/quickstart/custom_dataset.html#realitycapture) | Any            | [RealityCapture](https://www.capturingreality.com/realitycapture) | 🐇                      |
-| 🖥 [ODM](https://docs.nerf.studio/quickstart/custom_dataset.html#ODM)                       | Any            | [ODM](https://github.com/OpenDroneMap/ODM)                        | 🐇                      |
-| 🛠 [Custom](https://docs.nerf.studio/quickstart/data_conventions.html)                      | Any            | Camera Poses                                                      | 🐇                      |
+| Data                                                                                          | Capture Device | Requirements                                                      | `ns-process-data` Speed |
+| --------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------- | ----------------------- |
+| 📷 [Images](https://docs.nerf.studio/quickstart/custom_dataset.html#images-or-video)          | Any            | [COLMAP](https://colmap.github.io/install.html)                   | 🐢                      |
+| 📹 [Video](https://docs.nerf.studio/quickstart/custom_dataset.html#images-or-video)           | Any            | [COLMAP](https://colmap.github.io/install.html)                   | 🐢                      |
+| 🌎 [360 Data](https://docs.nerf.studio/quickstart/custom_dataset.html#data-equirectangular)   | Any            | [COLMAP](https://colmap.github.io/install.html)                   | 🐢                      |
+| 📱 [Polycam](https://docs.nerf.studio/quickstart/custom_dataset.html#polycam-capture)         | IOS with LiDAR | [Polycam App](https://poly.cam/)                                  | 🐇                      |
+| 📱 [KIRI Engine](https://docs.nerf.studio/quickstart/custom_dataset.html#kiri-engine-capture) | IOS or Android | [KIRI Engine App](https://www.kiriengine.com/)                    | 🐇                      |
+| 📱 [Record3D](https://docs.nerf.studio/quickstart/custom_dataset.html#record3d-capture)       | IOS with LiDAR | [Record3D app](https://record3d.app/)                             | 🐇                      |
+| 🖥 [Metashape](https://docs.nerf.studio/quickstart/custom_dataset.html#metashape)             | Any            | [Metashape](https://www.agisoft.com/)                             | 🐇                      |
+| 🖥 [RealityCapture](https://docs.nerf.studio/quickstart/custom_dataset.html#realitycapture)   | Any            | [RealityCapture](https://www.capturingreality.com/realitycapture) | 🐇                      |
+| 🖥 [ODM](https://docs.nerf.studio/quickstart/custom_dataset.html#ODM)                         | Any            | [ODM](https://github.com/OpenDroneMap/ODM)                        | 🐇                      |
+| 👓 [Aria](https://docs.nerf.studio/quickstart/custom_dataset.html#Aria)                       | Aria glasses   | [Project Aria](https://projectaria.com/)                          | 🐇                      |
+| 🛠 [Custom](https://docs.nerf.studio/quickstart/data_conventions.html)                        | Any            | Camera Poses                                                      | 🐇                      |
 
 ## 5. Advanced Options
 
@@ -276,25 +277,25 @@ And that's it for getting started with the basics of nerfstudio.
 
 If you're interested in learning more on how to create your own pipelines, develop with the viewer, run benchmarks, and more, please check out some of the quicklinks below or visit our [documentation](https://docs.nerf.studio/) directly.
 
-| Section                                                                                            | Description                                                                                        |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Section                                                                                  | Description                                                                                        |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | [Documentation](https://docs.nerf.studio/)                                               | Full API documentation and tutorials                                                               |
-| [Viewer](https://viewer.nerf.studio/)                                                              | Home page for our web viewer                                                                       |
-| 🎒 **Educational**                                                                                 |
+| [Viewer](https://viewer.nerf.studio/)                                                    | Home page for our web viewer                                                                       |
+| 🎒 **Educational**                                                                       |
 | [Model Descriptions](https://docs.nerf.studio/nerfology/methods/index.html)              | Description of all the models supported by nerfstudio and explanations of component parts.         |
 | [Component Descriptions](https://docs.nerf.studio/nerfology/model_components/index.html) | Interactive notebooks that explain notable/commonly used modules in various models.                |
-| 🏃 **Tutorials**                                                                                   |
+| 🏃 **Tutorials**                                                                         |
 | [Getting Started](https://docs.nerf.studio/quickstart/installation.html)                 | A more in-depth guide on how to get started with nerfstudio from installation to contributing.     |
 | [Using the Viewer](https://docs.nerf.studio/quickstart/viewer_quickstart.html)           | A quick demo video on how to navigate the viewer.                                                  |
-| [Using Record3D](https://www.youtube.com/watch?v=XwKq7qDQCQk)                                      | Demo video on how to run nerfstudio without using COLMAP.                                          |
-| 💻 **For Developers**                                                                              |
+| [Using Record3D](https://www.youtube.com/watch?v=XwKq7qDQCQk)                            | Demo video on how to run nerfstudio without using COLMAP.                                          |
+| 💻 **For Developers**                                                                    |
 | [Creating pipelines](https://docs.nerf.studio/developer_guides/pipelines/index.html)     | Learn how to easily build new neural rendering pipelines by using and/or implementing new modules. |
 | [Creating datasets](https://docs.nerf.studio/quickstart/custom_dataset.html)             | Have a new dataset? Learn how to run it with nerfstudio.                                           |
 | [Contributing](https://docs.nerf.studio/reference/contributing.html)                     | Walk-through for how you can start contributing now.                                               |
-| 💖 **Community**                                                                                   |
-| [Discord](https://discord.gg/uMbNqcraFc)                                                           | Join our community to discuss more. We would love to hear from you!                                |
-| [Twitter](https://twitter.com/nerfstudioteam)                                                      | Follow us on Twitter @nerfstudioteam to see cool updates and announcements                         |
-| [Feedback Form](TODO)                                                                              | We welcome any feedback! This is our chance to learn what you all are using Nerfstudio for.    |
+| 💖 **Community**                                                                         |
+| [Discord](https://discord.gg/uMbNqcraFc)                                                 | Join our community to discuss more. We would love to hear from you!                                |
+| [Twitter](https://twitter.com/nerfstudioteam)                                            | Follow us on Twitter @nerfstudioteam to see cool updates and announcements                         |
+| [Feedback Form](TODO)                                                                    | We welcome any feedback! This is our chance to learn what you all are using Nerfstudio for.        |
 
 # Supported Features
 

--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -374,6 +374,8 @@ ns-process-data aria --vrs-file /path/to/vrs/file --mps-data-dir /path/to/mps/da
 ns-train nerfacto --data {output directory}
 ```
 
+(360_data)=
+
 ## 360 Data (Equirectangular)
 
 Equirectangular data is data that has been taken by a 360 camera such as Insta360. Both equirectangular image sets and videos can be processed by nerfstudio.

--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -22,7 +22,7 @@ We currently support the following custom data types:
 | 🖥 [Metashape](metashape) | Any | [Metashape](https://www.agisoft.com/) | 🐇 |
 | 🖥 [RealityCapture](realitycapture) | Any | [RealityCapture](https://www.capturingreality.com/realitycapture) | 🐇 |
 | 🖥 [ODM](odm) | Any | [ODM](https://github.com/OpenDroneMap/ODM) | 🐇 |
-| 👓 [Aria](aria) | Project Aria glasses | [Project Aria](https://projectaria.com/) | 🐇 |
+| 👓 [Aria](aria) | Aria glasses | [Project Aria](https://projectaria.com/) | 🐇 |
 
 (images_and_video)=
 
@@ -349,19 +349,26 @@ ns-process-data odm --data /path/to/dataset --output-dir {output directory}
 ns-train nerfacto --data {output directory}
 ```
 
-(360_data)=
+(aria)=
 
 ## Aria
 
-1. Download a VRS file from Project Aria glasses, and run Machine Perception Services to extract poses.
+1. Install projectaria_tools:
 
-2. Convert to nerfstudio format.
+```bash
+conda activate nerfstudio
+pip install projectaria-tools'[all]'
+```
+
+2. Download a VRS file from Project Aria glasses, and run Machine Perception Services to extract poses.
+
+3. Convert to nerfstudio format.
 
 ```bash
 ns-process-data aria --vrs-file /path/to/vrs/file --mps-data-dir /path/to/mps/data --output-dir {output directory}
 ```
 
-3. Train!
+4. Train!
 
 ```bash
 ns-train nerfacto --data {output directory}

--- a/docs/quickstart/custom_dataset.md
+++ b/docs/quickstart/custom_dataset.md
@@ -10,7 +10,7 @@ ns-process-data {video,images,polycam,record3d} --data {DATA_PATH} --output-dir 
 
 A full set of arguments can be found {doc}`here</reference/cli/ns_process_data>`.
 
-We Currently support the following custom data types:
+We currently support the following custom data types:
 | Data | Capture Device | Requirements | `ns-process-data` Speed |
 | ----------------------------- | -------------- | ----------------------------------------------- | ----------------------- |
 | 📷 [Images](images_and_video) | Any | [COLMAP](https://colmap.github.io/install.html) | 🐢 |
@@ -22,6 +22,7 @@ We Currently support the following custom data types:
 | 🖥 [Metashape](metashape) | Any | [Metashape](https://www.agisoft.com/) | 🐇 |
 | 🖥 [RealityCapture](realitycapture) | Any | [RealityCapture](https://www.capturingreality.com/realitycapture) | 🐇 |
 | 🖥 [ODM](odm) | Any | [ODM](https://github.com/OpenDroneMap/ODM) | 🐇 |
+| 👓 [Aria](aria) | Project Aria glasses | [Project Aria](https://projectaria.com/) | 🐇 |
 
 (images_and_video)=
 
@@ -349,6 +350,22 @@ ns-train nerfacto --data {output directory}
 ```
 
 (360_data)=
+
+## Aria
+
+1. Download a VRS file from Project Aria glasses, and run Machine Perception Services to extract poses.
+
+2. Convert to nerfstudio format.
+
+```bash
+ns-process-data aria --vrs-file /path/to/vrs/file --mps-data-dir /path/to/mps/data --output-dir {output directory}
+```
+
+3. Train!
+
+```bash
+ns-train nerfacto --data {output directory}
+```
 
 ## 360 Data (Equirectangular)
 

--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -48,6 +48,7 @@ class CameraType(Enum):
     OMNIDIRECTIONALSTEREO_R = auto()
     VR180_L = auto()
     VR180_R = auto()
+    FISHEYE624 = auto()
 
 
 CAMERA_MODEL_TO_TYPE = {
@@ -62,6 +63,7 @@ CAMERA_MODEL_TO_TYPE = {
     "OMNIDIRECTIONALSTEREO_R": CameraType.OMNIDIRECTIONALSTEREO_R,
     "VR180_L": CameraType.VR180_L,
     "VR180_R": CameraType.VR180_R,
+    "FISHEYE624": CameraType.FISHEYE624,
 }
 
 
@@ -79,7 +81,7 @@ class Cameras(TensorDataclass):
         cy: Principal point y
         width: Image width
         height: Image height
-        distortion_params: OpenCV 6 radial distortion coefficients
+        distortion_params: distortion coefficients (OpenCV 6 radial or 6-2-4 radial, tangential, thin-prism for Fisheye624)
         camera_type: Type of camera model. This will be an int corresponding to the CameraType enum.
         times: Timestamps for each camera
         metadata: Additional metadata or data needed for interpolation, will mimic shape of the cameras
@@ -828,6 +830,33 @@ class Cameras(TensorDataclass):
                 vr180_origins, directions_stack = _compute_rays_for_vr180("right")
                 # assign final camera origins
                 c2w[..., :3, 3] = vr180_origins
+
+            elif CameraType.FISHEYE624.value in cam_types:
+                mask = (self.camera_type[true_indices] == CameraType.FISHEYE624.value).squeeze(-1)  # (num_rays)
+                coord_mask = torch.stack([mask, mask, mask], dim=0)
+
+                # fisheye624 requires pixel coordinates to unproject, so we need to recomput the offsets in pixel coords.
+                pcoord = torch.stack([x, y], -1)  # (num_rays, 2)
+                pcoord_x_offset = torch.stack([x + 1, y], -1)  # (num_rays, 2)
+                pcoord_y_offset = torch.stack([x, y + 1], -1)  # (num_rays, 2)
+
+                # Stack image coordinates and image coordinates offset by 1, check shapes too
+                pcoord_stack = torch.stack([pcoord, pcoord_x_offset, pcoord_y_offset], dim=0)  # (3, num_rays, 2)
+
+                masked_coords = pcoord_stack[coord_mask, :]
+                # The fisheye unprojection does not rely on planar/pinhold unprojection, thus the method needs
+                # to access the focal length and principle points directly.
+                camera_params = torch.cat(
+                    [
+                        fx[mask].unsqueeze(1),
+                        fy[mask].unsqueeze(1),
+                        cx[mask].unsqueeze(1),
+                        cy[mask].unsqueeze(1),
+                        distortion_params[mask, :],
+                    ],
+                    dim=1,
+                )
+                directions_stack[coord_mask] = camera_utils.fisheye624_unproject(masked_coords, camera_params)
 
             else:
                 raise ValueError(f"Camera type {cam} not supported.")

--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -32,7 +32,7 @@ import nerfstudio.utils.math
 import nerfstudio.utils.poses as pose_utils
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.rays import RayBundle
-from nerfstudio.data.scene_box import SceneBox, OrientedBox
+from nerfstudio.data.scene_box import OrientedBox, SceneBox
 from nerfstudio.utils.tensor_dataclass import TensorDataclass
 
 TORCH_DEVICE = Union[torch.device, str]
@@ -631,8 +631,8 @@ class Cameras(TensorDataclass):
         assert coord_stack.shape == (3,) + num_rays_shape + (2,)
 
         # Undistorts our images according to our distortion parameters
+        distortion_params = None
         if not disable_distortion:
-            distortion_params = None
             if self.distortion_params is not None:
                 distortion_params = self.distortion_params[true_indices]
                 if distortion_params_delta is not None:
@@ -846,6 +846,7 @@ class Cameras(TensorDataclass):
                 # Stack image coordinates and image coordinates offset by 1, check shapes too
                 pcoord_stack = torch.stack([pcoord, pcoord_x_offset, pcoord_y_offset], dim=0)  # (3, num_rays, 2)
 
+                assert distortion_params is not None
                 masked_coords = pcoord_stack[coord_mask, :]
                 # The fisheye unprojection does not rely on planar/pinhold unprojection, thus the method needs
                 # to access the focal length and principle points directly.

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -475,8 +475,12 @@ class VanillaDataManager(DataManager, Generic[TDataset]):
         is_equirectangular = (dataset.cameras.camera_type == CameraType.EQUIRECTANGULAR.value).all()
         if is_equirectangular.any():
             CONSOLE.print("[bold yellow]Warning: Some cameras are equirectangular, but using default pixel sampler.")
+
+        fisheye_crop_radius = None if dataset.cameras.metadata is None else dataset.cameras.metadata["fisheye_crop_radius"]
         return self.config.pixel_sampler.setup(
-            is_equirectangular=is_equirectangular, num_rays_per_batch=num_rays_per_batch
+            is_equirectangular=is_equirectangular,
+            num_rays_per_batch=num_rays_per_batch,
+            fisheye_crop_radius=fisheye_crop_radius,
         )
 
     def setup_train(self):

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -476,7 +476,9 @@ class VanillaDataManager(DataManager, Generic[TDataset]):
         if is_equirectangular.any():
             CONSOLE.print("[bold yellow]Warning: Some cameras are equirectangular, but using default pixel sampler.")
 
-        fisheye_crop_radius = None if dataset.cameras.metadata is None else dataset.cameras.metadata["fisheye_crop_radius"]
+        fisheye_crop_radius = (
+            None if dataset.cameras.metadata is None else dataset.cameras.metadata["fisheye_crop_radius"]
+        )
         return self.config.pixel_sampler.setup(
             is_equirectangular=is_equirectangular,
             num_rays_per_batch=num_rays_per_batch,

--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -48,6 +48,8 @@ class PixelSamplerConfig(InstantiateConfig):
     """Whether or not to include a reference to the full image in returned batch."""
     is_equirectangular: bool = False
     """List of whether or not camera i is equirectangular."""
+    fisheye_crop_radius: Optional[float] = None
+    """Set to the radius (in pixels) for fisheye cameras."""
 
 
 class PixelSampler:
@@ -66,6 +68,7 @@ class PixelSampler:
         self.config.num_rays_per_batch = self.kwargs.get("num_rays_per_batch", self.config.num_rays_per_batch)
         self.config.keep_full_image = self.kwargs.get("keep_full_image", self.config.keep_full_image)
         self.config.is_equirectangular = self.kwargs.get("is_equirectangular", self.config.is_equirectangular)
+        self.config.fisheye_crop_radius = self.kwargs.get("fisheye_crop_radius", self.config.fisheye_crop_radius)
         self.set_num_rays_per_batch(self.config.num_rays_per_batch)
 
     def set_num_rays_per_batch(self, num_rays_per_batch: int):
@@ -135,6 +138,36 @@ class PixelSampler:
 
         return indices
 
+    def sample_method_fisheye(
+        self,
+        batch_size: int,
+        num_images: int,
+        image_height: int,
+        image_width: int,
+        mask: Optional[Tensor] = None,
+        device: Union[torch.device, str] = "cpu",
+    ) -> Int[Tensor, "batch_size 3"]:
+        if isinstance(mask, torch.Tensor):
+            indices = self.sample_method(batch_size, num_images, image_height, image_width, mask=mask, device=device)
+        else:
+            rand_samples = torch.rand((batch_size, 3), device=device)
+            # convert random samples tto radius and theta
+            radii = self.config.fisheye_crop_radius * torch.sqrt(rand_samples[:, 1])
+            theta = 2.0 * torch.pi * rand_samples[:, 2]
+
+            # convert radius and theta to x and y between -radii and radii
+            x = radii * torch.cos(theta)
+            y = radii * torch.sin(theta)
+
+            # Multiply by the batch size and height/width to get pixel indices.
+            indices = torch.floor(
+                torch.stack([rand_samples[:, 0], y, x], dim=1)
+                * torch.tensor([num_images, image_height // 2, image_width // 2], device=device)
+                + torch.tensor([0, image_height // 2, image_width // 2], device=device)
+            ).long()
+
+        return indices
+
     def collate_image_dataset_batch(self, batch: Dict, num_rays_per_batch: int, keep_full_image: bool = False):
         """
         Operates on a batch of images and samples pixels to use for generating rays.
@@ -155,6 +188,10 @@ class PixelSampler:
                 indices = self.sample_method_equirectangular(
                     num_rays_per_batch, num_images, image_height, image_width, mask=batch["mask"], device=device
                 )
+            elif self.config.fisheye_crop_radius is not None:
+                indices = self.sample_method_fisheye(
+                    num_rays_per_batch, num_images, image_height, image_width, mask=batch["mask"], device=device
+                )
             else:
                 indices = self.sample_method(
                     num_rays_per_batch, num_images, image_height, image_width, mask=batch["mask"], device=device
@@ -162,6 +199,10 @@ class PixelSampler:
         else:
             if self.config.is_equirectangular:
                 indices = self.sample_method_equirectangular(
+                    num_rays_per_batch, num_images, image_height, image_width, device=device
+                )
+            elif self.config.fisheye_crop_radius is not None:
+                indices = self.sample_method_fisheye(
                     num_rays_per_batch, num_images, image_height, image_width, device=device
                 )
             else:

--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -23,13 +23,12 @@ import numpy as np
 import tyro
 from PIL import Image
 
-try:
-    from projectaria_tools.core import mps
-    from projectaria_tools.core.data_provider import VrsDataProvider, create_vrs_data_provider
-    from projectaria_tools.core.sophus import SE3
-except ImportError:
-    print("projectaria_tools not found, please install with pip3 install projectaria-tools'[all]'")
-    sys.exit(1)
+from projectaria_tools.core import mps
+from projectaria_tools.core.data_provider import (
+    VrsDataProvider,
+    create_vrs_data_provider,
+)
+from projectaria_tools.core.sophus import SE3
 
 ARIA_CAMERA_MODEL = "FISHEYE624"
 
@@ -226,11 +225,6 @@ class ProcessProjectAria:
             transform_file.write_text(json.dumps(nerfstudio_frames))
 
 
-def entrypoint():
-    """Entrypoint for use with pyproject scripts."""
+if __name__ == "__main__":
     tyro.extras.set_accent_color("bright_yellow")
     tyro.cli(ProcessProjectAria).main()
-
-
-if __name__ == "__main__":
-    entrypoint()

--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import sys
 import threading
 from dataclasses import dataclass
 from pathlib import Path

--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -1,0 +1,226 @@
+# Copyright 2022 the Regents of the University of California, Nerfstudio Team and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import projectaria_tools.core.mps as mps
+import tyro
+from PIL import Image
+from projectaria_tools.core.data_provider import VrsDataProvider, create_vrs_data_provider
+from projectaria_tools.core.sophus import SE3
+from tqdm import tqdm
+
+ARIA_CAMERA_MODEL = "FISHEYE624"
+
+# The Aria coordinate system is different than the Blender/NerfStudio coordinate system.
+# Blender / Nerfstudio: +Z = back, +Y = up, +X = right
+# Surreal: +Z = forward, +Y = down, +X = right
+T_ARIA_NERFSTUDIO = SE3.from_matrix(
+    np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0, 0.0],
+            [0.0, 0.0, -1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+)
+
+
+@dataclass
+class AriaCameraCalibration:
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    distortion_params: np.ndarray
+    width: int
+    height: int
+    t_device_camera: SE3
+
+
+@dataclass
+class AriaImageFrame:
+    camera: AriaCameraCalibration
+    file_path: str
+    t_world_camera: SE3
+    timestamp_ns: float
+
+
+@dataclass
+class TimedPoses:
+    timestamps_ns: np.ndarray
+    t_world_devices: List[SE3]
+
+
+def get_camera_calibs(provider: VrsDataProvider) -> Dict[str, AriaCameraCalibration]:
+    """Retrieve the per-camera factory calibration from within the VRS."""
+
+    factory_calib = {}
+    name = "camera-rgb"
+    device_calib = provider.get_device_calibration()
+    assert device_calib is not None, "Could not find device calibration"
+    sensor_calib = device_calib.get_camera_calib(name)
+    assert sensor_calib is not None, f"Could not find sensor calibration for {name}"
+
+    width = sensor_calib.get_image_size()[0].item()
+    height = sensor_calib.get_image_size()[1].item()
+    intrinsics = sensor_calib.projection_params()
+
+    factory_calib[name] = AriaCameraCalibration(
+        fx=intrinsics[0],
+        fy=intrinsics[0],
+        cx=intrinsics[1],
+        cy=intrinsics[2],
+        distortion_params=intrinsics[3:15],
+        width=width,
+        height=height,
+        t_device_camera=sensor_calib.get_transform_device_camera(),
+    )
+
+    return factory_calib
+
+
+def read_trajectory_csv_to_dict(file_iterable_csv: str) -> TimedPoses:
+    closed_loop_traj = mps.read_closed_loop_trajectory(file_iterable_csv)
+
+    timestamps_secs, poses = zip(
+        *[(it.tracking_timestamp.total_seconds(), it.transform_world_device) for it in closed_loop_traj]
+    )
+
+    SEC_TO_NANOSEC = 1e9
+    return TimedPoses(
+        timestamps_ns=(np.array(timestamps_secs) * SEC_TO_NANOSEC).astype(int),
+        t_world_devices=poses,
+    )
+
+
+def to_aria_image_frame(
+    provider: VrsDataProvider,
+    index: int,
+    name_to_camera: Dict[str, AriaCameraCalibration],
+    t_world_devices: TimedPoses,
+    output_dir: Path,
+) -> AriaImageFrame:
+    name = "camera-rgb"
+
+    camera_calibration = name_to_camera[name]
+    stream_id = provider.get_stream_id_from_label(name)
+    assert stream_id is not None, f"Could not find stream {name}"
+
+    # Get the image corresponding to this index
+    image_data = provider.get_image_data_by_index(stream_id, index)
+    img = Image.fromarray(image_data[0].to_numpy_array())
+    capture_time_ns = image_data[1].capture_timestamp_ns
+
+    file_path = f"{output_dir}/{name}_{capture_time_ns}.jpg"
+    threading.Thread(target=lambda: img.save(file_path)).start()
+
+    # Find the nearest neighbor pose with the closest timestamp to the capture time.
+    nearest_pose_idx = np.searchsorted(t_world_devices.timestamps_ns, capture_time_ns)
+    nearest_pose_idx = np.minimum(nearest_pose_idx, len(t_world_devices.timestamps_ns) - 1)
+    assert nearest_pose_idx != -1, f"Could not find pose for {capture_time_ns}"
+    t_world_device = t_world_devices.t_world_devices[nearest_pose_idx]
+
+    # Compute the world to camera transform.
+    t_world_camera = t_world_device @ camera_calibration.t_device_camera @ T_ARIA_NERFSTUDIO
+
+    return AriaImageFrame(
+        camera=camera_calibration,
+        file_path=file_path,
+        t_world_camera=t_world_camera,
+        timestamp_ns=capture_time_ns,
+    )
+
+
+def to_nerfstudio_frame(frame: AriaImageFrame) -> Dict:
+    return {
+        "fl_x": frame.camera.fx,
+        "fl_y": frame.camera.fy,
+        "cx": frame.camera.cx,
+        "cy": frame.camera.cy,
+        "distortion_params": frame.camera.distortion_params.tolist(),
+        "w": frame.camera.width,
+        "h": frame.camera.height,
+        "file_path": frame.file_path,
+        "transform_matrix": frame.t_world_camera.to_matrix().tolist(),
+        "timestamp": frame.timestamp_ns,
+    }
+
+
+@dataclass
+class ProcessProjectAria:
+    """Processes Project Aria data i.e. a VRS of the raw recording streams and the MPS attachments
+    that provide poses, calibration, and 3d points. More information on MPS data can be found at:
+      https://facebookresearch.github.io/projectaria_tools/docs/ARK/mps.
+    """
+
+    vrs_file: Path
+    """Path to the VRS file."""
+    mps_data_dir: Path
+    """Path to Project Aria Machine Perception Services (MPS) attachments."""
+    output_dir: Path
+    """Path to the output directory."""
+
+    def main(self) -> None:
+        """Generate a nerfstudio dataset from ProjectAria data (VRS) and MPS attachments."""
+        # Create output directory if it doesn't exist.
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        provider = create_vrs_data_provider(self.vrs_file.absolute().as_posix())
+        assert provider is not None, "Cannot open file"
+
+        name_to_camera = get_camera_calibs(provider)
+
+        print("Getting poses from closed loop trajectory CSV...")
+        trajectory_csv = self.mps_data_dir / "closed_loop_trajectory.csv"
+        t_world_devices = read_trajectory_csv_to_dict(trajectory_csv.absolute().as_posix())
+
+        name = "camera-rgb"
+        stream_id = provider.get_stream_id_from_label(name)
+
+        # create an AriaImageFrame for each image in the VRS.
+        print("Creating Aria frames...")
+        aria_frames = [
+            to_aria_image_frame(provider, index, name_to_camera, t_world_devices, self.output_dir)
+            for index in range(0, provider.get_num_data(stream_id))
+        ]
+
+        # create the NerfStudio frames from the AriaImageFrames.
+        print("Creating NerfStudio frames...")
+        nerfstudio_frames = {
+            "camera_model": ARIA_CAMERA_MODEL,
+            "frames": [to_nerfstudio_frame(frame) for frame in aria_frames],
+        }
+
+        # write the json out to disk as transforms.json
+        print("Writing transforms.json")
+        transform_file = self.output_dir / "transforms.json"
+        with open(transform_file, "w", encoding="UTF-8") as file:
+            json.dump(nerfstudio_frames, file, indent=4)
+
+
+def entrypoint():
+    """Entrypoint for use with pyproject scripts."""
+    tyro.extras.set_accent_color("bright_yellow")
+    tyro.cli(ProcessProjectAria).main()
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import sys
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,12 +23,13 @@ import numpy as np
 import tyro
 from PIL import Image
 
-from projectaria_tools.core import mps
-from projectaria_tools.core.data_provider import (
-    VrsDataProvider,
-    create_vrs_data_provider,
-)
-from projectaria_tools.core.sophus import SE3
+try:
+    from projectaria_tools.core import mps
+    from projectaria_tools.core.data_provider import VrsDataProvider, create_vrs_data_provider
+    from projectaria_tools.core.sophus import SE3
+except ImportError:
+    print("projectaria_tools import failed, please install with pip3 install projectaria-tools'[all]'")
+    sys.exit(1)
 
 ARIA_CAMERA_MODEL = "FISHEYE624"
 

--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -189,14 +189,14 @@ class ProcessProjectAria:
         self.output_dir = self.output_dir.absolute()
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-        provider = create_vrs_data_provider(self.vrs_file.absolute().as_posix())
+        provider = create_vrs_data_provider(str(self.vrs_file.absolute()))
         assert provider is not None, "Cannot open file"
 
         name_to_camera = get_camera_calibs(provider)
 
         print("Getting poses from closed loop trajectory CSV...")
         trajectory_csv = self.mps_data_dir / "closed_loop_trajectory.csv"
-        t_world_devices = read_trajectory_csv_to_dict(trajectory_csv.absolute().as_posix())
+        t_world_devices = read_trajectory_csv_to_dict(str(trajectory_csv.absolute()))
 
         name = "camera-rgb"
         stream_id = provider.get_stream_id_from_label(name)

--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -16,15 +16,14 @@ import json
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 import numpy as np
-import projectaria_tools.core.mps as mps
 import tyro
 from PIL import Image
+from projectaria_tools.core import mps
 from projectaria_tools.core.data_provider import VrsDataProvider, create_vrs_data_provider
 from projectaria_tools.core.sophus import SE3
-from tqdm import tqdm
 
 ARIA_CAMERA_MODEL = "FISHEYE624"
 
@@ -204,9 +203,11 @@ class ProcessProjectAria:
 
         # create the NerfStudio frames from the AriaImageFrames.
         print("Creating NerfStudio frames...")
+        RGB_VALID_RADIUS = 707.5
         nerfstudio_frames = {
             "camera_model": ARIA_CAMERA_MODEL,
             "frames": [to_nerfstudio_frame(frame) for frame in aria_frames],
+            "fisheye_crop_radius": RGB_VALID_RADIUS,
         }
 
         # write the json out to disk as transforms.json

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -38,6 +38,7 @@ from nerfstudio.process_data.colmap_converter_to_nerfstudio_dataset import BaseC
 from nerfstudio.process_data.images_to_nerfstudio_dataset import ImagesToNerfstudioDataset
 from nerfstudio.process_data.video_to_nerfstudio_dataset import VideoToNerfstudioDataset
 from nerfstudio.utils.rich_utils import CONSOLE
+from nerfstudio.scripts.datasets.process_project_aria import ProcessProjectAria
 
 
 @dataclass
@@ -483,6 +484,7 @@ Commands = Union[
     Annotated[ProcessRealityCapture, tyro.conf.subcommand(name="realitycapture")],
     Annotated[ProcessRecord3D, tyro.conf.subcommand(name="record3d")],
     Annotated[ProcessODM, tyro.conf.subcommand(name="odm")],
+    Annotated[ProcessProjectAria, tyro.conf.subcommand(name="aria")],
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "opencv-python==4.6.0.66",
     "Pillow>=9.3.0",
     "plotly>=5.7.0",
-    "projectaria_tools[all]>=1.2.0",
     "protobuf<=3.20.3,!=3.20.0",
     # TODO(1480) enable when pycolmap windows wheels are available
     # "pycolmap==0.3.0",
@@ -95,6 +94,7 @@ dev = [
     "opencv-stubs==0.0.7",
     "transformers==4.29.2",
     "pyright==1.1.331",
+    "projectaria_tools[all]>=1.2.0",
 ]
 
 # Documentation related packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "opencv-python==4.6.0.66",
     "Pillow>=9.3.0",
     "plotly>=5.7.0",
+    "projectaria_tools[all]>=1.2.0",
     "protobuf<=3.20.3,!=3.20.0",
     # TODO(1480) enable when pycolmap windows wheels are available
     # "pycolmap==0.3.0",


### PR DESCRIPTION
1) An export script for processing Project Aria datasets
2) Add support for Fisheye624 cameras
3) Add support for center-crop masking and sampling

Example commands for running nerfstudio on Project Aria data:

```
python scripts/datasets/process_project_aria.py --vrs_file=<path_to_vrs> --mps_data_dir=<path to MPS directory> --output_dir=<nerfstudio_data_dir>

ns-train nerfacto --data <nerfstudio_data_dir>  nerfstudio-data --orientation-method none