### PR TITLE
Bugfix; scrape pipeline for viewercontrol, not trainer

### DIFF
--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -213,7 +213,7 @@ class Viewer:
 
             # scrape the trainer/pipeline for any ViewerControl objects to initialize them
             self.viewer_controls: List[ViewerControl] = [
-                e for (_, e) in parse_object(self.trainer, ViewerControl, "Custom Elements")
+                e for (_, e) in parse_object(pipeline, ViewerControl, "Custom Elements")
             ]
         for c in self.viewer_controls:
             c._setup(self)


### PR DESCRIPTION
ViewerElements are scraped on pipeline, but ViewerControl is currently being scraped on trainer. This is problematic for `ns-viewer`, because trainer is not instantiated then.

https://github.com/nerfstudio-project/nerfstudio/blob/9528a3f717fe28a6c6500199b5b37d4f2c6e10ca/nerfstudio/viewer_beta/viewer.py#L209

https://github.com/nerfstudio-project/nerfstudio/blob/9528a3f717fe28a6c6500199b5b37d4f2c6e10ca/nerfstudio/viewer_beta/viewer.py#L216