### PR TITLE
Ns-process-data bug with dev version of colmap

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -55,7 +55,9 @@ def get_colmap_version(colmap_cmd: str, default_version=3.8) -> float:
     assert output is not None
     for line in output.split("\n"):
         if line.startswith("COLMAP"):
-            return float(line.split(" ")[1])
+            version = line.split(" ")[1]
+            version = ''.join([c for c in version if c.isdigit() or c == '.'])
+            return float(version)
     CONSOLE.print(f"[bold red]Could not find COLMAP version. Using default {default_version}")
     return default_version
 

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -56,7 +56,7 @@ def get_colmap_version(colmap_cmd: str, default_version=3.8) -> float:
     for line in output.split("\n"):
         if line.startswith("COLMAP"):
             version = line.split(" ")[1]
-            version = ''.join([c for c in version if c.isdigit() or c == '.'])
+            version = "".join([c for c in version if c.isdigit() or c == "."])
             return float(version)
     CONSOLE.print(f"[bold red]Could not find COLMAP version. Using default {default_version}")
     return default_version


### PR DESCRIPTION
When you build colmap from source you get the '3.9-dev' version and the old code would try to turn it to a float to figure out the version number and crash. I changed it to only parse digits and decimals.