### PR TITLE
added Intel GPU support for training and inference

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -69,7 +69,7 @@ class MachineConfig(PrintableConfig):
     """current machine's rank (for DDP)"""
     dist_url: str = "auto"
     """distributed connection point (for DDP)"""
-    device_type: Literal["cpu", "cuda", "mps"] = "cuda"
+    device_type: Literal["cpu", "cuda", "mps", "xpu"] = "cuda"
     """device type to use for training"""
 
 

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -43,6 +43,7 @@ from rich import box, style
 from rich.panel import Panel
 from rich.table import Table
 from torch.cuda.amp.grad_scaler import GradScaler
+import importlib
 
 TRAIN_INTERATION_OUTPUT = Tuple[torch.Tensor, Dict[str, torch.Tensor], Dict[str, torch.Tensor]]
 TORCH_DEVICE = str
@@ -116,12 +117,14 @@ class Trainer:
         self.device: TORCH_DEVICE = config.machine.device_type
         if self.device == "cuda":
             self.device += f":{local_rank}"
+        elif self.device == "xpu":
+            importlib.import_module('intel_extension_for_pytorch')
         self.mixed_precision: bool = self.config.mixed_precision
         self.use_grad_scaler: bool = self.mixed_precision or self.config.use_grad_scaler
         self.training_state: Literal["training", "paused", "completed"] = "training"
         self.gradient_accumulation_steps: int = self.config.gradient_accumulation_steps
 
-        if self.device == "cpu":
+        if self.device == "cpu" or self.device == "xpu":
             self.mixed_precision = False
             CONSOLE.print("Mixed precision is disabled for CPU training.")
         self._start_step: int = 0
@@ -463,13 +466,13 @@ class Trainer:
         """
 
         self.optimizers.zero_grad_all()
-        cpu_or_cuda_str: str = self.device.split(":")[0]
-        cpu_or_cuda_str = "cpu" if cpu_or_cuda_str == "mps" else cpu_or_cuda_str
+        cpu_or_gpu_str: str = self.device.split(":")[0]
+        cpu_or_gpu_str = "cpu" if cpu_or_gpu_str == "mps" else cpu_or_gpu_str
         assert (
             self.gradient_accumulation_steps > 0
         ), f"gradient_accumulation_steps must be > 0, not {self.gradient_accumulation_steps}"
         for _ in range(self.gradient_accumulation_steps):
-            with torch.autocast(device_type=cpu_or_cuda_str, enabled=self.mixed_precision):
+            with torch.autocast(device_type=cpu_or_gpu_str, enabled=self.mixed_precision):
                 _, loss_dict, metrics_dict = self.pipeline.get_train_loss_dict(step=step)
                 loss = functools.reduce(torch.add, loss_dict.values())
                 loss /= self.gradient_accumulation_steps

--- a/nerfstudio/utils/eval_utils.py
+++ b/nerfstudio/utils/eval_utils.py
@@ -16,6 +16,7 @@
 Evaluation utils
 """
 from __future__ import annotations
+import importlib
 
 import os
 import sys
@@ -101,7 +102,15 @@ def eval_setup(
     config.load_dir = config.get_checkpoint_dir()
 
     # setup pipeline (which includes the DataManager)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device_type = "cuda"
+    else:
+        try:
+            importlib.import_module('intel_extension_for_pytorch')
+            device_type = "xpu" if torch.xpu.is_available() else "cpu"
+        except:
+            device_type = "cpu"
+    device = torch.device(device_type)
     pipeline = config.pipeline.setup(device=device, test_mode=test_mode)
     assert isinstance(pipeline, Pipeline)
     pipeline.eval()


### PR DESCRIPTION
Added 'xpu' device type, which represent Intel GPU.

Using Intel GPU for training and inference requires configuring oneAPI and IPEX.
oneAPI: https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=linux&distributions=offline
IPEX: https://github.com/intel/intel-extension-for-pytorch
 
Example commands for running nerfstudio on XPU device:
```
# train
ns-train nerfacto --data data/nerfstudio/poster --machine.device-type xpu
# eval
ns-eval  --load-config=outputs/poster/nerfacto/exp_folder/config.yml
# render
ns-render dataset --load-config outputs/poster/nerfacto/exp_folder/config.yml
```