### PR TITLE
Trainer can now always save dataparser transform

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -225,11 +225,9 @@ class Trainer:
         """Train the model."""
         assert self.pipeline.datamanager.train_dataset is not None, "Missing DatsetInputs"
 
-        # don't want to call save_dataparser_transform if pipeline's datamanager does not have a dataparser
-        if isinstance(self.pipeline.datamanager, VanillaDataManager):
-            self.pipeline.datamanager.train_dataparser_outputs.save_dataparser_transform(
-                self.base_dir / "dataparser_transforms.json"
-            )
+        self.pipeline.datamanager.train_dataparser_outputs.save_dataparser_transform(
+            self.base_dir / "dataparser_transforms.json"
+        )
 
         self._init_viewer_state()
         with TimeWriter(writer, EventName.TOTAL_TRAIN_TIME):


### PR DESCRIPTION
The base_dataparser now has a base `save_dataparser_transform()` method https://github.com/nerfstudio-project/nerfstudio/blob/64f0b2547ba02b1e2aeef719de95b4e7b1aa188a/nerfstudio/data/dataparsers/base_dataparser.py#L77

I think this might have just been a clean-up item that either didn't get addressed in the earlier PR https://github.com/nerfstudio-project/nerfstudio/pull/1008/files#r1207121018

or likely something else got refactored and this got missed.   The current guard is too restrictive now.  If we want to maintain a guard, probably better to do a`hasattr` on `self.pipeline.datamanager.train_dataparser_outputs` for duck-typing.  

Not sure if there are unit tests that can look for this file?  