### PR TITLE
Improved render panel for beta viewer

### DIFF
--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -103,7 +103,7 @@ def get_camera_calibs(provider: VrsDataProvider) -> Dict[str, AriaCameraCalibrat
 
 
 def read_trajectory_csv_to_dict(file_iterable_csv: str) -> TimedPoses:
-    closed_loop_traj = mps.read_closed_loop_trajectory(file_iterable_csv)
+    closed_loop_traj = mps.read_closed_loop_trajectory(file_iterable_csv)  # type: ignore
 
     timestamps_secs, poses = zip(
         *[(it.tracking_timestamp.total_seconds(), it.transform_world_device) for it in closed_loop_traj]

--- a/nerfstudio/viewer_beta/control_panel.py
+++ b/nerfstudio/viewer_beta/control_panel.py
@@ -19,8 +19,6 @@ from typing import Callable, DefaultDict, List, Tuple, get_args
 import numpy as np
 import torch
 import viser.transforms as vtf
-from viser import ViserServer
-
 from nerfstudio.data.scene_box import OrientedBox
 from nerfstudio.utils.colormaps import ColormapOptions, Colormaps
 from nerfstudio.viewer_beta.viewer_elements import (  # ViewerButtonGroup,
@@ -34,6 +32,7 @@ from nerfstudio.viewer_beta.viewer_elements import (  # ViewerButtonGroup,
     ViewerSlider,
     ViewerVec3,
 )
+from viser import ViserServer
 
 
 class ControlPanel:
@@ -43,7 +42,6 @@ class ControlPanel:
         time_enabled: whether or not the time slider should be enabled
         rerender_cb: a callback that will be called when the user changes a parameter that requires a rerender
             (eg train speed, max res, etc)
-        crop_update_cb: a callback that will be called when the user changes the crop parameters
         update_output_cb: a callback that will be called when the user changes the output render
         default_composite_depth: whether to default to compositing depth or not
     """
@@ -53,8 +51,7 @@ class ControlPanel:
         viser_server: ViserServer,
         time_enabled: bool,
         scale_ratio: float,
-        rerender_cb: Callable,
-        crop_update_cb: Callable,
+        rerender_cb: Callable[[], None],
         update_output_cb: Callable,
         update_split_output_cb: Callable,
         toggle_training_state_cb: Callable,
@@ -78,51 +75,53 @@ class ControlPanel:
             cb_hook=lambda han: self._reset_camera_cb(),
         )
         self._output_render = ViewerDropdown(
-            "Output Render",
+            "Output type",
             "not set",
             ["not set"],
-            cb_hook=lambda han: [self.update_control_panel(), update_output_cb(han), rerender_cb(han)],
+            cb_hook=lambda han: [self.update_control_panel(), update_output_cb(han), rerender_cb()],
             hint="The output to render",
         )
         self._colormap = ViewerDropdown[Colormaps](
-            "Colormap", "default", ["default"], cb_hook=rerender_cb, hint="The colormap to use"
+            "Colormap", "default", ["default"], cb_hook=lambda _: rerender_cb(), hint="The colormap to use"
         )
-        self._invert = ViewerCheckbox("Invert", False, cb_hook=rerender_cb, hint="Invert the colormap")
-        self._normalize = ViewerCheckbox("Normalize", True, cb_hook=rerender_cb, hint="Normalize the colormap")
-        self._min = ViewerNumber("Min", 0.0, cb_hook=rerender_cb, hint="Min value of the colormap")
-        self._max = ViewerNumber("Max", 1.0, cb_hook=rerender_cb, hint="Max value of the colormap")
+        self._invert = ViewerCheckbox("Invert", False, cb_hook=lambda _: rerender_cb(), hint="Invert the colormap")
+        self._normalize = ViewerCheckbox(
+            "Normalize", True, cb_hook=lambda _: rerender_cb(), hint="Normalize the colormap"
+        )
+        self._min = ViewerNumber("Min", 0.0, cb_hook=lambda _: rerender_cb(), hint="Min value of the colormap")
+        self._max = ViewerNumber("Max", 1.0, cb_hook=lambda _: rerender_cb(), hint="Max value of the colormap")
 
         self._split = ViewerCheckbox(
             "Enable",
             False,
-            cb_hook=lambda han: [self.update_control_panel(), rerender_cb(han)],
+            cb_hook=lambda han: [self.update_control_panel(), rerender_cb()],
             hint="Render two outputs",
         )
         self._split_percentage = ViewerSlider(
-            "Split Percentage", 0.5, 0.0, 1.0, 0.01, cb_hook=rerender_cb, hint="Where to split"
+            "Split percentage", 0.5, 0.0, 1.0, 0.01, cb_hook=lambda _: rerender_cb(), hint="Where to split"
         )
         self._split_output_render = ViewerDropdown(
-            "Output Render Split",
+            "Output render split",
             "not set",
             ["not set"],
-            cb_hook=lambda han: [self.update_control_panel(), update_split_output_cb(han), rerender_cb(han)],
+            cb_hook=lambda han: [self.update_control_panel(), update_split_output_cb(han), rerender_cb()],
             hint="The second output",
         )
         # Hack: spaces are after at the end of the names to make them unique
         self._split_colormap = ViewerDropdown[Colormaps](
-            "Colormap ", "default", ["default"], cb_hook=rerender_cb, hint="Colormap of the second output"
+            "Colormap ", "default", ["default"], cb_hook=lambda _: rerender_cb(), hint="Colormap of the second output"
         )
         self._split_invert = ViewerCheckbox(
-            "Invert ", False, cb_hook=rerender_cb, hint="Invert the colormap of the second output"
+            "Invert ", False, cb_hook=lambda _: rerender_cb(), hint="Invert the colormap of the second output"
         )
         self._split_normalize = ViewerCheckbox(
-            "Normalize ", True, cb_hook=rerender_cb, hint="Normalize the colormap of the second output"
+            "Normalize ", True, cb_hook=lambda _: rerender_cb(), hint="Normalize the colormap of the second output"
         )
         self._split_min = ViewerNumber(
-            "Min ", 0.0, cb_hook=rerender_cb, hint="Min value of the colormap of the second output"
+            "Min ", 0.0, cb_hook=lambda _: rerender_cb(), hint="Min value of the colormap of the second output"
         )
         self._split_max = ViewerNumber(
-            "Max ", 1.0, cb_hook=rerender_cb, hint="Max value of the colormap of the second output"
+            "Max ", 1.0, cb_hook=lambda _: rerender_cb(), hint="Max value of the colormap of the second output"
         )
 
         self._train_util = ViewerSlider(
@@ -134,22 +133,28 @@ class ControlPanel:
             hint="Target training utilization, 0.0 is slow, 1.0 is fast. Doesn't affect final render quality",
         )
         self._layer_depth = ViewerCheckbox(
-            "Composite Depth",
+            "Composite depth",
             self.default_composite_depth,
-            cb_hook=rerender_cb,
+            cb_hook=lambda _: rerender_cb(),
             hint="Allow NeRF to occlude 3D browser objects",
         )
         self._max_res = ViewerSlider(
-            "Max Res", 512, 64, 2048, 100, cb_hook=rerender_cb, hint="Maximum resolution to render in viewport"
+            "Max res",
+            512,
+            64,
+            2048,
+            100,
+            cb_hook=lambda _: rerender_cb(),
+            hint="Maximum resolution to render in viewport",
         )
         self._crop_viewport = ViewerCheckbox(
             "Enable ",
             False,
-            cb_hook=lambda han: [self.update_control_panel(), crop_update_cb(han), rerender_cb(han)],
+            cb_hook=lambda han: [self.update_control_panel(), rerender_cb()],
             hint="Crop the scene to a specified box",
         )
         self._background_color = ViewerRGB(
-            "Background color", (38, 42, 55), cb_hook=crop_update_cb, hint="Color of the background"
+            "Background color", (38, 42, 55), cb_hook=lambda _: rerender_cb(), hint="Color of the background"
         )
         self._crop_handle = self.viser_server.add_transform_controls("Crop", depth_test=False, line_width=4.0)
 
@@ -157,10 +162,10 @@ class ControlPanel:
             self._crop_handle.position = tuple(p * self.viser_scale_ratio for p in han.value)  # type: ignore
 
         self._crop_center = ViewerVec3(
-            "Crop Center",
+            "Crop center",
             (0.0, 0.0, 0.0),
             step=0.01,
-            cb_hook=lambda e: [crop_update_cb(e), update_center(e)],
+            cb_hook=lambda e: [rerender_cb(), update_center(e)],
             hint="Center of the crop box",
         )
 
@@ -168,15 +173,15 @@ class ControlPanel:
             self._crop_handle.wxyz = vtf.SO3.from_rpy_radians(*han.value).wxyz
 
         self._crop_rot = ViewerVec3(
-            "Crop Rotation",
+            "Crop rotation",
             (0.0, 0.0, 0.0),
             step=0.01,
-            cb_hook=lambda e: [crop_update_cb(e), update_rot(e)],
+            cb_hook=lambda e: [rerender_cb(), update_rot(e)],
             hint="Rotation of the crop box",
         )
 
         self._crop_scale = ViewerVec3(
-            "Crop Scale", (1.0, 1.0, 1.0), step=0.01, cb_hook=crop_update_cb, hint="Scale of the crop box"
+            "Crop scale", (1.0, 1.0, 1.0), step=0.01, cb_hook=lambda _: rerender_cb(), hint="Size of the crop box."
         )
 
         @self._crop_handle.on_update
@@ -186,7 +191,7 @@ class ControlPanel:
             rpy = vtf.SO3(self._crop_handle.wxyz).as_rpy_radians()
             self._crop_rot.value = (float(rpy.roll), float(rpy.pitch), float(rpy.yaw))
 
-        self._time = ViewerSlider("Time", 0.0, 0.0, 1.0, 0.01, cb_hook=rerender_cb, hint="Time to render")
+        self._time = ViewerSlider("Time", 0.0, 0.0, 1.0, 0.01, cb_hook=lambda _: rerender_cb(), hint="Time to render")
         self._time_enabled = time_enabled
 
         self.stat_folder = self.viser_server.add_gui_folder("Stats")

--- a/nerfstudio/viewer_beta/control_panel.py
+++ b/nerfstudio/viewer_beta/control_panel.py
@@ -225,7 +225,10 @@ class ControlPanel:
 
         self.add_element(self._time, additional_tags=("time",))
         self._reset_camera = viser_server.add_gui_button(
-            label="Reset Up Dir", disabled=False, icon=viser.Icon.ARROW_BIG_UP_LINES, color="gray"
+            label="Reset Up Direction",
+            icon=viser.Icon.ARROW_BIG_UP_LINES,
+            color="gray",
+            hint="Set the up direction of the camera orbit controls to the camera's current up direction.",
         )
         self._reset_camera.on_click(self._reset_camera_cb)
 

--- a/nerfstudio/viewer_beta/render_panel.py
+++ b/nerfstudio/viewer_beta/render_panel.py
@@ -749,7 +749,6 @@ def populate_render_tab(
                 for client in server.get_clients().values():
                     client.camera.wxyz = pose.rotation().wxyz
                     client.camera.position = pose.translation()
-                    client.camera.fov = fov_rad
 
         return preview_frame_slider
 
@@ -789,11 +788,10 @@ def populate_render_tab(
             for client in server.get_clients().values():
                 if client.client_id not in camera_pose_backup_from_id:
                     continue
-                cam_position, cam_look_at, cam_up, cam_fov = camera_pose_backup_from_id.pop(client.client_id)
+                cam_position, cam_look_at, cam_up = camera_pose_backup_from_id.pop(client.client_id)
                 client.camera.position = cam_position
                 client.camera.look_at = cam_look_at
                 client.camera.up_direction = cam_up
-                client.camera.fov = cam_fov
                 client.flush()
 
             # Un-hide scene nodes.
@@ -807,11 +805,9 @@ def populate_render_tab(
                         client.camera.position,
                         client.camera.look_at,
                         client.camera.up_direction,
-                        client.camera.fov,
                     )
                     client.camera.wxyz = pose.rotation().wxyz
                     client.camera.position = pose.translation()
-                    client.camera.fov = fov
 
     preview_frame_slider = add_preview_frame_slider()
 

--- a/nerfstudio/viewer_beta/render_panel.py
+++ b/nerfstudio/viewer_beta/render_panel.py
@@ -536,17 +536,6 @@ def populate_render_tab(
         duration_number.value = camera_path.compute_duration()
         camera_path.update_spline()
 
-    reset_up_button = server.add_gui_button(
-        "Reset up direction",
-        icon=viser.Icon.ARROW_BIG_UP_LINES,
-        hint="Reset the orbit up direction.",
-    )
-
-    @reset_up_button.on_click
-    def _(event: viser.GuiEvent) -> None:
-        assert event.client is not None
-        event.client.camera.up_direction = tf.SO3(event.client.camera.wxyz) @ np.array([0.0, -1.0, 0.0])
-
     clear_keyframes_button = server.add_gui_button(
         "Clear Keyframes",
         icon=viser.Icon.TRASH,
@@ -944,6 +933,18 @@ def populate_render_tab(
         icon=viser.Icon.FILE_EXPORT,
         hint="Generate the ns-render command for rendering the camera path.",
     )
+
+    reset_up_button = server.add_gui_button(
+        "Reset Up Direction",
+        icon=viser.Icon.ARROW_BIG_UP_LINES,
+        color="gray",
+        hint="Set the up direction of the camera orbit controls to the camera's current up direction.",
+    )
+
+    @reset_up_button.on_click
+    def _(event: viser.GuiEvent) -> None:
+        assert event.client is not None
+        event.client.camera.up_direction = tf.SO3(event.client.camera.wxyz) @ np.array([0.0, -1.0, 0.0])
 
     @render_button.on_click
     def _(event: viser.GuiEvent) -> None:

--- a/nerfstudio/viewer_beta/render_panel.py
+++ b/nerfstudio/viewer_beta/render_panel.py
@@ -56,9 +56,7 @@ class Keyframe:
 
 
 class CameraPath:
-    def __init__(
-        self, server: viser.ViserServer, duration_element: viser.GuiInputHandle[float]
-    ):
+    def __init__(self, server: viser.ViserServer, duration_element: viser.GuiInputHandle[float]):
         self._server = server
         self._keyframes: Dict[int, Tuple[Keyframe, viser.CameraFrustumHandle]] = {}
         self._keyframe_counter: int = 0
@@ -85,9 +83,7 @@ class CameraPath:
         for keyframe in self._keyframes.values():
             keyframe[1].visible = visible
 
-    def add_camera(
-        self, keyframe: Keyframe, keyframe_index: Optional[int] = None
-    ) -> None:
+    def add_camera(self, keyframe: Keyframe, keyframe_index: Optional[int] = None) -> None:
         """Add a new camera, or replace an old one if `keyframe_index` is passed in."""
         server = self._server
 
@@ -98,9 +94,7 @@ class CameraPath:
 
         frustum_handle = server.add_camera_frustum(
             f"/render_cameras/{keyframe_index}",
-            fov=keyframe.override_fov_rad
-            if keyframe.override_fov_enabled
-            else self.default_fov,
+            fov=keyframe.override_fov_rad if keyframe.override_fov_enabled else self.default_fov,
             aspect=keyframe.aspect,
             scale=0.1,
             color=(200, 10, 30),
@@ -125,9 +119,7 @@ class CameraPath:
                 position=keyframe.position,
             ) as camera_edit_panel:
                 self._camera_edit_panel = camera_edit_panel
-                override_fov = server.add_gui_checkbox(
-                    "Override FOV", initial_value=keyframe.override_fov_enabled
-                )
+                override_fov = server.add_gui_checkbox("Override FOV", initial_value=keyframe.override_fov_enabled)
                 override_fov_degrees = server.add_gui_slider(
                     "Override FOV (degrees)",
                     5.0,
@@ -136,9 +128,7 @@ class CameraPath:
                     initial_value=keyframe.override_fov_rad * 180.0 / np.pi,
                     disabled=not keyframe.override_fov_enabled,
                 )
-                delete_button = server.add_gui_button(
-                    "Delete", color="red", icon=viser.Icon.TRASH
-                )
+                delete_button = server.add_gui_button("Delete", color="red", icon=viser.Icon.TRASH)
                 go_to_button = server.add_gui_button("Go to")
                 close_button = server.add_gui_button("Close")
 
@@ -158,9 +148,7 @@ class CameraPath:
                 assert event.client is not None
                 with event.client.add_gui_modal("Confirm") as modal:
                     event.client.add_gui_markdown("Delete keyframe?")
-                    confirm_button = event.client.add_gui_button(
-                        "Yes", color="red", icon=viser.Icon.TRASH
-                    )
+                    confirm_button = event.client.add_gui_button("Yes", color="red", icon=viser.Icon.TRASH)
                     exit_button = event.client.add_gui_button("Cancel")
 
                     @confirm_button.on_click
@@ -199,9 +187,7 @@ class CameraPath:
                 T_current_target = T_world_current.inverse() @ T_world_target
 
                 for j in range(10):
-                    T_world_set = T_world_current @ tf.SE3.exp(
-                        T_current_target.log() * j / 9.0
-                    )
+                    T_world_set = T_world_current @ tf.SE3.exp(T_current_target.log() * j / 9.0)
 
                     # Important bit: we atomically set both the orientation and the position
                     # of the camera.
@@ -251,29 +237,21 @@ class CameraPath:
                     ],
                     axis=0,
                 ),
-                y=np.concatenate(
-                    [[-1], spline_indices, [spline_indices[-1] + 1]], axis=0
-                ),
+                y=np.concatenate([[-1], spline_indices, [spline_indices[-1] + 1]], axis=0),
             )
         else:
-            interpolator = scipy.interpolate.PchipInterpolator(
-                x=transition_times_cumsum, y=spline_indices
-            )
+            interpolator = scipy.interpolate.PchipInterpolator(x=transition_times_cumsum, y=spline_indices)
 
         # Clip to account for floating point error.
         return np.clip(interpolator(time), 0, spline_indices[-1])
 
-    def interpolate_pose_and_fov_rad(
-        self, normalized_t: float
-    ) -> Optional[Tuple[tf.SE3, float]]:
+    def interpolate_pose_and_fov_rad(self, normalized_t: float) -> Optional[Tuple[tf.SE3, float]]:
         if len(self._keyframes) < 2:
             return None
 
         self._fov_spline = splines.KochanekBartels(
             [
-                keyframe[0].override_fov_rad
-                if keyframe[0].override_fov_enabled
-                else self.default_fov
+                keyframe[0].override_fov_rad if keyframe[0].override_fov_enabled else self.default_fov
                 for keyframe in self._keyframes.values()
             ],
             tcb=(self.tension, 0.0, 0.0),
@@ -311,9 +289,7 @@ class CameraPath:
 
         self._orientation_spline = splines.quaternion.KochanekBartels(
             [
-                splines.quaternion.UnitQuaternion.from_unit_xyzw(
-                    np.roll(keyframe[0].wxyz, shift=-1)
-                )
+                splines.quaternion.UnitQuaternion.from_unit_xyzw(np.roll(keyframe[0].wxyz, shift=-1))
                 for keyframe in keyframes
             ],
             tcb=(self.tension, 0.0, 0.0),
@@ -327,16 +303,9 @@ class CameraPath:
 
         # Update visualized spline.
         points_array = self._position_spline.evaluate(
-            self.spline_t_from_t_sec(
-                np.linspace(0, transition_times_cumsum[-1], num_frames)
-            )
+            self.spline_t_from_t_sec(np.linspace(0, transition_times_cumsum[-1], num_frames))
         )
-        colors_array = np.array(
-            [
-                colorsys.hls_to_rgb(h, 0.5, 1.0)
-                for h in np.linspace(0.0, 1.0, len(points_array))
-            ]
-        )
+        colors_array = np.array([colorsys.hls_to_rgb(h, 0.5, 1.0) for h in np.linspace(0.0, 1.0, len(points_array))])
 
         # Clear prior spline nodes.
         for node in self._spline_nodes:
@@ -367,8 +336,7 @@ class CameraPath:
             transition_pos = self._position_spline.evaluate(
                 float(
                     self.spline_t_from_t_sec(
-                        (transition_times_cumsum[i] + transition_times_cumsum[i + 1])
-                        / 2.0,
+                        (transition_times_cumsum[i] + transition_times_cumsum[i + 1]) / 2.0,
                     )
                 )
             )
@@ -414,12 +382,8 @@ class CameraPath:
 
                 @override_transition_enabled.on_update
                 def _(_) -> None:
-                    keyframe.override_transition_enabled = (
-                        override_transition_enabled.value
-                    )
-                    override_transition_sec.disabled = (
-                        not override_transition_enabled.value
-                    )
+                    keyframe.override_transition_enabled = override_transition_enabled.value
+                    override_transition_sec.disabled = not override_transition_enabled.value
                     self._duration_element.value = self.compute_duration()
 
                 @override_transition_sec.on_update
@@ -448,8 +412,7 @@ class CameraPath:
             del frustum
             total += (
                 keyframe.override_transition_sec
-                if keyframe.override_transition_enabled
-                and keyframe.override_transition_sec is not None
+                if keyframe.override_transition_enabled and keyframe.override_transition_sec is not None
                 else self.default_transition_sec
             )
         return total
@@ -464,8 +427,7 @@ class CameraPath:
             del frustum
             total += (
                 keyframe.override_transition_sec
-                if keyframe.override_transition_enabled
-                and keyframe.override_transition_sec is not None
+                if keyframe.override_transition_enabled and keyframe.override_transition_sec is not None
                 else self.default_transition_sec
             )
             out.append(total)
@@ -474,8 +436,7 @@ class CameraPath:
             keyframe = next(iter(self._keyframes.values()))[0]
             total += (
                 keyframe.override_transition_sec
-                if keyframe.override_transition_enabled
-                and keyframe.override_transition_sec is not None
+                if keyframe.override_transition_enabled and keyframe.override_transition_sec is not None
                 else self.default_transition_sec
             )
             out.append(total)
@@ -519,9 +480,7 @@ def populate_render_tab(
         step=1,
         hint="Render output resolution in pixels.",
     )
-    resolution.on_update(
-        lambda _: camera_path.update_aspect(resolution.value[0] / resolution.value[1])
-    )
+    resolution.on_update(lambda _: camera_path.update_aspect(resolution.value[0] / resolution.value[1]))
 
     camera_type = server.add_gui_dropdown(
         "Camera Type",
@@ -559,9 +518,7 @@ def populate_render_tab(
     @reset_up_button.on_click
     def _(event: viser.GuiEvent) -> None:
         assert event.client is not None
-        event.client.camera.up_direction = tf.SO3(event.client.camera.wxyz) @ np.array(
-            [0.0, -1.0, 0.0]
-        )
+        event.client.camera.up_direction = tf.SO3(event.client.camera.wxyz) @ np.array([0.0, -1.0, 0.0])
 
     clear_keyframes_button = server.add_gui_button(
         "Clear keyframes",
@@ -575,9 +532,7 @@ def populate_render_tab(
         client = server.get_clients()[event.client_id]
         with client.atomic(), client.add_gui_modal("Confirm") as modal:
             client.add_gui_markdown("Clear all keyframes?")
-            confirm_button = client.add_gui_button(
-                "Yes", color="red", icon=viser.Icon.TRASH
-            )
+            confirm_button = client.add_gui_button("Yes", color="red", icon=viser.Icon.TRASH)
             exit_button = client.add_gui_button("Cancel")
 
             @confirm_button.on_click
@@ -598,9 +553,7 @@ def populate_render_tab(
             def _(_) -> None:
                 modal.close()
 
-    loop = server.add_gui_checkbox(
-        "Loop", False, hint="Add a segment between the first and last keyframes."
-    )
+    loop = server.add_gui_checkbox("Loop", False, hint="Add a segment between the first and last keyframes.")
 
     @loop.on_update
     def _(_) -> None:
@@ -686,12 +639,8 @@ def populate_render_tab(
     playback_folder = server.add_gui_folder("Playback")
     with playback_folder:
         play_button = server.add_gui_button("Play", icon=viser.Icon.PLAYER_PLAY)
-        pause_button = server.add_gui_button(
-            "Pause", icon=viser.Icon.PLAYER_PAUSE, visible=False
-        )
-        attach_viewport_checkbox = server.add_gui_checkbox(
-            "Attach viewport", initial_value=False
-        )
+        pause_button = server.add_gui_button("Pause", icon=viser.Icon.PLAYER_PAUSE, visible=False)
+        attach_viewport_checkbox = server.add_gui_checkbox("Attach viewport", initial_value=False)
         transition_sec_number = server.add_gui_number(
             "Transition (sec)",
             min=0.001,
@@ -700,9 +649,7 @@ def populate_render_tab(
             initial_value=0.5,
             hint="Time in seconds between each keyframe, which can also be overridden on a per-transition basis.",
         )
-        framerate_number = server.add_gui_number(
-            "FPS", min=0.1, max=240.0, step=1e-2, initial_value=30.0
-        )
+        framerate_number = server.add_gui_number("FPS", min=0.1, max=240.0, step=1e-2, initial_value=30.0)
         framerate_buttons = server.add_gui_button_group("", ("24", "30", "60"))
         duration_number = server.add_gui_number(
             "Duration (sec)",
@@ -852,9 +799,7 @@ def populate_render_tab(
                 max_frame = int(framerate_number.value * duration_number.value)
                 if max_frame > 0:
                     assert preview_frame_slider is not None
-                    preview_frame_slider.value = (
-                        preview_frame_slider.value + 1
-                    ) % max_frame
+                    preview_frame_slider.value = (preview_frame_slider.value + 1) % max_frame
                 time.sleep(1.0 / framerate_number.value)
 
         threading.Thread(target=play).start()
@@ -901,9 +846,7 @@ def populate_render_tab(
                     camera_path.reset()
                     for i in range(len(keyframes)):
                         frame = keyframes[i]
-                        pose = tf.SE3.from_matrix(
-                            np.array(frame["matrix"]).reshape(4, 4)
-                        )
+                        pose = tf.SE3.from_matrix(np.array(frame["matrix"]).reshape(4, 4))
                         # apply the x rotation by 180 deg
                         pose = tf.SE3.from_rotation_and_translation(
                             pose.rotation() @ tf.SO3.from_x_radians(np.pi),
@@ -911,24 +854,17 @@ def populate_render_tab(
                         )
                         camera_path.add_camera(
                             Keyframe(
-                                position=pose.translation()
-                                * VISER_NERFSTUDIO_SCALE_RATIO,
+                                position=pose.translation() * VISER_NERFSTUDIO_SCALE_RATIO,
                                 wxyz=pose.rotation().wxyz,
                                 override_fov_enabled=True,
                                 override_fov_rad=frame["fov"] / 180.0 * np.pi,
                                 aspect=frame["aspect"],
-                                override_transition_enabled=frame.get(
-                                    "override_transition_enabled", None
-                                ),
-                                override_transition_sec=frame.get(
-                                    "override_transition_sec", None
-                                ),
+                                override_transition_enabled=frame.get("override_transition_enabled", None),
+                                override_transition_sec=frame.get("override_transition_sec", None),
                             ),
                         )
 
-                    transition_sec_number.value = json_data.get(
-                        "default_transition_sec", 0.5
-                    )
+                    transition_sec_number.value = json_data.get("default_transition_sec", 0.5)
 
                     # update the render name
                     render_name_text.value = json_path.stem
@@ -1006,9 +942,7 @@ def populate_render_tab(
         # now populate the camera path:
         camera_path_list = []
         for i in range(num_frames):
-            maybe_pose_and_fov = camera_path.interpolate_pose_and_fov_rad(
-                i / num_frames
-            )
+            maybe_pose_and_fov = camera_path.interpolate_pose_and_fov_rad(i / num_frames)
             if maybe_pose_and_fov is None:
                 return
             pose, fov = maybe_pose_and_fov

--- a/nerfstudio/viewer_beta/render_panel.py
+++ b/nerfstudio/viewer_beta/render_panel.py
@@ -899,7 +899,9 @@ def populate_render_tab(
                             Keyframe(
                                 position=pose.translation() * VISER_NERFSTUDIO_SCALE_RATIO,
                                 wxyz=pose.rotation().wxyz,
-                                override_fov_enabled=True,
+                                # There are some floating point conversions between degrees and radians, so the fov and
+                                # default_Fov values will not be exactly matched.
+                                override_fov_enabled=abs(frame["fov"] - json_data.get("default_fov", 0.0)) < 1e-3,
                                 override_fov_rad=frame["fov"] / 180.0 * np.pi,
                                 aspect=frame["aspect"],
                                 override_transition_enabled=frame.get("override_transition_enabled", None),
@@ -985,6 +987,7 @@ def populate_render_tab(
                     "override_transition_sec": keyframe.override_transition_sec,
                 }
             )
+        json_data["default_fov"] = fov_degrees.value
         json_data["default_transition_sec"] = transition_sec_number.value
         json_data["keyframes"] = keyframes
         json_data["camera_type"] = camera_type.value.lower()

--- a/nerfstudio/viewer_beta/render_state_machine.py
+++ b/nerfstudio/viewer_beta/render_state_machine.py
@@ -21,12 +21,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, get_args
 
 import torch
-from viser import ClientHandle
 from nerfstudio.model_components.renderers import background_color_override_context
 from nerfstudio.utils import colormaps, writer
 from nerfstudio.utils.writer import GLOBAL_BUFFER, EventName, TimeWriter
 from nerfstudio.viewer.server import viewer_utils
 from nerfstudio.viewer_beta.utils import CameraState, get_camera
+from viser import ClientHandle
 
 if TYPE_CHECKING:
     from nerfstudio.viewer_beta.viewer import Viewer

--- a/nerfstudio/viewer_beta/render_state_machine.py
+++ b/nerfstudio/viewer_beta/render_state_machine.py
@@ -273,7 +273,13 @@ class RenderStateMachine(threading.Thread):
                 constant_values=0,
             )
 
-        jpg_quality = self.viewer.config.jpeg_quality if static_render else 70
+        jpg_quality = (
+            self.viewer.config.jpeg_quality
+            if static_render
+            else 75
+            if self.viewer.render_tab_state.preview_render
+            else 40
+        )
         self.client.set_background_image(
             selected_output,
             format=self.viewer.config.image_format,

--- a/nerfstudio/viewer_beta/render_state_machine.py
+++ b/nerfstudio/viewer_beta/render_state_machine.py
@@ -95,7 +95,7 @@ class RenderStateMachine(threading.Thread):
             #  1. we are in low_moving state
             #  2. the current next_action is move, static, or rerender
             return
-        elif self.next_action == "rerender":
+        elif self.next_action.action == "rerender":
             # never overwrite rerenders
             pass
         elif action.action == "static" and self.next_action.action == "move":

--- a/nerfstudio/viewer_beta/render_state_machine.py
+++ b/nerfstudio/viewer_beta/render_state_machine.py
@@ -273,7 +273,7 @@ class RenderStateMachine(threading.Thread):
                 constant_values=0,
             )
 
-        jpg_quality = self.viewer.config.jpeg_quality if static_render else 40
+        jpg_quality = self.viewer.config.jpeg_quality if static_render else 70
         self.client.set_background_image(
             selected_output,
             format=self.viewer.config.image_format,

--- a/nerfstudio/viewer_beta/utils.py
+++ b/nerfstudio/viewer_beta/utils.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -31,11 +31,13 @@ class CameraState:
     """A dataclass for storing the camera state."""
 
     fov: float
-    """ The field of view of the camera. """
+    """The field of view of the camera."""
     aspect: float
-    """ The aspect ratio of the image. """
+    """The aspect ratio of the image. """
     c2w: Float[torch.Tensor, "3 4"]
-    """ The camera matrix. """
+    """The camera matrix."""
+    camera_type: Literal[CameraType.PERSPECTIVE, CameraType.EQUIRECTANGULAR, CameraType.FISHEYE]
+    """Type of camera to render."""
 
 
 def get_camera(
@@ -57,14 +59,12 @@ def get_camera(
     focal_length = pp_h / np.tan(fov / 2.0)
     intrinsics_matrix = torch.tensor([[focal_length, 0, pp_w], [0, focal_length, pp_h], [0, 0, 1]], dtype=torch.float32)
 
-    camera_type = CameraType.PERSPECTIVE
-
     camera = Cameras(
         fx=intrinsics_matrix[0, 0],
         fy=intrinsics_matrix[1, 1],
         cx=pp_w,
         cy=pp_h,
-        camera_type=camera_type,
+        camera_type=camera_state.camera_type,
         camera_to_worlds=camera_state.c2w.to(torch.float32),
         times=torch.tensor([0.0], dtype=torch.float32),
     )

--- a/nerfstudio/viewer_beta/utils.py
+++ b/nerfstudio/viewer_beta/utils.py
@@ -59,9 +59,16 @@ def get_camera(
     focal_length = pp_h / np.tan(fov / 2.0)
     intrinsics_matrix = torch.tensor([[focal_length, 0, pp_w], [0, focal_length, pp_h], [0, 0, 1]], dtype=torch.float32)
 
+    if camera_state.camera_type is CameraType.EQUIRECTANGULAR:
+        fx = float(image_width / 2)
+        fy = float(image_height)
+    else:
+        fx = intrinsics_matrix[0, 0]
+        fy = intrinsics_matrix[1, 1]
+
     camera = Cameras(
-        fx=intrinsics_matrix[0, 0],
-        fy=intrinsics_matrix[1, 1],
+        fx=fx,
+        fy=fy,
         cx=pp_w,
         cy=pp_h,
         camera_type=camera_state.camera_type,

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -26,7 +26,6 @@ import torchvision
 import viser
 import viser.theme
 import viser.transforms as vtf
-
 from nerfstudio.cameras.camera_optimizers import CameraOptimizer
 from nerfstudio.configs import base_config as cfg
 from nerfstudio.data.datasets.base_dataset import InputDataset

--- a/nerfstudio/viewer_beta/viewer.py
+++ b/nerfstudio/viewer_beta/viewer.py
@@ -271,7 +271,7 @@ class Viewer:
         R = torch.tensor(R.as_matrix())
         pos = torch.tensor(client.camera.position, dtype=torch.float64) / VISER_NERFSTUDIO_SCALE_RATIO
         c2w = torch.concatenate([R, pos[:, None]], dim=1)
-        if self.render_tab_state.preview_render:
+        if self.ready and self.render_tab_state.preview_render:
             camera_type = self.render_tab_state.preview_camera_type
             camera_state = CameraState(
                 fov=self.render_tab_state.preview_fov,

--- a/nerfstudio/viewer_beta/viewer_elements.py
+++ b/nerfstudio/viewer_beta/viewer_elements.py
@@ -35,7 +35,7 @@ from viser import (
     ViserServer,
 )
 
-from nerfstudio.cameras.cameras import Cameras
+from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.viewer_beta.utils import CameraState, get_camera
 
 if TYPE_CHECKING:
@@ -141,7 +141,9 @@ class ViewerControl:
         R = torch.tensor(R.as_matrix())
         pos = torch.tensor(client.camera.position, dtype=torch.float64) / VISER_NERFSTUDIO_SCALE_RATIO
         c2w = torch.concatenate([R, pos[:, None]], dim=1)
-        camera_state = CameraState(fov=client.camera.fov, aspect=client.camera.aspect, c2w=c2w)
+        camera_state = CameraState(
+            fov=client.camera.fov, aspect=client.camera.aspect, c2w=c2w, camera_type=CameraType.PERSPECTIVE
+        )
         return get_camera(camera_state, img_height, img_width)
 
     def register_click_cb(self, cb: Callable):
@@ -483,7 +485,11 @@ class ViewerDropdown(ViewerParameter[TString], Generic[TString]):
     def _create_gui_handle(self, viser_server: ViserServer) -> None:
         assert self.gui_handle is None, "gui_handle should be initialized once"
         self.gui_handle = viser_server.add_gui_dropdown(
-            self.name, self.options, self.default_value, disabled=self.disabled, hint=self.hint  # type: ignore
+            self.name,
+            self.options,
+            self.default_value,
+            disabled=self.disabled,
+            hint=self.hint,  # type: ignore
         )
 
     def set_options(self, new_options: List[TString]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "torchvision>=0.14.1",
     "torchmetrics[image]>=1.0.1",
     "typing_extensions>=4.4.0",
-    "viser==0.1.14",
+    "viser==0.1.17",
     "nuscenes-devkit>=1.1.1",
     "wandb>=0.13.3",
     "xatlas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ pythonVersion = "3.8"
 pythonPlatform = "Linux"
 
 [tool.ruff]
+line-length = 120
 select = [
     "E",  # pycodestyle errors.
     "F",  # Pyflakes rules.


### PR DESCRIPTION
**(1) Continuos velocity trajectories**

Previously, velocities in the beta viewer were piecewise linear. I think this was because I misinterpreted some of the original viewer code.

This new implementation produces nicer splines with continuous velocities:
![image](https://github.com/nerfstudio-project/nerfstudio/assets/6992947/e0d7de62-38e8-47c3-bab2-0f70488bf040)

**(2) Better render preview**

We now support previewing fisheye + equirectangular renders, hide threejs elements during previews, and respect the render aspect ratio.

https://github.com/nerfstudio-project/nerfstudio/assets/6992947/178ff7ab-8f7f-48f4-b980-a6afc48fd3eb


