### PR TITLE
[Fix] Pixel Sampler setup in VanillaDataManager for Cameras incl. metadata

### DIFF
--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -476,9 +476,10 @@ class VanillaDataManager(DataManager, Generic[TDataset]):
         if is_equirectangular.any():
             CONSOLE.print("[bold yellow]Warning: Some cameras are equirectangular, but using default pixel sampler.")
 
-        fisheye_crop_radius = (
-            None if dataset.cameras.metadata is None else dataset.cameras.metadata["fisheye_crop_radius"]
-        )
+        fisheye_crop_radius = None
+        if dataset.cameras.metadata is not None and "fisheye_crop_radius" in dataset.cameras.metadata:
+            fisheye_crop_radius = dataset.cameras.metadata["fisheye_crop_radius"]
+
         return self.config.pixel_sampler.setup(
             is_equirectangular=is_equirectangular,
             num_rays_per_batch=num_rays_per_batch,


### PR DESCRIPTION
This PR fixes the pixel sampler setup in the vanilla datamanager for cameras with metadata other than `fisheye_crop_radius`, i.e. it is not correct to assume that if cameras have metadata, the key `fisheye_crop_radius` will be available in all cases. Therefore, I added a check to the if condition.