### PR TITLE
fixed not cache images for full image datamanager

### DIFF
--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -59,8 +59,8 @@ class FullImageDatamanagerConfig(DataManagerConfig):
     new images. If -1, never pick new images."""
     eval_image_indices: Optional[Tuple[int, ...]] = (0,)
     """Specifies the image indices to use during eval; if None, uses all."""
-    cache_images: Literal["no-cache", "cpu", "gpu"] = "cpu"
-    """Whether to cache images in memory. If "numpy", caches as numpy arrays, if "torch", caches as torch tensors."""
+    cache_images: Literal["cpu", "gpu"] = "cpu"
+    """Whether to cache images in memory. If "cpu", caches on cpu. If "gpu", caches on device."""
 
 
 class FullImageDatamanager(DataManager, Generic[TDataset]):
@@ -123,10 +123,6 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
     def cache_images(self, cache_images_option):
         cached_train = []
         cached_eval = []
-
-        if self.config.cache_images == "no-cache":
-            return cached_train, cached_eval
-
         CONSOLE.log("Caching / undistorting train images")
         for i in tqdm(range(len(self.train_dataset)), leave=False):
             # cv2.undistort the images / cameras

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -122,6 +122,11 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
 
     def cache_images(self, cache_images_option):
         cached_train = []
+        cached_eval = []
+
+        if self.config.cache_images == "no-cache":
+            return cached_train, cached_eval
+
         CONSOLE.log("Caching / undistorting train images")
         for i in tqdm(range(len(self.train_dataset)), leave=False):
             # cv2.undistort the images / cameras
@@ -195,7 +200,6 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
             self.train_dataset.cameras.cx[i] = float(K[0, 2])
             self.train_dataset.cameras.cy[i] = float(K[1, 2])
 
-        cached_eval = []
         CONSOLE.log("Caching / undistorting eval images")
         for i in tqdm(range(len(self.eval_dataset)), leave=False):
             # cv2.undistort the images / cameras


### PR DESCRIPTION
- skipping cache image for `no-cache` argument