### PR TITLE
Fix Python 3.11 dataclass field default_factory defaults

### DIFF
--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -23,12 +23,7 @@ from typing import Any, Dict, Literal, Optional
 
 import yaml
 
-from nerfstudio.configs.base_config import (
-    InstantiateConfig,
-    LoggingConfig,
-    MachineConfig,
-    ViewerConfig,
-)
+from nerfstudio.configs.base_config import InstantiateConfig, LoggingConfig, MachineConfig, ViewerConfig
 from nerfstudio.configs.config_utils import to_immutable_dict
 from nerfstudio.engine.optimizers import OptimizerConfig
 from nerfstudio.engine.schedulers import SchedulerConfig
@@ -51,13 +46,13 @@ class ExperimentConfig(InstantiateConfig):
     """Project name."""
     timestamp: str = "{timestamp}"
     """Experiment timestamp."""
-    machine: MachineConfig = field(default_factory=lambda: MachineConfig())
+    machine: MachineConfig = field(default_factory=MachineConfig)
     """Machine configuration"""
-    logging: LoggingConfig = field(default_factory=lambda: LoggingConfig())
+    logging: LoggingConfig = field(default_factory=LoggingConfig)
     """Logging configuration"""
-    viewer: ViewerConfig = field(default_factory=lambda: ViewerConfig())
+    viewer: ViewerConfig = field(default_factory=ViewerConfig)
     """Viewer configuration"""
-    pipeline: VanillaPipelineConfig = field(default_factory=lambda: VanillaPipelineConfig())
+    pipeline: VanillaPipelineConfig = field(default_factory=VanillaPipelineConfig)
     """Pipeline configuration"""
     optimizers: Dict[str, Any] = to_immutable_dict(
         {

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -316,7 +316,7 @@ class VanillaDataManagerConfig(DataManagerConfig):
 
     _target: Type = field(default_factory=lambda: VanillaDataManager)
     """Target class to instantiate."""
-    dataparser: AnnotatedDataParserUnion = field(default_factory=lambda: BlenderDataParserConfig())
+    dataparser: AnnotatedDataParserUnion = field(default_factory=BlenderDataParserConfig)
     """Specifies the dataparser used to unpack the data."""
     train_num_rays_per_batch: int = 1024
     """Number of rays per batch to use per training iteration."""
@@ -344,7 +344,7 @@ class VanillaDataManagerConfig(DataManagerConfig):
     """Size of patch to sample from. If > 1, patch-based sampling will be used."""
     camera_optimizer: Optional[CameraOptimizerConfig] = field(default=None)
     """Deprecated, has been moved to the model config."""
-    pixel_sampler: PixelSamplerConfig = field(default_factory=lambda: PixelSamplerConfig())
+    pixel_sampler: PixelSamplerConfig = field(default_factory=PixelSamplerConfig)
     """Specifies the pixel sampler used to sample pixels from images."""
 
     def __post_init__(self):

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -22,6 +22,7 @@ paradigm
 from __future__ import annotations
 
 import random
+from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
@@ -30,7 +31,6 @@ from typing import Dict, ForwardRef, Generic, List, Literal, Optional, Tuple, Ty
 import cv2
 import numpy as np
 import torch
-from copy import deepcopy
 from torch.nn import Parameter
 from tqdm import tqdm
 
@@ -47,7 +47,7 @@ from nerfstudio.utils.rich_utils import CONSOLE
 @dataclass
 class FullImageDatamanagerConfig(DataManagerConfig):
     _target: Type = field(default_factory=lambda: FullImageDatamanager)
-    dataparser: AnnotatedDataParserUnion = NerfstudioDataParserConfig()
+    dataparser: AnnotatedDataParserUnion = field(default_factory=NerfstudioDataParserConfig)
     camera_res_scale_factor: float = 1.0
     """The scale factor for scaling spatial data such as images, mask, semantics
     along with relevant information about camera intrinsics

--- a/nerfstudio/models/base_surface_model.py
+++ b/nerfstudio/models/base_surface_model.py
@@ -36,19 +36,9 @@ from nerfstudio.field_components.spatial_distortions import SceneContraction
 from nerfstudio.fields.nerfacto_field import NerfactoField
 from nerfstudio.fields.sdf_field import SDFFieldConfig
 from nerfstudio.fields.vanilla_nerf_field import NeRFField
-from nerfstudio.model_components.losses import (
-    L1Loss,
-    MSELoss,
-    ScaleAndShiftInvariantLoss,
-    monosdf_normal_loss,
-)
+from nerfstudio.model_components.losses import L1Loss, MSELoss, ScaleAndShiftInvariantLoss, monosdf_normal_loss
 from nerfstudio.model_components.ray_samplers import LinearDisparitySampler
-from nerfstudio.model_components.renderers import (
-    AccumulationRenderer,
-    DepthRenderer,
-    RGBRenderer,
-    SemanticRenderer,
-)
+from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, RGBRenderer, SemanticRenderer
 from nerfstudio.model_components.scene_colliders import AABBBoxCollider, NearFarCollider
 from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.utils import colormaps
@@ -79,7 +69,7 @@ class SurfaceModelConfig(ModelConfig):
     """Monocular normal consistency loss multiplier."""
     mono_depth_loss_mult: float = 0.0
     """Monocular depth consistency loss multiplier."""
-    sdf_field: SDFFieldConfig = field(default_factory=lambda: SDFFieldConfig())
+    sdf_field: SDFFieldConfig = field(default_factory=SDFFieldConfig)
     """Config for SDF Field"""
     background_model: Literal["grid", "mlp", "none"] = "mlp"
     """background models"""

--- a/nerfstudio/pipelines/base_pipeline.py
+++ b/nerfstudio/pipelines/base_pipeline.py
@@ -32,14 +32,10 @@ from torch.cuda.amp.grad_scaler import GradScaler
 from torch.nn import Parameter
 from torch.nn.parallel import DistributedDataParallel as DDP
 
-from nerfstudio.configs import base_config as cfg
-from nerfstudio.data.datamanagers.base_datamanager import (
-    DataManager,
-    DataManagerConfig,
-    VanillaDataManager,
-)
-from nerfstudio.data.datamanagers.parallel_datamanager import ParallelDataManager
+from nerfstudio.configs.base_config import InstantiateConfig
+from nerfstudio.data.datamanagers.base_datamanager import DataManager, DataManagerConfig, VanillaDataManager
 from nerfstudio.data.datamanagers.full_images_datamanager import FullImageDatamanager
+from nerfstudio.data.datamanagers.parallel_datamanager import ParallelDataManager
 from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes
 from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.utils import profiler
@@ -213,14 +209,14 @@ class Pipeline(nn.Module):
 
 
 @dataclass
-class VanillaPipelineConfig(cfg.InstantiateConfig):
+class VanillaPipelineConfig(InstantiateConfig):
     """Configuration for pipeline instantiation"""
 
     _target: Type = field(default_factory=lambda: VanillaPipeline)
     """target class to instantiate"""
-    datamanager: DataManagerConfig = field(default_factory=lambda: DataManagerConfig())
+    datamanager: DataManagerConfig = field(default_factory=DataManagerConfig)
     """specifies the datamanager config"""
-    model: ModelConfig = field(default_factory=lambda: ModelConfig())
+    model: ModelConfig = field(default_factory=ModelConfig)
     """specifies the model config"""
 
 

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -3,14 +3,13 @@ Tests for the nerfstudio.plugins.registry module.
 """
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from nerfstudio.engine.trainer import TrainerConfig
 from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
-from nerfstudio.plugins import registry
+from nerfstudio.plugins import registry, registry_dataparser
+from nerfstudio.plugins.registry_dataparser import DataParserConfig, DataParserSpecification, discover_dataparsers
 from nerfstudio.plugins.types import MethodSpecification
-from nerfstudio.plugins import registry_dataparser
-from nerfstudio.plugins.registry_dataparser import DataParserSpecification, discover_dataparsers, DataParserConfig
 
 if sys.version_info < (3, 10):
     import importlib_metadata
@@ -100,7 +99,7 @@ def test_discover_methods_from_environment_variable_instance():
 
 @dataclass
 class TestDataparserConfigClass(DataParserSpecification):
-    config: DataParserConfig = DataParserConfig()
+    config: DataParserConfig = field(default_factory=DataParserConfig)
     description: str = "Test description"
 
 


### PR DESCRIPTION
Following the [Training your first model](https://docs.nerf.studio/quickstart/first_nerf.html#training-your-first-model) docs using Python 3.11:

```console
$ ns-train nerfacto --data data/nerfstudio/poster
Traceback (most recent call last):
  File "/home/matthew/.conda/envs/nerfstudio311/bin/ns-train", line 5, in <module>
    from nerfstudio.scripts.train import entrypoint
  File "/home/matthew/Repositories/nerfstudio/nerfstudio/scripts/train.py", line 62, in <module>
    from nerfstudio.configs.method_configs import AnnotatedBaseConfigUnion
  File "/home/matthew/Repositories/nerfstudio/nerfstudio/configs/method_configs.py", line 28, in <module>
    from nerfstudio.configs.external_methods import get_external_methods
  File "/home/matthew/Repositories/nerfstudio/nerfstudio/configs/external_methods.py", line 24, in <module>
    from nerfstudio.engine.trainer import TrainerConfig
  File "/home/matthew/Repositories/nerfstudio/nerfstudio/engine/trainer.py", line 30, in <module>
    from nerfstudio.configs.experiment_config import ExperimentConfig
  File "/home/matthew/Repositories/nerfstudio/nerfstudio/configs/experiment_config.py", line 35, in <module>
    from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
  File "/home/matthew/Repositories/nerfstudio/nerfstudio/pipelines/base_pipeline.py", line 42, in <module>
    from nerfstudio.data.datamanagers.full_images_datamanager import FullImageDatamanager
  File "/home/matthew/Repositories/nerfstudio/nerfstudio/data/datamanagers/full_images_datamanager.py", line 47, in <module>
    @dataclass
     ^^^^^^^^^
  File "/home/matthew/.conda/envs/nerfstudio311/lib/python3.11/dataclasses.py", line 1230, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/home/matthew/.conda/envs/nerfstudio311/lib/python3.11/dataclasses.py", line 1220, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matthew/.conda/envs/nerfstudio311/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matthew/.conda/envs/nerfstudio311/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'nerfstudio.data.dataparsers.nerfstudio_dataparser.NerfstudioDataParserConfig'> for field dataparser is not allowed: use default_factory
```

It looks like not all of the mutable default values were set using `default_factory`, so I have updated them here.

With these changes, I can successfully run the above command using Python 3.11.