### PR TITLE
Update docs to recommend torch 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,19 +124,10 @@ pip install --upgrade pip
 Install PyTorch with CUDA (this repo has been tested with CUDA 11.7 and CUDA 11.8) and [tiny-cuda-nn](https://github.com/NVlabs/tiny-cuda-nn).
 `cuda-toolkit` is required for building `tiny-cuda-nn`.
 
-For CUDA 11.7:
-
-```bash
-pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 --extra-index-url https://download.pytorch.org/whl/cu117
-
-conda install -c "nvidia/label/cuda-11.7.1" cuda-toolkit
-pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
-```
-
 For CUDA 11.8:
 
 ```bash
-pip install torch==2.0.1+cu118 torchvision==0.15.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
 
 conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit
 pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch

--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -42,12 +42,12 @@ pip uninstall torch torchvision functorch tinycudann
 ```
 
 ::::{tab-set}
-:::{tab-item} Torch 2.0.1 with CUDA 11.8
+:::{tab-item} Torch 2.1.2 with CUDA 11.8 (recommended)
 
-Install PyTorch 2.0.1 with CUDA 11.8:
+Install PyTorch 2.1.2 with CUDA 11.8:
 
 ```bash
-pip install torch==2.0.1+cu118 torchvision==0.15.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
 ```
 
 To build the necessary CUDA extensions, `cuda-toolkit` is also required. We


### PR DESCRIPTION
I couldn't get `gsplat` to build automatically from a PyPI install on any of my servers with torch 2.0.1. `gsplat` worked fine when installing from the git repo.

The root cause was that my CUDA libraries, when installed via conda, needed to be linked from `$CUDA_HOME/lib` and not `$CUDA_HOME/lib64`. This is fixed in 2.1: https://github.com/pytorch/pytorch/pull/101285