### PR TITLE
Remove unused make_share_url arg in ns-viewer

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -147,7 +147,7 @@ class ViewerConfig(PrintableConfig):
     jpeg_quality: int = 75
     """Quality tradeoff to use for jpeg compression."""
     make_share_url: bool = False
-    """Viewer beta feature: print a shareable URL. `vis` must be set to viewer_beta; this flag is otherwise ignored."""
+    """Viewer beta feature: print a shareable URL. This flag is ignored in the legacy version of the viewer."""
     camera_frustum_scale: float = 0.1
     """Scale for the camera frustums in the viewer."""
     default_composite_depth: bool = True

--- a/nerfstudio/scripts/viewer/run_viewer.py
+++ b/nerfstudio/scripts/viewer/run_viewer.py
@@ -24,14 +24,13 @@ from pathlib import Path
 from typing import Literal
 
 import tyro
-
 from nerfstudio.configs.base_config import ViewerConfig
 from nerfstudio.engine.trainer import TrainerConfig
 from nerfstudio.pipelines.base_pipeline import Pipeline
 from nerfstudio.utils import writer
 from nerfstudio.utils.eval_utils import eval_setup
-from nerfstudio.viewer_legacy.server.viewer_state import ViewerLegacyState
 from nerfstudio.viewer.viewer import Viewer as ViewerState
+from nerfstudio.viewer_legacy.server.viewer_state import ViewerLegacyState
 
 
 @dataclass
@@ -55,8 +54,6 @@ class RunViewer:
     """Viewer configuration"""
     vis: Literal["viewer", "viewer_legacy"] = "viewer"
     """Type of viewer"""
-    make_share_url: bool = True
-    """Print a shareable URL"""
 
     def main(self) -> None:
         """Main function."""
@@ -68,7 +65,6 @@ class RunViewer:
         num_rays_per_chunk = config.viewer.num_rays_per_chunk
         assert self.viewer.num_rays_per_chunk == -1
         config.vis = self.vis
-        config.viewer.make_share_url = self.make_share_url
         config.viewer = self.viewer.as_viewer_config()
         config.viewer.num_rays_per_chunk = num_rays_per_chunk
 

--- a/nerfstudio/scripts/viewer/run_viewer.py
+++ b/nerfstudio/scripts/viewer/run_viewer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Literal
 
 import tyro
+
 from nerfstudio.configs.base_config import ViewerConfig
 from nerfstudio.engine.trainer import TrainerConfig
 from nerfstudio.pipelines.base_pipeline import Pipeline


### PR DESCRIPTION
Looks like this argument is both redundant (there's both `--make-share-url` and `--viewer.make-share-url`) and ignored (immediately overwritten)!