### PR TITLE
Update dependencies for aarch64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "protobuf<=3.20.3,!=3.20.0",
     # TODO(1480) enable when pycolmap windows wheels are available
     # "pycolmap==0.3.0",
-    "pymeshlab>=2022.2.post2; platform_machine != 'arm64'",
+    "pymeshlab>=2022.2.post2; platform_machine != 'arm64' and platform_machine != 'aarch64'",
     "pyngrok>=5.1.0",
     "python-socketio>=5.7.1",
     "pyquaternion>=0.9.9",


### PR DESCRIPTION
Installing nerfstudio on NVIDIA Jetson throws an error:
```
ERROR: Could not find a version that satisfies the requirement pymeshlab>=2022.2.post2; 
platform_machine != "arm64" (from nerfstudio) (from versions: none)
```

This PR fixes the issue, enabling installation of nerfstudio on AArch64 machines. 