### PR TITLE
Remove deprecated dependency_links config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,12 +130,6 @@ ns-export = "nerfstudio.scripts.exporter:entrypoint"
 ns-dev-test = "nerfstudio.scripts.github.run_actions:entrypoint"
 ns-dev-sync-viser-message-defs = "nerfstudio.scripts.viewer.sync_viser_message_defs:entrypoint"
 
-[options]
-# equivalent to using --extra-index-url with pip, which is needed for specifying the CUDA version torch and torchvision
-dependency_links = [
-    "https://download.pytorch.org/whl/cu118"
-]
-
 [tool.setuptools.packages.find]
 include = ["nerfstudio*"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[options]
+# https://setuptools.pypa.io/en/latest/deprecated/dependency_links.html
+# equivalent to using --extra-index-url with pip, which is needed for specifying the CUDA version torch and torchvision
+dependency_links = https://download.pytorch.org/whl/cu118

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[options]
-# https://setuptools.pypa.io/en/latest/deprecated/dependency_links.html
-# equivalent to using --extra-index-url with pip, which is needed for specifying the CUDA version torch and torchvision
-dependency_links = https://download.pytorch.org/whl/cu118


### PR DESCRIPTION
~~Move `dependency_links` to `setup.cfg`~~
    
`[options]` is not a valid table in `pyproject.toml`: https://packaging.python.org/en/latest/specifications/pyproject-toml/

but it is in `setup.cfg`: https://setuptools.pypa.io/en/latest/deprecated/dependency_links.html