### PR TITLE
Add isort

### DIFF
--- a/.github/workflows/core_code_checks.yml
+++ b/.github/workflows/core_code_checks.yml
@@ -36,6 +36,8 @@ jobs:
         run: ruff docs/ nerfstudio/ tests/
       - name: Run Black
         run: black docs/ nerfstudio/ tests/ --check
+      - name: Run isort
+        run: isort docs/ nerfstudio/ tests/ --check --diff
       - name: Run Pyright
         run: |
           pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,7 @@ repos:
     rev: '23.3.0'
     hooks:
     -   id: black
+-   repo: https://github.com/pycqa/isort
+    rev: '5.13.2'
+    hooks:
+    -   id: isort

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
     }
   },
   "editor.formatOnSave": true,
+  "editor.rulers": [120],
   "python.envFile": "${workspaceFolder}/.env",
   "python.formatting.provider": "none",
   "black-formatter.args": ["--line-length=120"],

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -14,15 +14,15 @@ In addition to code contributions, we also encourage contributors to add their o
 
 Below are the various tooling features our team uses to maintain this codebase.
 
-| Tooling         | Support                                                    |
-| --------------- | ---------------------------------------------------------- |
-| Formatting      | [Black](https://black.readthedocs.io/en/stable/)           |
-| Linter          | [Ruff](https://beta.ruff.rs/docs/)                         |
-| Type checking   | [Pyright](https://github.com/microsoft/pyright)            |
-| Testing         | [pytest](https://docs.pytest.org/en/7.1.x/)                |
-| Docs            | [Sphinx](https://www.sphinx-doc.org/en/master/)            |
-| Docstring style | [Google](https://google.github.io/styleguide/pyguide.html) |
-| JS Linting      | [eslint](https://eslint.org/)                              |
+| Tooling         | Support                                                                                      |
+| --------------- | -------------------------------------------------------------------------------------------- |
+| Formatting      | [Black](https://black.readthedocs.io/en/stable/) and [isort](https://pycqa.github.io/isort/) |
+| Linter          | [Ruff](https://beta.ruff.rs/docs/)                                                           |
+| Type checking   | [Pyright](https://github.com/microsoft/pyright)                                              |
+| Testing         | [pytest](https://docs.pytest.org/en/7.1.x/)                                                  |
+| Docs            | [Sphinx](https://www.sphinx-doc.org/en/master/)                                              |
+| Docstring style | [Google](https://google.github.io/styleguide/pyguide.html)                                   |
+| JS Linting      | [eslint](https://eslint.org/)                                                                |
 
 ## Requirements
 

--- a/nerfstudio/cameras/camera_optimizers.py
+++ b/nerfstudio/cameras/camera_optimizers.py
@@ -27,13 +27,13 @@ from jaxtyping import Float, Int
 from torch import Tensor, nn
 from typing_extensions import assert_never
 
+from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.cameras.lie_groups import exp_map_SE3, exp_map_SO3xR3
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.configs.base_config import InstantiateConfig
-from nerfstudio.utils import poses as pose_utils
 from nerfstudio.engine.optimizers import OptimizerConfig
 from nerfstudio.engine.schedulers import SchedulerConfig
-from nerfstudio.cameras.cameras import Cameras
+from nerfstudio.utils import poses as pose_utils
 
 
 @dataclass
@@ -60,6 +60,7 @@ class CameraOptimizerConfig(InstantiateConfig):
     def __post_init__(self):
         if self.optimizer is not None:
             import warnings
+
             from nerfstudio.utils.rich_utils import CONSOLE
 
             CONSOLE.print(
@@ -70,6 +71,7 @@ class CameraOptimizerConfig(InstantiateConfig):
 
         if self.scheduler is not None:
             import warnings
+
             from nerfstudio.utils.rich_utils import CONSOLE
 
             CONSOLE.print(

--- a/nerfstudio/configs/dataparser_configs.py
+++ b/nerfstudio/configs/dataparser_configs.py
@@ -33,9 +33,9 @@ from nerfstudio.data.dataparsers.nerfstudio_dataparser import NerfstudioDataPars
 from nerfstudio.data.dataparsers.nuscenes_dataparser import NuScenesDataParserConfig
 from nerfstudio.data.dataparsers.phototourism_dataparser import PhototourismDataParserConfig
 from nerfstudio.data.dataparsers.scannet_dataparser import ScanNetDataParserConfig
+from nerfstudio.data.dataparsers.scannetpp_dataparser import ScanNetppDataParserConfig
 from nerfstudio.data.dataparsers.sdfstudio_dataparser import SDFStudioDataParserConfig
 from nerfstudio.data.dataparsers.sitcoms3d_dataparser import Sitcoms3DDataParserConfig
-from nerfstudio.data.dataparsers.scannetpp_dataparser import ScanNetppDataParserConfig
 from nerfstudio.plugins.registry_dataparser import discover_dataparsers
 
 dataparsers = {

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -26,23 +26,16 @@ import tyro
 from nerfstudio.cameras.camera_optimizers import CameraOptimizerConfig
 from nerfstudio.configs.base_config import ViewerConfig
 from nerfstudio.configs.external_methods import get_external_methods
-from nerfstudio.data.datamanagers.base_datamanager import (
-    VanillaDataManager,
-    VanillaDataManagerConfig,
-)
+from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManager, VanillaDataManagerConfig
+from nerfstudio.data.datamanagers.full_images_datamanager import FullImageDatamanagerConfig
 from nerfstudio.data.datamanagers.parallel_datamanager import ParallelDataManagerConfig
-from nerfstudio.data.datamanagers.random_cameras_datamanager import (
-    RandomCamerasDataManagerConfig,
-)
+from nerfstudio.data.datamanagers.random_cameras_datamanager import RandomCamerasDataManagerConfig
 from nerfstudio.data.dataparsers.blender_dataparser import BlenderDataParserConfig
+from nerfstudio.data.dataparsers.colmap_dataparser import ColmapDataParserConfig
 from nerfstudio.data.dataparsers.dnerf_dataparser import DNeRFDataParserConfig
-from nerfstudio.data.dataparsers.instant_ngp_dataparser import (
-    InstantNGPDataParserConfig,
-)
+from nerfstudio.data.dataparsers.instant_ngp_dataparser import InstantNGPDataParserConfig
 from nerfstudio.data.dataparsers.nerfstudio_dataparser import NerfstudioDataParserConfig
-from nerfstudio.data.dataparsers.phototourism_dataparser import (
-    PhototourismDataParserConfig,
-)
+from nerfstudio.data.dataparsers.phototourism_dataparser import PhototourismDataParserConfig
 from nerfstudio.data.dataparsers.sdfstudio_dataparser import SDFStudioDataParserConfig
 from nerfstudio.data.dataparsers.sitcoms3d_dataparser import Sitcoms3DDataParserConfig
 from nerfstudio.data.datasets.depth_dataset import DepthDataset
@@ -62,7 +55,6 @@ from nerfstudio.models.depth_nerfacto import DepthNerfactoModelConfig
 from nerfstudio.models.gaussian_splatting import GaussianSplattingModelConfig
 from nerfstudio.models.generfacto import GenerfactoModelConfig
 from nerfstudio.models.instant_ngp import InstantNGPModelConfig
-from nerfstudio.data.dataparsers.colmap_dataparser import ColmapDataParserConfig
 from nerfstudio.models.mipnerf import MipNerfModel
 from nerfstudio.models.nerfacto import NerfactoModelConfig
 from nerfstudio.models.neus import NeuSModelConfig
@@ -71,7 +63,6 @@ from nerfstudio.models.semantic_nerfw import SemanticNerfWModelConfig
 from nerfstudio.models.tensorf import TensoRFModelConfig
 from nerfstudio.models.vanilla_nerf import NeRFModel, VanillaModelConfig
 from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
-from nerfstudio.data.datamanagers.full_images_datamanager import FullImageDatamanagerConfig
 from nerfstudio.pipelines.dynamic_batch import DynamicBatchPipelineConfig
 from nerfstudio.plugins.registry import discover_methods
 

--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -54,16 +54,8 @@ from nerfstudio.configs.dataparser_configs import AnnotatedDataParserUnion
 from nerfstudio.data.dataparsers.base_dataparser import DataparserOutputs
 from nerfstudio.data.dataparsers.blender_dataparser import BlenderDataParserConfig
 from nerfstudio.data.datasets.base_dataset import InputDataset
-from nerfstudio.data.pixel_samplers import (
-    PatchPixelSamplerConfig,
-    PixelSampler,
-    PixelSamplerConfig,
-)
-from nerfstudio.data.utils.dataloaders import (
-    CacheDataloader,
-    FixedIndicesEvalDataloader,
-    RandIndicesEvalDataloader,
-)
+from nerfstudio.data.pixel_samplers import PatchPixelSamplerConfig, PixelSampler, PixelSamplerConfig
+from nerfstudio.data.utils.dataloaders import CacheDataloader, FixedIndicesEvalDataloader, RandIndicesEvalDataloader
 from nerfstudio.data.utils.nerfstudio_collate import nerfstudio_collate
 from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes
 from nerfstudio.model_components.ray_generators import RayGenerator

--- a/nerfstudio/data/datamanagers/random_cameras_datamanager.py
+++ b/nerfstudio/data/datamanagers/random_cameras_datamanager.py
@@ -24,8 +24,8 @@ from typing import Dict, List, Tuple, Type, Union
 
 import torch
 from rich.progress import Console
-from torch.nn import Parameter
 from torch import Tensor
+from torch.nn import Parameter
 from typing_extensions import Literal
 
 from nerfstudio.cameras.cameras import Cameras

--- a/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
@@ -24,11 +24,7 @@ import torch
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 
 

--- a/nerfstudio/data/dataparsers/blender_dataparser.py
+++ b/nerfstudio/data/dataparsers/blender_dataparser.py
@@ -24,11 +24,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.colors import get_color
 from nerfstudio.utils.io import load_from_json

--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
-from pathlib import Path
 from functools import partial
+from pathlib import Path
 from typing import List, Literal, Optional, Type
 
 import numpy as np
@@ -31,15 +31,15 @@ from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras
 from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.data.utils import colmap_parsing_utils as colmap_utils
-from nerfstudio.process_data.colmap_utils import parse_colmap_camera_params
-from nerfstudio.utils.scripts import run_command
-from nerfstudio.utils.rich_utils import CONSOLE, status
 from nerfstudio.data.utils.dataparsers_utils import (
+    get_train_eval_split_all,
     get_train_eval_split_filename,
     get_train_eval_split_fraction,
     get_train_eval_split_interval,
-    get_train_eval_split_all,
 )
+from nerfstudio.process_data.colmap_utils import parse_colmap_camera_params
+from nerfstudio.utils.rich_utils import CONSOLE, status
+from nerfstudio.utils.scripts import run_command
 
 MAX_AUTO_RESOLUTION = 1600
 

--- a/nerfstudio/data/dataparsers/dnerf_dataparser.py
+++ b/nerfstudio/data/dataparsers/dnerf_dataparser.py
@@ -24,11 +24,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.colors import get_color
 from nerfstudio.utils.io import load_from_json

--- a/nerfstudio/data/dataparsers/dycheck_dataparser.py
+++ b/nerfstudio/data/dataparsers/dycheck_dataparser.py
@@ -25,11 +25,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.colors import get_color
 from nerfstudio.utils.io import load_from_json

--- a/nerfstudio/data/dataparsers/instant_ngp_dataparser.py
+++ b/nerfstudio/data/dataparsers/instant_ngp_dataparser.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Tuple, Type, Literal
+from typing import Dict, Literal, Tuple, Type
 
 import imageio
 import numpy as np
@@ -26,17 +26,13 @@ import torch
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.data.utils.dataparsers_utils import (
+    get_train_eval_split_all,
     get_train_eval_split_filename,
     get_train_eval_split_fraction,
     get_train_eval_split_interval,
-    get_train_eval_split_all,
 )
 from nerfstudio.utils.io import load_from_json
 from nerfstudio.utils.rich_utils import CONSOLE

--- a/nerfstudio/data/dataparsers/minimal_dataparser.py
+++ b/nerfstudio/data/dataparsers/minimal_dataparser.py
@@ -24,12 +24,7 @@ import numpy as np
 import torch
 
 from nerfstudio.cameras.cameras import Cameras
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-    Semantics,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs, Semantics
 from nerfstudio.data.scene_box import SceneBox
 
 

--- a/nerfstudio/data/dataparsers/nerfosr_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfosr_dataparser.py
@@ -30,11 +30,7 @@ import torch
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 
 

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -29,10 +29,10 @@ from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras, CameraType
 from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.data.utils.dataparsers_utils import (
+    get_train_eval_split_all,
     get_train_eval_split_filename,
     get_train_eval_split_fraction,
     get_train_eval_split_interval,
-    get_train_eval_split_all,
 )
 from nerfstudio.utils.io import load_from_json
 from nerfstudio.utils.rich_utils import CONSOLE

--- a/nerfstudio/data/dataparsers/nuscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/nuscenes_dataparser.py
@@ -25,11 +25,7 @@ import torch
 from nuscenes.nuscenes import NuScenes as NuScenesDatabase
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 
 

--- a/nerfstudio/data/dataparsers/phototourism_dataparser.py
+++ b/nerfstudio/data/dataparsers/phototourism_dataparser.py
@@ -25,19 +25,12 @@ import torch
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 
 # TODO(1480) use pycolmap instead of colmap_parsing_utils
 # import pycolmap
-from nerfstudio.data.utils.colmap_parsing_utils import (
-    read_cameras_binary,
-    read_images_binary,
-)
+from nerfstudio.data.utils.colmap_parsing_utils import read_cameras_binary, read_images_binary
 from nerfstudio.utils.rich_utils import CONSOLE
 
 

--- a/nerfstudio/data/dataparsers/scannet_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannet_dataparser.py
@@ -24,11 +24,7 @@ import torch
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 
 

--- a/nerfstudio/data/dataparsers/scannetpp_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannetpp_dataparser.py
@@ -21,6 +21,7 @@ from typing import Literal, Type
 
 import numpy as np
 import torch
+
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras, CameraType
 from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -23,11 +23,7 @@ import torch
 
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.io import load_from_json
 

--- a/nerfstudio/data/dataparsers/sitcoms3d_dataparser.py
+++ b/nerfstudio/data/dataparsers/sitcoms3d_dataparser.py
@@ -27,12 +27,7 @@ from typing import Type
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
-from nerfstudio.data.dataparsers.base_dataparser import (
-    DataParser,
-    DataParserConfig,
-    DataparserOutputs,
-    Semantics,
-)
+from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs, Semantics
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.utils.io import load_from_json
 

--- a/nerfstudio/data/datasets/depth_dataset.py
+++ b/nerfstudio/data/datasets/depth_dataset.py
@@ -16,23 +16,21 @@
 Depth dataset.
 """
 
-from typing import Dict
+import json
+from pathlib import Path
+from typing import Dict, Union
 
 import numpy as np
+import torch
+from PIL import Image
+from rich.progress import track
 
 from nerfstudio.data.dataparsers.base_dataparser import DataparserOutputs
-from nerfstudio.model_components import losses
 from nerfstudio.data.datasets.base_dataset import InputDataset
 from nerfstudio.data.utils.data_utils import get_depth_image_from_path
+from nerfstudio.model_components import losses
 from nerfstudio.utils.misc import torch_compile
 from nerfstudio.utils.rich_utils import CONSOLE
-
-from typing import Union
-from PIL import Image
-import torch
-from rich.progress import track
-from pathlib import Path
-import json
 
 
 class DepthDataset(InputDataset):

--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -18,20 +18,13 @@ Code for sampling pixels.
 
 import random
 from dataclasses import dataclass, field
-from typing import (
-    Dict,
-    Optional,
-    Type,
-    Union,
-)
+from typing import Dict, Optional, Type, Union
 
 import torch
 from jaxtyping import Int
 from torch import Tensor
 
-from nerfstudio.configs.base_config import (
-    InstantiateConfig,
-)
+from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.data.utils.pixel_sampling_utils import erode_mask
 
 

--- a/nerfstudio/data/scene_box.py
+++ b/nerfstudio/data/scene_box.py
@@ -17,10 +17,10 @@ Dataset input structures.
 """
 
 from dataclasses import dataclass
-from typing import Union, Tuple
-import viser.transforms as vtf
+from typing import Tuple, Union
 
 import torch
+import viser.transforms as vtf
 from jaxtyping import Float
 from torch import Tensor
 

--- a/nerfstudio/data/utils/pixel_sampling_utils.py
+++ b/nerfstudio/data/utils/pixel_sampling_utils.py
@@ -15,8 +15,8 @@
 """ Pixel sampling utils such as eroding of valid masks that we sample from. """
 
 import torch
-from torch import Tensor
 from jaxtyping import Float
+from torch import Tensor
 
 
 def dilate(tensor: Float[Tensor, "bs 1 H W"], kernel_size=3) -> Float[Tensor, "bs 1 H W"]:

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -21,12 +21,18 @@ import dataclasses
 import functools
 import os
 import time
+from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
-from typing import Dict, List, Literal, Optional, Tuple, Type, cast, DefaultDict
-from collections import defaultdict
+from typing import DefaultDict, Dict, List, Literal, Optional, Tuple, Type, cast
+
 import torch
+from rich import box, style
+from rich.panel import Panel
+from rich.table import Table
+from torch.cuda.amp.grad_scaler import GradScaler
+
 from nerfstudio.configs.experiment_config import ExperimentConfig
 from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
 from nerfstudio.engine.optimizers import Optimizers
@@ -36,12 +42,8 @@ from nerfstudio.utils.decorators import check_eval_enabled, check_main_thread, c
 from nerfstudio.utils.misc import step_check
 from nerfstudio.utils.rich_utils import CONSOLE
 from nerfstudio.utils.writer import EventName, TimeWriter
-from nerfstudio.viewer_legacy.server.viewer_state import ViewerLegacyState
 from nerfstudio.viewer.viewer import Viewer as ViewerState
-from rich import box, style
-from rich.panel import Panel
-from rich.table import Table
-from torch.cuda.amp.grad_scaler import GradScaler
+from nerfstudio.viewer_legacy.server.viewer_state import ViewerLegacyState
 
 TRAIN_INTERATION_OUTPUT = Tuple[torch.Tensor, Dict[str, torch.Tensor], Dict[str, torch.Tensor]]
 TORCH_DEVICE = str

--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -28,11 +28,11 @@ import open3d as o3d
 import pymeshlab
 import torch
 from jaxtyping import Float
-from nerfstudio.cameras.rays import RayBundle
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeRemainingColumn
 from torch import Tensor
 
 from nerfstudio.cameras.cameras import Cameras
+from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.data.datasets.base_dataset import InputDataset
 from nerfstudio.data.scene_box import OrientedBox
 from nerfstudio.pipelines.base_pipeline import Pipeline, VanillaPipeline

--- a/nerfstudio/field_components/__init__.py
+++ b/nerfstudio/field_components/__init__.py
@@ -14,6 +14,5 @@
 
 """init field modules"""
 from .base_field_component import FieldComponent as FieldComponent
-from .encodings import Encoding as Encoding
-from .encodings import ScalingAndOffset as ScalingAndOffset
+from .encodings import Encoding as Encoding, ScalingAndOffset as ScalingAndOffset
 from .mlp import MLP as MLP

--- a/nerfstudio/field_components/encodings.py
+++ b/nerfstudio/field_components/encodings.py
@@ -28,11 +28,7 @@ from torch import Tensor, nn
 
 from nerfstudio.field_components.base_field_component import FieldComponent
 from nerfstudio.utils.external import TCNN_EXISTS, tcnn
-from nerfstudio.utils.math import (
-    components_from_spherical_harmonics,
-    expected_sin,
-    generate_polyhedron_basis,
-)
+from nerfstudio.utils.math import components_from_spherical_harmonics, expected_sin, generate_polyhedron_basis
 from nerfstudio.utils.printing import print_tcnn_speed_warning
 
 

--- a/nerfstudio/field_components/mlp.py
+++ b/nerfstudio/field_components/mlp.py
@@ -23,11 +23,10 @@ from jaxtyping import Float
 from torch import Tensor, nn
 
 from nerfstudio.field_components.base_field_component import FieldComponent
-from nerfstudio.utils.printing import print_tcnn_speed_warning
 from nerfstudio.field_components.encodings import HashEncoding
-
-from nerfstudio.utils.rich_utils import CONSOLE
 from nerfstudio.utils.external import TCNN_EXISTS, tcnn
+from nerfstudio.utils.printing import print_tcnn_speed_warning
+from nerfstudio.utils.rich_utils import CONSOLE
 
 
 def activation_to_tcnn_string(activation: Union[nn.Module, None]) -> str:

--- a/nerfstudio/fields/semantic_nerf_field.py
+++ b/nerfstudio/fields/semantic_nerf_field.py
@@ -22,12 +22,7 @@ from torch import Tensor, nn
 
 from nerfstudio.cameras.rays import RaySamples
 from nerfstudio.field_components.encodings import Encoding, Identity
-from nerfstudio.field_components.field_heads import (
-    DensityFieldHead,
-    FieldHeadNames,
-    RGBFieldHead,
-    SemanticFieldHead,
-)
+from nerfstudio.field_components.field_heads import DensityFieldHead, FieldHeadNames, RGBFieldHead, SemanticFieldHead
 from nerfstudio.field_components.mlp import MLP
 from nerfstudio.fields.base_field import Field
 

--- a/nerfstudio/fields/vanilla_nerf_field.py
+++ b/nerfstudio/fields/vanilla_nerf_field.py
@@ -22,12 +22,7 @@ from torch import Tensor, nn
 
 from nerfstudio.cameras.rays import RaySamples
 from nerfstudio.field_components.encodings import Encoding, Identity
-from nerfstudio.field_components.field_heads import (
-    DensityFieldHead,
-    FieldHead,
-    FieldHeadNames,
-    RGBFieldHead,
-)
+from nerfstudio.field_components.field_heads import DensityFieldHead, FieldHead, FieldHeadNames, RGBFieldHead
 from nerfstudio.field_components.mlp import MLP
 from nerfstudio.field_components.spatial_distortions import SpatialDistortion
 from nerfstudio.fields.base_field import Field

--- a/nerfstudio/generative/deepfloyd.py
+++ b/nerfstudio/generative/deepfloyd.py
@@ -19,21 +19,16 @@ from typing import List, Optional, Union
 import torch
 import torch.nn.functional as F
 import tyro
-
 from jaxtyping import Float
 from PIL import Image
 from torch import Generator, Tensor, nn
 from torch.cuda.amp.grad_scaler import GradScaler
 
-
 from nerfstudio.generative.utils import CatchMissingPackages
 
 try:
-    from diffusers import IFPipeline as IFOrig
-    from diffusers.pipelines.deepfloyd_if import IFPipelineOutput as IFOutputOrig
-
-    from diffusers import IFPipeline, DiffusionPipeline
-    from diffusers.pipelines.deepfloyd_if import IFPipelineOutput
+    from diffusers import DiffusionPipeline, IFPipeline, IFPipeline as IFOrig
+    from diffusers.pipelines.deepfloyd_if import IFPipelineOutput, IFPipelineOutput as IFOutputOrig
     from transformers import T5EncoderModel
 
 except ImportError:

--- a/nerfstudio/generative/positional_text_embeddings.py
+++ b/nerfstudio/generative/positional_text_embeddings.py
@@ -14,14 +14,15 @@
 
 """Utility helper functions for generative 3D models"""
 
-import torch
-from torch import Tensor
-from jaxtyping import Float
-from typing_extensions import Literal
 from typing import Union
 
-from nerfstudio.generative.stable_diffusion import StableDiffusion
+import torch
+from jaxtyping import Float
+from torch import Tensor
+from typing_extensions import Literal
+
 from nerfstudio.generative.deepfloyd import DeepFloyd
+from nerfstudio.generative.stable_diffusion import StableDiffusion
 
 
 class PositionalTextEmbeddings:

--- a/nerfstudio/generative/stable_diffusion.py
+++ b/nerfstudio/generative/stable_diffusion.py
@@ -18,7 +18,6 @@
 
 from pathlib import Path
 from typing import List, Optional, Union
-from nerfstudio.utils.rich_utils import CONSOLE
 
 import mediapy
 import numpy as np
@@ -30,10 +29,10 @@ from torch import Tensor, nn
 from torch.cuda.amp.grad_scaler import GradScaler
 
 from nerfstudio.generative.utils import CatchMissingPackages
-
+from nerfstudio.utils.rich_utils import CONSOLE
 
 try:
-    from diffusers import PNDMScheduler, StableDiffusionPipeline, DiffusionPipeline
+    from diffusers import DiffusionPipeline, PNDMScheduler, StableDiffusionPipeline
 
 except ImportError:
     PNDMScheduler = StableDiffusionPipeline = CatchMissingPackages()

--- a/nerfstudio/generative/utils.py
+++ b/nerfstudio/generative/utils.py
@@ -15,6 +15,7 @@
 """Utility helper functions for diffusion models"""
 
 import sys
+
 from nerfstudio.utils.rich_utils import CONSOLE
 
 

--- a/nerfstudio/models/base_model.py
+++ b/nerfstudio/models/base_model.py
@@ -31,7 +31,7 @@ from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.configs.base_config import InstantiateConfig
 from nerfstudio.configs.config_utils import to_immutable_dict
-from nerfstudio.data.scene_box import SceneBox, OrientedBox
+from nerfstudio.data.scene_box import OrientedBox, SceneBox
 from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes
 from nerfstudio.model_components.scene_colliders import NearFarCollider
 

--- a/nerfstudio/models/depth_nerfacto.py
+++ b/nerfstudio/models/depth_nerfacto.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, Tuple, Type
 
-import torch
 import numpy as np
+import torch
 
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.model_components import losses

--- a/nerfstudio/models/generfacto.py
+++ b/nerfstudio/models/generfacto.py
@@ -27,33 +27,16 @@ from torch.nn import Parameter
 from typing_extensions import Literal
 
 from nerfstudio.cameras.rays import RayBundle
-from nerfstudio.engine.callbacks import (
-    TrainingCallback,
-    TrainingCallbackAttributes,
-    TrainingCallbackLocation,
-)
+from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.fields.density_fields import HashMLPDensityField
 from nerfstudio.fields.generfacto_field import GenerfactoField
-from nerfstudio.generative.stable_diffusion import StableDiffusion
 from nerfstudio.generative.deepfloyd import DeepFloyd
 from nerfstudio.generative.positional_text_embeddings import PositionalTextEmbeddings
-from nerfstudio.model_components.losses import (
-    MSELoss,
-    distortion_loss,
-    interlevel_loss,
-    orientation_loss,
-)
-from nerfstudio.model_components.ray_samplers import (
-    ProposalNetworkSampler,
-    UniformSampler,
-)
-from nerfstudio.model_components.renderers import (
-    AccumulationRenderer,
-    DepthRenderer,
-    NormalsRenderer,
-    RGBRenderer,
-)
+from nerfstudio.generative.stable_diffusion import StableDiffusion
+from nerfstudio.model_components.losses import MSELoss, distortion_loss, interlevel_loss, orientation_loss
+from nerfstudio.model_components.ray_samplers import ProposalNetworkSampler, UniformSampler
+from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, NormalsRenderer, RGBRenderer
 from nerfstudio.model_components.scene_colliders import AABBBoxCollider, SphereCollider
 from nerfstudio.model_components.shaders import LambertianShader, NormalsShader
 from nerfstudio.models.base_model import Model, ModelConfig

--- a/nerfstudio/models/instant_ngp.py
+++ b/nerfstudio/models/instant_ngp.py
@@ -29,21 +29,13 @@ from torchmetrics.image import PeakSignalNoiseRatio
 from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
 
 from nerfstudio.cameras.rays import RayBundle
-from nerfstudio.engine.callbacks import (
-    TrainingCallback,
-    TrainingCallbackAttributes,
-    TrainingCallbackLocation,
-)
+from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.field_components.spatial_distortions import SceneContraction
 from nerfstudio.fields.nerfacto_field import NerfactoField
 from nerfstudio.model_components.losses import MSELoss, scale_gradients_by_distance_squared
 from nerfstudio.model_components.ray_samplers import VolumetricSampler
-from nerfstudio.model_components.renderers import (
-    AccumulationRenderer,
-    DepthRenderer,
-    RGBRenderer,
-)
+from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, RGBRenderer
 from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.utils import colormaps
 

--- a/nerfstudio/models/mipnerf.py
+++ b/nerfstudio/models/mipnerf.py
@@ -31,11 +31,7 @@ from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.fields.vanilla_nerf_field import NeRFField
 from nerfstudio.model_components.losses import MSELoss, scale_gradients_by_distance_squared
 from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
-from nerfstudio.model_components.renderers import (
-    AccumulationRenderer,
-    DepthRenderer,
-    RGBRenderer,
-)
+from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, RGBRenderer
 from nerfstudio.models.base_model import Model
 from nerfstudio.models.vanilla_nerf import VanillaModelConfig
 from nerfstudio.utils import colormaps, misc

--- a/nerfstudio/models/neus.py
+++ b/nerfstudio/models/neus.py
@@ -22,11 +22,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Type
 
 from nerfstudio.cameras.rays import RayBundle
-from nerfstudio.engine.callbacks import (
-    TrainingCallback,
-    TrainingCallbackAttributes,
-    TrainingCallbackLocation,
-)
+from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.model_components.ray_samplers import NeuSSampler
 from nerfstudio.models.base_surface_model import SurfaceModel, SurfaceModelConfig

--- a/nerfstudio/models/neus_facto.py
+++ b/nerfstudio/models/neus_facto.py
@@ -27,18 +27,11 @@ import torch
 from torch.nn import Parameter
 
 from nerfstudio.cameras.rays import RayBundle
-from nerfstudio.engine.callbacks import (
-    TrainingCallback,
-    TrainingCallbackAttributes,
-    TrainingCallbackLocation,
-)
+from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.fields.density_fields import HashMLPDensityField
 from nerfstudio.model_components.losses import interlevel_loss
-from nerfstudio.model_components.ray_samplers import (
-    ProposalNetworkSampler,
-    UniformSampler,
-)
+from nerfstudio.model_components.ray_samplers import ProposalNetworkSampler, UniformSampler
 from nerfstudio.models.neus import NeuSModel, NeuSModelConfig
 from nerfstudio.utils import colormaps
 

--- a/nerfstudio/models/semantic_nerfw.py
+++ b/nerfstudio/models/semantic_nerfw.py
@@ -30,11 +30,7 @@ from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
 
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.data.dataparsers.base_dataparser import Semantics
-from nerfstudio.engine.callbacks import (
-    TrainingCallback,
-    TrainingCallbackAttributes,
-    TrainingCallbackLocation,
-)
+from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.field_components.spatial_distortions import SceneContraction
 from nerfstudio.fields.density_fields import HashMLPDensityField

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -28,32 +28,19 @@ from torchmetrics.functional import structural_similarity_index_measure
 from torchmetrics.image import PeakSignalNoiseRatio
 from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
 
+from nerfstudio.cameras.camera_optimizers import CameraOptimizer, CameraOptimizerConfig
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.configs.config_utils import to_immutable_dict
-from nerfstudio.engine.callbacks import (
-    TrainingCallback,
-    TrainingCallbackAttributes,
-    TrainingCallbackLocation,
-)
-from nerfstudio.field_components.encodings import (
-    NeRFEncoding,
-    TensorCPEncoding,
-    TensorVMEncoding,
-    TriplaneEncoding,
-)
+from nerfstudio.engine.callbacks import TrainingCallback, TrainingCallbackAttributes, TrainingCallbackLocation
+from nerfstudio.field_components.encodings import NeRFEncoding, TensorCPEncoding, TensorVMEncoding, TriplaneEncoding
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.fields.tensorf_field import TensoRFField
-from nerfstudio.model_components.losses import MSELoss, tv_loss, scale_gradients_by_distance_squared
+from nerfstudio.model_components.losses import MSELoss, scale_gradients_by_distance_squared, tv_loss
 from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
-from nerfstudio.model_components.renderers import (
-    AccumulationRenderer,
-    DepthRenderer,
-    RGBRenderer,
-)
+from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, RGBRenderer
 from nerfstudio.model_components.scene_colliders import AABBBoxCollider
 from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.utils import colormaps, colors, misc
-from nerfstudio.cameras.camera_optimizers import CameraOptimizer, CameraOptimizerConfig
 
 
 @dataclass

--- a/nerfstudio/models/vanilla_nerf.py
+++ b/nerfstudio/models/vanilla_nerf.py
@@ -19,7 +19,7 @@ Implementation of vanilla nerf.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Tuple, Type, Literal
+from typing import Any, Dict, List, Literal, Tuple, Type
 
 import torch
 from torch.nn import Parameter
@@ -35,11 +35,7 @@ from nerfstudio.field_components.temporal_distortions import TemporalDistortionK
 from nerfstudio.fields.vanilla_nerf_field import NeRFField
 from nerfstudio.model_components.losses import MSELoss, scale_gradients_by_distance_squared
 from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
-from nerfstudio.model_components.renderers import (
-    AccumulationRenderer,
-    DepthRenderer,
-    RGBRenderer,
-)
+from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, RGBRenderer
 from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.utils import colormaps, misc
 

--- a/nerfstudio/pipelines/dynamic_batch.py
+++ b/nerfstudio/pipelines/dynamic_batch.py
@@ -17,7 +17,7 @@ A pipeline that dynamically chooses the number of rays to sample.
 """
 
 from dataclasses import dataclass, field
-from typing import Literal, Type, Optional
+from typing import Literal, Optional, Type
 
 import torch
 from torch.cuda.amp.grad_scaler import GradScaler

--- a/nerfstudio/plugins/registry_dataparser.py
+++ b/nerfstudio/plugins/registry_dataparser.py
@@ -16,8 +16,8 @@
 Module that keeps all registered plugins and allows for plugin discovery.
 """
 
-import os
 import importlib
+import os
 import sys
 import typing as t
 from dataclasses import dataclass

--- a/nerfstudio/process_data/odm_utils.py
+++ b/nerfstudio/process_data/odm_utils.py
@@ -15,11 +15,11 @@
 """Helper utils for processing ODM data into the nerfstudio format."""
 
 import json
-from pathlib import Path
-from typing import Dict, List
+import math
 import os
 import sys
-import math
+from pathlib import Path
+from typing import Dict, List
 
 import numpy as np
 

--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -31,6 +31,7 @@ except ImportError:
     import newrawpy as rawpy  # type: ignore
 
 import numpy as np
+
 from nerfstudio.utils.rich_utils import CONSOLE, status
 from nerfstudio.utils.scripts import run_command
 

--- a/nerfstudio/scripts/completions/install.py
+++ b/nerfstudio/scripts/completions/install.py
@@ -24,8 +24,7 @@ import shutil
 import stat
 import subprocess
 import sys
-from typing import List, Literal, Optional, Union
-from typing import get_args as typing_get_args
+from typing import List, Literal, Optional, Union, get_args as typing_get_args
 
 import tyro
 from rich.prompt import Confirm

--- a/nerfstudio/scripts/downloads/download_data.py
+++ b/nerfstudio/scripts/downloads/download_data.py
@@ -27,10 +27,10 @@ from typing import TYPE_CHECKING, Union
 import gdown
 import torch
 import tyro
-from nerfstudio.process_data import process_data_utils
 from typing_extensions import Annotated
 
 from nerfstudio.configs.base_config import PrintableConfig
+from nerfstudio.process_data import process_data_utils
 from nerfstudio.utils import install_checks
 from nerfstudio.utils.scripts import run_command
 

--- a/nerfstudio/scripts/github/run_actions.py
+++ b/nerfstudio/scripts/github/run_actions.py
@@ -23,7 +23,7 @@ from rich.style import Style
 
 from nerfstudio.utils.rich_utils import CONSOLE
 
-LOCAL_TESTS = ["Run license checks", "Run Ruff", "Run Black", "Run Pyright", "Test with pytest"]
+LOCAL_TESTS = ["Run license checks", "Run Ruff", "Run Black", "Run isort", "Run Pyright", "Test with pytest"]
 
 
 def run_command(command: str, continue_on_fail: bool = False) -> bool:
@@ -61,6 +61,7 @@ def run_github_actions_file(filename: str, continue_on_fail: bool = False):
                 curr_command = f"{compressed} --fix"
             else:
                 curr_command = compressed.replace("--check", "")
+                curr_command = compressed.replace("--diff", "")
 
             CONSOLE.line()
             CONSOLE.rule(f"[bold green]Running: {curr_command}")

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -28,11 +28,11 @@ from typing_extensions import Annotated
 
 from nerfstudio.process_data import (
     metashape_utils,
+    odm_utils,
     polycam_utils,
     process_data_utils,
     realitycapture_utils,
     record3d_utils,
-    odm_utils,
 )
 from nerfstudio.process_data.colmap_converter_to_nerfstudio_dataset import BaseConverterToNerfstudioDataset
 from nerfstudio.process_data.images_to_nerfstudio_dataset import ImagesToNerfstudioDataset

--- a/nerfstudio/scripts/render.py
+++ b/nerfstudio/scripts/render.py
@@ -33,38 +33,20 @@ import mediapy as media
 import numpy as np
 import torch
 import tyro
+import viser.transforms as tf
 from jaxtyping import Float
 from rich import box, style
 from rich.panel import Panel
-from rich.progress import (
-    BarColumn,
-    Progress,
-    TaskProgressColumn,
-    TextColumn,
-    TimeElapsedColumn,
-    TimeRemainingColumn,
-)
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.table import Table
 from torch import Tensor
 from typing_extensions import Annotated
 
-import viser.transforms as tf
-
-from nerfstudio.cameras.camera_paths import (
-    get_interpolated_camera_path,
-    get_path_from_json,
-    get_spiral_path,
-)
-
+from nerfstudio.cameras.camera_paths import get_interpolated_camera_path, get_path_from_json, get_spiral_path
 from nerfstudio.cameras.cameras import Cameras, CameraType, RayBundle
-from nerfstudio.data.datamanagers.base_datamanager import (
-    VanillaDataManager,
-    VanillaDataManagerConfig,
-)
+from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManager, VanillaDataManagerConfig
 from nerfstudio.data.datamanagers.parallel_datamanager import ParallelDataManager
-from nerfstudio.data.datamanagers.random_cameras_datamanager import (
-    RandomCamerasDataManager,
-)
+from nerfstudio.data.datamanagers.random_cameras_datamanager import RandomCamerasDataManager
 from nerfstudio.data.datasets.base_dataset import Dataset
 from nerfstudio.data.scene_box import OrientedBox
 from nerfstudio.data.utils.dataloaders import FixedIndicesEvalDataloader

--- a/nerfstudio/scripts/viewer/run_viewer.py
+++ b/nerfstudio/scripts/viewer/run_viewer.py
@@ -30,8 +30,8 @@ from nerfstudio.engine.trainer import TrainerConfig
 from nerfstudio.pipelines.base_pipeline import Pipeline
 from nerfstudio.utils import writer
 from nerfstudio.utils.eval_utils import eval_setup
-from nerfstudio.viewer_legacy.server.viewer_state import ViewerLegacyState
 from nerfstudio.viewer.viewer import Viewer as ViewerState
+from nerfstudio.viewer_legacy.server.viewer_state import ViewerLegacyState
 
 
 @dataclass

--- a/nerfstudio/utils/eval_utils.py
+++ b/nerfstudio/utils/eval_utils.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Literal, Optional, Tuple, Callable
+from typing import Callable, Literal, Optional, Tuple
 
 import torch
 import yaml

--- a/nerfstudio/utils/misc.py
+++ b/nerfstudio/utils/misc.py
@@ -17,11 +17,11 @@ Miscellaneous helper code.
 """
 
 
-from inspect import currentframe
-import typing
 import platform
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+import typing
 import warnings
+from inspect import currentframe
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 import torch
 

--- a/nerfstudio/utils/profiler.py
+++ b/nerfstudio/utils/profiler.py
@@ -24,28 +24,13 @@ import typing
 from collections import deque
 from contextlib import ContextDecorator, contextmanager
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    ContextManager,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, TypeVar, Union, overload
 
 from torch.profiler import ProfilerActivity, profile, record_function
 
 from nerfstudio.configs import base_config as cfg
 from nerfstudio.utils import comms
-from nerfstudio.utils.decorators import (
-    check_main_thread,
-    check_profiler_enabled,
-    decorate_all,
-)
+from nerfstudio.utils.decorators import check_main_thread, check_profiler_enabled, decorate_all
 from nerfstudio.utils.rich_utils import CONSOLE
 
 PROFILER = []

--- a/nerfstudio/utils/rich_utils.py
+++ b/nerfstudio/utils/rich_utils.py
@@ -18,15 +18,7 @@ from contextlib import nullcontext
 from typing import Optional
 
 from rich.console import Console
-from rich.progress import (
-    BarColumn,
-    Progress,
-    ProgressColumn,
-    Task,
-    TaskProgressColumn,
-    TextColumn,
-    TimeRemainingColumn,
-)
+from rich.progress import BarColumn, Progress, ProgressColumn, Task, TaskProgressColumn, TextColumn, TimeRemainingColumn
 from rich.text import Text
 
 CONSOLE = Console(width=120)

--- a/nerfstudio/utils/writer.py
+++ b/nerfstudio/utils/writer.py
@@ -28,12 +28,13 @@ import comet_ml
 import torch
 import wandb
 from jaxtyping import Float
+from torch import Tensor
+from torch.utils.tensorboard import SummaryWriter
+
 from nerfstudio.configs import base_config as cfg
 from nerfstudio.utils.decorators import check_main_thread, decorate_all
 from nerfstudio.utils.printing import human_format
 from nerfstudio.utils.rich_utils import CONSOLE
-from torch import Tensor
-from torch.utils.tensorboard import SummaryWriter
 
 
 def to8b(x):

--- a/nerfstudio/viewer/control_panel.py
+++ b/nerfstudio/viewer/control_panel.py
@@ -20,6 +20,8 @@ import numpy as np
 import torch
 import viser
 import viser.transforms as vtf
+from viser import ViserServer
+
 from nerfstudio.data.scene_box import OrientedBox
 from nerfstudio.utils.colormaps import ColormapOptions, Colormaps
 from nerfstudio.viewer.viewer_elements import (  # ViewerButtonGroup,
@@ -32,7 +34,6 @@ from nerfstudio.viewer.viewer_elements import (  # ViewerButtonGroup,
     ViewerSlider,
     ViewerVec3,
 )
-from viser import ViserServer
 
 
 class ControlPanel:

--- a/nerfstudio/viewer/export_panel.py
+++ b/nerfstudio/viewer/export_panel.py
@@ -18,9 +18,10 @@ from pathlib import Path
 
 import viser
 import viser.transforms as vtf
+from typing_extensions import Literal
+
 from nerfstudio.data.scene_box import OrientedBox
 from nerfstudio.viewer.control_panel import ControlPanel
-from typing_extensions import Literal
 
 
 def populate_export_tab(server: viser.ViserServer, control_panel: ControlPanel, config_path: Path) -> None:

--- a/nerfstudio/viewer/render_panel.py
+++ b/nerfstudio/viewer/render_panel.py
@@ -20,15 +20,17 @@ import datetime
 import json
 import threading
 import time
-from typing import Dict, List, Optional, Tuple, Literal
 from pathlib import Path
-from nerfstudio.viewer.control_panel import ControlPanel
+from typing import Dict, List, Literal, Optional, Tuple
+
+import numpy as np
+import scipy
 import splines
 import splines.quaternion
 import viser
 import viser.transforms as tf
-import numpy as np
-import scipy
+
+from nerfstudio.viewer.control_panel import ControlPanel
 
 
 @dataclasses.dataclass

--- a/nerfstudio/viewer/render_state_machine.py
+++ b/nerfstudio/viewer/render_state_machine.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, get_args
 import numpy as np
 import torch
 import torch.nn.functional as F
+from viser import ClientHandle
+
 from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.model_components.renderers import background_color_override_context
 from nerfstudio.models.gaussian_splatting import GaussianSplattingModel
@@ -31,8 +33,6 @@ from nerfstudio.utils import colormaps, writer
 from nerfstudio.utils.writer import GLOBAL_BUFFER, EventName, TimeWriter
 from nerfstudio.viewer.utils import CameraState, get_camera
 from nerfstudio.viewer_legacy.server import viewer_utils
-
-from viser import ClientHandle
 
 if TYPE_CHECKING:
     from nerfstudio.viewer.viewer import Viewer

--- a/nerfstudio/viewer/utils.py
+++ b/nerfstudio/viewer/utils.py
@@ -20,10 +20,11 @@ from typing import Any, List, Literal, Optional, Tuple, Union
 import numpy as np
 import torch
 from jaxtyping import Float
+from torch import nn
+
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.models.base_model import Model
-from torch import nn
 
 
 @dataclass

--- a/nerfstudio/viewer/viewer.py
+++ b/nerfstudio/viewer/viewer.py
@@ -26,6 +26,8 @@ import torchvision
 import viser
 import viser.theme
 import viser.transforms as vtf
+from typing_extensions import assert_never
+
 from nerfstudio.cameras.camera_optimizers import CameraOptimizer
 from nerfstudio.cameras.cameras import CameraType
 from nerfstudio.configs import base_config as cfg
@@ -34,14 +36,13 @@ from nerfstudio.models.base_model import Model
 from nerfstudio.pipelines.base_pipeline import Pipeline
 from nerfstudio.utils.decorators import check_main_thread, decorate_all
 from nerfstudio.utils.writer import GLOBAL_BUFFER, EventName
-from nerfstudio.viewer_legacy.server import viewer_utils
 from nerfstudio.viewer.control_panel import ControlPanel
 from nerfstudio.viewer.export_panel import populate_export_tab
 from nerfstudio.viewer.render_panel import populate_render_tab
 from nerfstudio.viewer.render_state_machine import RenderAction, RenderStateMachine
 from nerfstudio.viewer.utils import CameraState, parse_object
 from nerfstudio.viewer.viewer_elements import ViewerControl, ViewerElement
-from typing_extensions import assert_never
+from nerfstudio.viewer_legacy.server import viewer_utils
 
 if TYPE_CHECKING:
     from nerfstudio.engine.trainer import Trainer

--- a/nerfstudio/viewer/viewer_elements.py
+++ b/nerfstudio/viewer/viewer_elements.py
@@ -35,8 +35,8 @@ from viser import (
     ViserServer,
 )
 
-from nerfstudio.viewer.utils import CameraState, get_camera
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.viewer.utils import CameraState, get_camera
 
 if TYPE_CHECKING:
     from nerfstudio.viewer.viewer import Viewer

--- a/nerfstudio/viewer_legacy/viser/__init__.py
+++ b/nerfstudio/viewer_legacy/viser/__init__.py
@@ -15,7 +15,6 @@
 """ Viser is used for the nerfstudio viewer backend """
 
 
-from .message_api import GuiHandle as GuiHandle
-from .message_api import GuiSelectHandle as GuiSelectHandle
+from .message_api import GuiHandle as GuiHandle, GuiSelectHandle as GuiSelectHandle
 from .messages import NerfstudioMessage as NerfstudioMessage
 from .server import ViserServer as ViserServer

--- a/nerfstudio/viewer_legacy/viser/gui.py
+++ b/nerfstudio/viewer_legacy/viser/gui.py
@@ -21,28 +21,12 @@ from __future__ import annotations
 
 import dataclasses
 import time
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 import numpy as onp
 from viser.infra import ClientId
 
-from .messages import (
-    GuiRemoveMessage,
-    GuiSetHiddenMessage,
-    GuiSetLevaConfMessage,
-    GuiSetValueMessage,
-)
+from .messages import GuiRemoveMessage, GuiSetHiddenMessage, GuiSetLevaConfMessage, GuiSetValueMessage
 
 if TYPE_CHECKING:
     from .message_api import MessageApi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ gen = [
 # Development packages
 dev = [
     "black[jupyter]==23.3.0",
+    "isort==5.13.2",
     "pre-commit==3.3.2",
     "pytest==7.1.2",
     "pytest-xdist==2.5.0",
@@ -144,6 +145,12 @@ include = ["nerfstudio*"]
 
 [tool.black]
 line-length = 120
+
+[tool.isort]
+combine_as_imports = true
+known_first_party = ["nerfstudio"]
+line_length = 120
+profile = "black"
 
 [tool.pytest.ini_options]
 addopts = "-n=4 --typeguard-packages=nerfstudio --disable-warnings"

--- a/tests/dataparsers/test_nerfstudio_dataparser.py
+++ b/tests/dataparsers/test_nerfstudio_dataparser.py
@@ -71,10 +71,7 @@ def test_nerfstudio_dataparser_split_filelist(mocked_dataset):
         f.truncate(0)
         json.dump(data, f)
 
-    from nerfstudio.data.dataparsers.nerfstudio_dataparser import (
-        Nerfstudio,
-        NerfstudioDataParserConfig,
-    )
+    from nerfstudio.data.dataparsers.nerfstudio_dataparser import Nerfstudio, NerfstudioDataParserConfig
 
     parser: Nerfstudio = NerfstudioDataParserConfig(
         data=mocked_dataset,

--- a/tests/pipelines/test_vanilla_pipeline.py
+++ b/tests/pipelines/test_vanilla_pipeline.py
@@ -7,14 +7,9 @@ import torch
 from torch import nn
 
 from nerfstudio.cameras.cameras import Cameras
-from nerfstudio.data.datasets.base_dataset import DataparserOutputs, InputDataset
-from nerfstudio.pipelines.base_pipeline import (
-    Model,
-    ModelConfig,
-    VanillaPipeline,
-    VanillaPipelineConfig,
-)
 from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManagerConfig
+from nerfstudio.data.datasets.base_dataset import DataparserOutputs, InputDataset
+from nerfstudio.pipelines.base_pipeline import Model, ModelConfig, VanillaPipeline, VanillaPipelineConfig
 
 
 class MockedDataManager:

--- a/tests/process_data/test_process_images.py
+++ b/tests/process_data/test_process_images.py
@@ -9,9 +9,13 @@ import torch
 from PIL import Image
 
 from nerfstudio.data.dataparsers.nerfstudio_dataparser import NerfstudioDataParserConfig
-from nerfstudio.data.utils.colmap_parsing_utils import Camera
-from nerfstudio.data.utils.colmap_parsing_utils import Image as ColmapImage
-from nerfstudio.data.utils.colmap_parsing_utils import qvec2rotmat, write_cameras_binary, write_images_binary
+from nerfstudio.data.utils.colmap_parsing_utils import (
+    Camera,
+    Image as ColmapImage,
+    qvec2rotmat,
+    write_cameras_binary,
+    write_images_binary,
+)
 from nerfstudio.process_data.images_to_nerfstudio_dataset import ImagesToNerfstudioDataset
 
 


### PR DESCRIPTION
`isort` is a linter that complements black and helps keeps imports nicely formatted: https://pycqa.github.io/isort/

Mainly, it splits imports into 3 groups: builtins, third party (e.g. `torch`), first party (i.e. `nerfstudio`). It enforces proper spacing between these groups, combines multiple imports from the same module into one line, alphabetizes them, and respects line-length by splitting long import statements into multiple lines.
