### PR TITLE
MAX_AUTO_RESOLUTION is ensured in auto downscale

### DIFF
--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -486,7 +486,7 @@ class ColmapDataParser(DataParser):
                 max_res = max(h, w)
                 df = 0
                 while True:
-                    if (max_res / 2 ** (df)) < MAX_AUTO_RESOLUTION:
+                    if (max_res / 2 ** (df)) <= MAX_AUTO_RESOLUTION:
                         break
                     df += 1
 

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -376,7 +376,7 @@ class Nerfstudio(DataParser):
                 max_res = max(h, w)
                 df = 0
                 while True:
-                    if (max_res / 2 ** (df)) < MAX_AUTO_RESOLUTION:
+                    if (max_res / 2 ** (df)) <= MAX_AUTO_RESOLUTION:
                         break
                     if not (data_dir / f"{downsample_folder_prefix}{2**(df+1)}" / filepath.name).exists():
                         break


### PR DESCRIPTION
Simple change, this is to ensure 1600 pixels is the maximal (inclusive) dimension in auto-downscaling. This behavior is consistent with several other repos such as Inria Gaussian Splatting ( https://github.com/graphdeco-inria/gaussian-splatting/blob/main/utils/camera_utils.py#L26 )

