### PR TITLE
Disable projectaria tools on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,12 +91,15 @@ dev = [
     "typeguard==2.13.3",
     "ruff==0.1.13",
     "sshconf==0.2.5",
-    "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions
+    # TODO(1480) enable when pycolmap windows wheels are available
+    # "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions
     "diffusers==0.16.1",
     "opencv-stubs==0.0.7",
     "transformers==4.29.2",
     "pyright==1.1.331",
-    "projectaria_tools[all]>=1.2.0",
+    # NOTE: Disabling projectaria-tools because it doesn't have prebuilt windows wheels
+    # Syntax comes from here: https://pip.pypa.io/en/stable/reference/requirement-specifiers/
+    "projectaria-tools>=1.3.1; sys_platform != 'win32'",
 ]
 
 # Documentation related packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,7 @@ dev = [
     "typeguard==2.13.3",
     "ruff==0.1.13",
     "sshconf==0.2.5",
-    # TODO(1480) enable when pycolmap windows wheels are available
-    # "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions
+    "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions
     "diffusers==0.16.1",
     "opencv-stubs==0.0.7",
     "transformers==4.29.2",


### PR DESCRIPTION
The `projectaria-tools` package doesn't have Windows binaries, which prevents `pip install -e .[dev]` from working. I've updated the specification to require a platform other than Windows for installation. I also updated the specification to not use `[all]` after a discussion with the library authors, and fixed an underscore typo which was probably being silently transformed by `pip`.

Previously (https://github.com/nerfstudio-project/nerfstudio/pull/2672), I had also disabled `pycolmap`, but it turns out that very recently (as of Jan 11), there's now Windows wheels published for `pycolmap` on PyPi (https://pypi.org/project/pycolmap/#files), so it actually installs just fine. I also posted about that in the associated issue (https://github.com/nerfstudio-project/nerfstudio/issues/1480) in case someone wants to pick up the task to enable `pycolmap` usage again.