### PR TITLE
important fix typo 

### DIFF
--- a/docs/nerfology/methods/splat.md
+++ b/docs/nerfology/methods/splat.md
@@ -33,7 +33,7 @@ To run splatfacto, run `ns-train splatfacto --data <data>`. Just like NeRF metho
 
 #### Quality and Regularization
 The default settings provided maintain a balance between speed, quality, and splat file size, but if you care more about quality than training speed or size, you can decrease the alpha cull threshold 
-(threshold to delete translucent gaussians) and disable culling after 15k steps like so: `ns-train splatfacto --pipeline.model.cull_scale_thresh=0.005 --pipeline.model.continue_cull_post_densification=False --data <data>`
+(threshold to delete translucent gaussians) and disable culling after 15k steps like so: `ns-train splatfacto --pipeline.model.cull_alpha_thresh=0.005 --pipeline.model.continue_cull_post_densification=False --data <data>`
 
 A common artifact in splatting is long, spikey gaussians. [PhysGaussian](https://xpandora.github.io/PhysGaussian/) proposes a scale regularizer that encourages gaussians to be more evenly shaped. To enable this, set the `use_scale_regularization` flag to `True`.
 


### PR DESCRIPTION
We have `--cull_alpha_thresh` and `--cull_scale_thresh`, they are very different ... 