### PR TITLE
Update nerfstudio_dataparser.py

### DIFF
--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -73,7 +73,7 @@ class NerfstudioDataParserConfig(DataParserConfig):
     """The interval between frames to use for eval. Only used when eval_mode is eval-interval."""
     depth_unit_scale_factor: float = 1e-3
     """Scales the depth values to meters. Default value is 0.001 for a millimeter to meter conversion."""
-    load_3D_points: bool = False
+    load_3D_points: bool = True
     """Whether to load the 3D points from the colmap reconstruction."""
 
 


### PR DESCRIPTION
This is initial code:
https://github.com/nerfstudio-project/nerfstudio/blob/8952fb531ea09db00c481de95cafadbb80c262e6/nerfstudio/data/dataparsers/nerfstudio_dataparser.py#L76

I fix to `--load-3D-points` set to True by default.

Why I set True by default? Because I see another recommendation in this line for set it true
https://github.com/nerfstudio-project/nerfstudio/blob/8952fb531ea09db00c481de95cafadbb80c262e6/nerfstudio/data/dataparsers/colmap_dataparser.py#L96

Meanwhile, we already switching from colmap dataparser to nerfstudio dataparser https://github.com/nerfstudio-project/nerfstudio/pull/2791