### PR TITLE
Use packaging.version for colmap version

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -19,6 +19,7 @@ Tools supporting the execution of COLMAP and preparation of COLMAP-based dataset
 import json
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Union
+from packaging.version import Version
 
 import appdirs
 import cv2
@@ -42,7 +43,7 @@ from nerfstudio.utils.rich_utils import CONSOLE, status
 from nerfstudio.utils.scripts import run_command
 
 
-def get_colmap_version(colmap_cmd: str, default_version=3.8) -> float:
+def get_colmap_version(colmap_cmd: str, default_version=3.8) -> Version:
     """Returns the version of COLMAP.
     This code assumes that colmap returns a version string of the form
     "COLMAP 3.8 ..." which may not be true for all versions of COLMAP.
@@ -57,9 +58,10 @@ def get_colmap_version(colmap_cmd: str, default_version=3.8) -> float:
     for line in output.split("\n"):
         if line.startswith("COLMAP"):
             version = line.split(" ")[1]
-            version = "".join([c for c in version if c.isdigit() or c == "."])
-            return float(version)
+            version = Version(version)
+            return version
     CONSOLE.print(f"[bold red]Could not find COLMAP version. Using default {default_version}")
+    default_version = Version(str(default_version))
     return default_version
 
 
@@ -158,7 +160,7 @@ def run_colmap(
         f"--image_path {image_dir}",
         f"--output_path {sparse_dir}",
     ]
-    if colmap_version >= 3.7:
+    if colmap_version >= Version("3.7"):
         mapper_cmd.append("--Mapper.ba_global_function_tolerance=1e-6")
 
     mapper_cmd = " ".join(mapper_cmd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ dependencies = [
     "timm==0.6.7",
     "gsplat==0.1.2.1",
     "pytorch-msssim",
-    "pathos"
+    "pathos",
+    "packaging"
 ]
 
 [project.urls]


### PR DESCRIPTION
Changes the way we check the version for `colmap` command. 

Using `Version` objects from `packaging.version` should be more stable than using float comparisons (3.7, 3.8, ...), which might break when the version cannot be represented as a float (e.g., 3.9.1). 
