### PR TITLE
fixing colmap installation to use apt-get since gdown on the URL unable to download colmap

### DIFF
--- a/colab/demo.ipynb
+++ b/colab/demo.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/nerfstudio-project/nerfstudio/blob/alex%2Fcolab-logo-fix/colab/demo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -65,8 +65,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "9oyLHl8QfYwP",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "9oyLHl8QfYwP"
       },
       "outputs": [],
       "source": [
@@ -83,28 +83,7 @@
         "\n",
         "# Installing COLMAP\n",
         "%cd /content/\n",
-        "!gdown \"https://drive.google.com/u/0/uc?id=15WngFRNar_b8CaPR5R-hvQ3eAnlyk_SL&confirm=t\"\n",
-        "!sudo apt-get install \\\n",
-        "    build-essential \\\n",
-        "    libboost-program-options-dev \\\n",
-        "    libboost-filesystem-dev \\\n",
-        "    libboost-graph-dev \\\n",
-        "    libboost-system-dev \\\n",
-        "    libboost-test-dev \\\n",
-        "    libeigen3-dev \\\n",
-        "    libflann-dev \\\n",
-        "    libfreeimage-dev \\\n",
-        "    libmetis-dev \\\n",
-        "    libgoogle-glog-dev \\\n",
-        "    libgflags-dev \\\n",
-        "    libsqlite3-dev \\\n",
-        "    libglew-dev \\\n",
-        "    qtbase5-dev \\\n",
-        "    libqt5opengl5-dev \\\n",
-        "    libcgal-dev \\\n",
-        "    libceres-dev\n",
-        "!unzip local.zip -d /usr/\n",
-        "!chmod +x /usr/local/bin/colmap\n",
+        "!apt-get install colmap\n",
         "\n",
         "# Install nerfstudio\n",
         "%cd /content/\n",
@@ -350,8 +329,8 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "provenance": [],
-      "include_colab_link": true
+      "include_colab_link": true,
+      "provenance": []
     },
     "gpuClass": "standard",
     "kernelspec": {


### PR DESCRIPTION
in the demo colab notebook, `gdown` is unable to install `colmap` because the gdrive link is not sharable or not available. 

This issue is also mentioned here:
1. https://github.com/nerfstudio-project/nerfstudio/pull/2787/files
- `!conda install -c conda-forge colmap` will raise a `PackagesNotFoundError`.
2. https://github.com/nerfstudio-project/nerfstudio/issues/2406#issuecomment-1746746583
- the fix mentioned here will also have a `PackagesNotFoundError` and then the runtime always crashes/restarts

To download colmap, using `apt-get` solved these issues and allowed me to process my data in the following cell - it is a quick one-line and it takes about 4minutes 16seconds to install nerfstudio and its dependencies