### PR TITLE
Fix "mutable default" error in render.py

### DIFF
--- a/nerfstudio/scripts/render.py
+++ b/nerfstudio/scripts/render.py
@@ -364,7 +364,7 @@ class CropData:
 
     background_color: Float[Tensor, "3"] = torch.Tensor([0.0, 0.0, 0.0])
     """background color"""
-    obb: OrientedBox = OrientedBox(R=torch.eye(3), T=torch.zeros(3), S=torch.ones(3) * 2)
+    obb: OrientedBox = field(default_factory=lambda: OrientedBox(R=torch.eye(3), T=torch.zeros(3), S=torch.ones(3) * 2))
     """Oriented box representing the crop region"""
 
     # properties for backwards-compatibility interface


### PR DESCRIPTION
This fixes 

```
ValueError: mutable default <class 'nerfstudio.data.scene_box.OrientedBox'> for field obb is not allowed: use default_factory
```