### PR TITLE
add zipnerf-pytorch as external method

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -156,6 +156,7 @@ This documentation is organized into 3 parts:
 - [Instruct-GS2GS](nerfology/methods/igs2gs.md): Editing 3DGS Scenes with Instructions
 - [PyNeRF](nerfology/methods/pynerf.md): Pyramidal Neural Radiance Fields
 - [SeaThru-NeRF](nerfology/methods/seathru_nerf.md): Neural Radiance Field for subsea scenes
+- [Zip-NeRF](nerfology/methods/szipnerf.md): Anti-Aliased Grid-Based Neural Radiance Fields
 
 **Eager to contribute a method?** We'd love to see you use nerfstudio in implementing new (or even existing) methods! Please view our {ref}`guide<own_method_docs>` for more details about how to add to this list!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,7 +156,7 @@ This documentation is organized into 3 parts:
 - [Instruct-GS2GS](nerfology/methods/igs2gs.md): Editing 3DGS Scenes with Instructions
 - [PyNeRF](nerfology/methods/pynerf.md): Pyramidal Neural Radiance Fields
 - [SeaThru-NeRF](nerfology/methods/seathru_nerf.md): Neural Radiance Field for subsea scenes
-- [Zip-NeRF](nerfology/methods/szipnerf.md): Anti-Aliased Grid-Based Neural Radiance Fields
+- [Zip-NeRF](nerfology/methods/zipnerf.md): Anti-Aliased Grid-Based Neural Radiance Fields
 
 **Eager to contribute a method?** We'd love to see you use nerfstudio in implementing new (or even existing) methods! Please view our {ref}`guide<own_method_docs>` for more details about how to add to this list!
 

--- a/docs/nerfology/methods/index.md
+++ b/docs/nerfology/methods/index.md
@@ -42,6 +42,7 @@ The following methods are supported in nerfstudio:
     Instruct-GS2GS<igs2gs.md>
     PyNeRF<pynerf.md>
     SeaThru-NeRF<seathru_nerf.md>
+    Zip-NeRF<zipnerf.md>
 ```
 
 (own_method_docs)=

--- a/docs/nerfology/methods/zipnerf.md
+++ b/docs/nerfology/methods/zipnerf.md
@@ -15,8 +15,8 @@ Code
 ### Installation
 First, install nerfstudio and its dependencies. Then run:
 ```
-pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio#subdirectory=extensions/cuda
-pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio
+pip install git+https://github.com/SuLvXiangXin/zipnerf-pytorch#subdirectory=extensions/cuda
+pip install git+https://github.com/SuLvXiangXin/zipnerf-pytorch
 ```
 Finally, install torch_scatter corresponding to your cuda version(https://pytorch-geometric.com/whl/torch-2.0.1%2Bcu118.html).
 

--- a/docs/nerfology/methods/zipnerf.md
+++ b/docs/nerfology/methods/zipnerf.md
@@ -7,6 +7,11 @@
 :outline:
 Paper Website
 ```
+```{button-link} https://github.com/SuLvXiangXin/zipnerf-pytorch
+:color: primary
+:outline:
+Code
+```
 ### Installation
 First, install nerfstudio and its dependencies. Then run:
 ```

--- a/docs/nerfology/methods/zipnerf.md
+++ b/docs/nerfology/methods/zipnerf.md
@@ -1,0 +1,28 @@
+# Zip-NeRF
+
+<h4>A pytorch implementation of "Zip-NeRF: Anti-Aliased Grid-Based Neural Radiance Fields"</h4>
+
+```{button-link} https://jonbarron.info/zipnerf/
+:color: primary
+:outline:
+Paper Website
+```
+### Installation
+First, install nerfstudio and its dependencies. Then run:
+```
+pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio#subdirectory=extensions/cuda
+pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio
+```
+Finally, install torch_scatter corresponding to your cuda version(https://pytorch-geometric.com/whl/torch-2.0.1%2Bcu118.html).
+
+
+### Running Model
+
+```bash
+ns-train zipnerf --data {DATA_DIR/SCENE}
+```
+
+## Overview
+Zipnerf combines mip-NeRF 360’s overall framework with iNGP’s featurization approach.
+Following mip-NeRF, zipnerf assume each pixel corresponds to a cone. Given an interval along the ray, it construct a set of multisamples that approximate the shape of that conical frustum.
+Also,  it present an alternative loss that, unlike mip-NeRF 360’s interlevel loss, is continuous and smooth with respect to distance along the ray to prevent z-aliasing.

--- a/nerfstudio/configs/external_methods.py
+++ b/nerfstudio/configs/external_methods.py
@@ -201,7 +201,10 @@ For more information visit https://docs.nerf.studio/nerfology/methods/zipnerf.ht
 To enable Zip-NeRF, you must install it first by running:
   [grey]pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio#subdirectory=extensions/cuda 
   and pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio[/grey]""",
-        configurations=[("zipnerf", "A pytorch implementation of 'Zip-NeRF: Anti-Aliased Grid-Based Neural Radiance Fields'")],
+        configurations=[
+            ("zipnerf", "A pytorch implementation of 'Zip-NeRF: Anti-Aliased Grid-Based Neural Radiance Fields'")
+        ],
+         pip_package="pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio",
         pip_package="pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio",
     )
 )

--- a/nerfstudio/configs/external_methods.py
+++ b/nerfstudio/configs/external_methods.py
@@ -199,8 +199,8 @@ external_methods.append(
 For more information visit https://docs.nerf.studio/nerfology/methods/zipnerf.html
 
 To enable Zip-NeRF, you must install it first by running:
-  [grey]pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio#subdirectory=extensions/cuda 
-  and pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio[/grey]""",
+  [grey]pip install git+https://github.com/SuLvXiangXin/zipnerf-pytorch#subdirectory=extensions/cuda 
+  and pip install git+https://github.com/SuLvXiangXin/zipnerf-pytorch[/grey]""",
         configurations=[
             ("zipnerf", "A pytorch implementation of 'Zip-NeRF: Anti-Aliased Grid-Based Neural Radiance Fields'")
         ],

--- a/nerfstudio/configs/external_methods.py
+++ b/nerfstudio/configs/external_methods.py
@@ -204,7 +204,7 @@ To enable Zip-NeRF, you must install it first by running:
         configurations=[
             ("zipnerf", "A pytorch implementation of 'Zip-NeRF: Anti-Aliased Grid-Based Neural Radiance Fields'")
         ],
-        pip_package="pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio",
+        pip_package="pip install git+https://github.com/SuLvXiangXin/zipnerf-pytorch",
     )
 )
 

--- a/nerfstudio/configs/external_methods.py
+++ b/nerfstudio/configs/external_methods.py
@@ -208,6 +208,7 @@ To enable Zip-NeRF, you must install it first by running:
     )
 )
 
+
 @dataclass
 class ExternalMethodDummyTrainerConfig:
     """Dummy trainer config for external methods (a) which do not have an

--- a/nerfstudio/configs/external_methods.py
+++ b/nerfstudio/configs/external_methods.py
@@ -192,6 +192,19 @@ To enable Seathru-NeRF, you must install it first by running:
     )
 )
 
+# Zip-NeRF
+external_methods.append(
+    ExternalMethod(
+        """[bold yellow]Zip-NeRF[/bold yellow]
+For more information visit https://docs.nerf.studio/nerfology/methods/zipnerf.html
+
+To enable Zip-NeRF, you must install it first by running:
+  [grey]pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio#subdirectory=extensions/cuda 
+  and pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio[/grey]""",
+        configurations=[("zipnerf", "A pytorch implementation of 'Zip-NeRF: Anti-Aliased Grid-Based Neural Radiance Fields'")],
+        pip_package="pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio",
+    )
+)
 
 @dataclass
 class ExternalMethodDummyTrainerConfig:

--- a/nerfstudio/configs/external_methods.py
+++ b/nerfstudio/configs/external_methods.py
@@ -204,7 +204,6 @@ To enable Zip-NeRF, you must install it first by running:
         configurations=[
             ("zipnerf", "A pytorch implementation of 'Zip-NeRF: Anti-Aliased Grid-Based Neural Radiance Fields'")
         ],
-         pip_package="pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio",
         pip_package="pip install git+https://github.com/Jing1Ling/zipnerf-pytorch@support_nerfstudio",
     )
 )


### PR DESCRIPTION
Add zipnerf-pytorch to the documentation as an external method. 
I’ve submitted a [PR](https://github.com/SuLvXiangXin/zipnerf-pytorch/pull/98) to the [original zipnerf pytorch repo](https://github.com/SuLvXiangXin/zipnerf-pytorch) to support nerfstudio. I'll update link in docs if its merged.