### PR TITLE
Have predicted depth as expected_depth so gradients can be computed

### DIFF
--- a/nerfstudio/models/depth_nerfacto.py
+++ b/nerfstudio/models/depth_nerfacto.py
@@ -95,7 +95,7 @@ class DepthNerfactoModel(NerfactoModel):
                         weights=outputs["weights_list"][i],
                         ray_samples=outputs["ray_samples_list"][i],
                         termination_depth=termination_depth,
-                        predicted_depth=outputs["depth"],
+                        predicted_depth=outputs["expected_depth"],
                         sigma=sigma,
                         directions_norm=outputs["directions_norm"],
                         is_euclidean=self.config.is_euclidean_depth,


### PR DESCRIPTION
In direct depth supervision methods, calling `depth_loss` will not work unless we can compute gradients on the predicted depth. The predicted depth right now is a median and there are no gradients that can be computed. I have changed it to expected depth to allow direct depth supervision methods to work.