### PR TITLE
Avoid OOM for caching undistorted images of splatfacto

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -603,6 +603,7 @@ method_configs["splatfacto"] = TrainerConfig(
     pipeline=VanillaPipelineConfig(
         datamanager=FullImageDatamanagerConfig(
             dataparser=NerfstudioDataParserConfig(load_3D_points=True),
+            cache_images_type="uint8",
         ),
         model=SplatfactoModelConfig(),
     ),


### PR DESCRIPTION
I found many users in discord complains about OOM error when training with > 1000 images. We probably need to enable this option by default in the `method_configs`.