### PR TITLE
limit torch to <=2.1 to avoid type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ dependencies = [
     "scikit-image>=0.19.3",
     "splines==0.3.0",
     "tensorboard>=2.13.0",
-    "torch>=1.13.1",
+    # pin torch to <=2.1 to fix https://github.com/pytorch/pytorch/issues/118736
+    "torch>=1.13.1,<=2.1",
     "torchvision>=0.14.1",
     "torchmetrics[image]>=1.0.1",
     "typing_extensions>=4.4.0",


### PR DESCRIPTION
Because of https://github.com/pytorch/pytorch/issues/118736, our build actions are failing. Hopefully this fixes it