### PR TITLE
Make colmapDataParser compatible with 360_v2 dataset format

### DIFF
--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -1012,8 +1012,11 @@ class Cameras(TensorDataclass):
         if scale_rounding_mode == "floor":
             self.height = (self.height * scaling_factor).to(torch.int64)
             self.width = (self.width * scaling_factor).to(torch.int64)
+        elif scale_rounding_mode == "round":
+            self.height = torch.floor(0.5 + (self.height * scaling_factor)).to(torch.int64)
+            self.width = torch.floor(0.5 + (self.width * scaling_factor)).to(torch.int64)
         elif scale_rounding_mode == "ceil":
             self.height = torch.ceil(self.height * scaling_factor).to(torch.int64)
             self.width = torch.ceil(self.width * scaling_factor).to(torch.int64)
         else:
-            raise ValueError("Scale rounding mode must be 'floor' or 'ceil'.")
+            raise ValueError("Scale rounding mode must be 'floor', 'round' or 'ceil'.")

--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -984,12 +984,15 @@ class Cameras(TensorDataclass):
         return K
 
     def rescale_output_resolution(
-        self, scaling_factor: Union[Shaped[Tensor, "*num_cameras"], Shaped[Tensor, "*num_cameras 1"], float, int]
+        self,
+        scaling_factor: Union[Shaped[Tensor, "*num_cameras"], Shaped[Tensor, "*num_cameras 1"], float, int],
+        scale_rounding_mode: str = "floor",
     ) -> None:
         """Rescale the output resolution of the cameras.
 
         Args:
             scaling_factor: Scaling factor to apply to the output resolution.
+            scale_rounding_mode: round down or round up when calculating the scaled image height and width
         """
         if isinstance(scaling_factor, (float, int)):
             scaling_factor = torch.tensor([scaling_factor]).to(self.device).broadcast_to((self.cx.shape))
@@ -1006,5 +1009,11 @@ class Cameras(TensorDataclass):
         self.fy = self.fy * scaling_factor
         self.cx = self.cx * scaling_factor
         self.cy = self.cy * scaling_factor
-        self.height = (self.height * scaling_factor).to(torch.int64)
-        self.width = (self.width * scaling_factor).to(torch.int64)
+        if scale_rounding_mode == "floor":
+            self.height = (self.height * scaling_factor).to(torch.int64)
+            self.width = (self.width * scaling_factor).to(torch.int64)
+        elif scale_rounding_mode == "ceil":
+            self.height = torch.ceil(self.height * scaling_factor).to(torch.int64)
+            self.width = torch.ceil(self.width * scaling_factor).to(torch.int64)
+        else:
+            raise ValueError("Scale rounding mode must be 'floor' or 'ceil'.")

--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -457,13 +457,20 @@ class ColmapDataParser(DataParser):
             out["points3D_points2D_xy"] = torch.stack(points3D_image_xy, dim=0)
         return out
 
-    def _downscale_images(self, paths, get_fname, downscale_factor: int, downscale_rounding_mode: str = "floor",nearest_neighbor: bool = False):
-        def calculate_scaled_size(original_width, original_height, downscale_factor, mode='floor'):
-            if mode == 'floor':
+    def _downscale_images(
+        self,
+        paths,
+        get_fname,
+        downscale_factor: int,
+        downscale_rounding_mode: str = "floor",
+        nearest_neighbor: bool = False,
+    ):
+        def calculate_scaled_size(original_width, original_height, downscale_factor, mode="floor"):
+            if mode == "floor":
                 return math.floor(original_width / downscale_factor), math.floor(original_height / downscale_factor)
-            elif mode == 'round':
+            elif mode == "round":
                 return round(original_width / downscale_factor), round(original_height / downscale_factor)
-            elif mode == 'ceil':
+            elif mode == "ceil":
                 return math.ceil(original_width / downscale_factor), math.ceil(original_height / downscale_factor)
             else:
                 raise ValueError("Invalid mode. Choose from 'floor', 'round', or 'ceil'.")
@@ -473,7 +480,7 @@ class ColmapDataParser(DataParser):
             assert isinstance(downscale_factor, int)
             filepath = next(iter(paths))
             img = Image.open(filepath)
-            w,h = img.size
+            w, h = img.size
             w_scaled, h_scaled = calculate_scaled_size(w, h, downscale_factor, downscale_rounding_mode)
             # Using %05d ffmpeg commands appears to be unreliable (skips images).
             for path in paths:
@@ -527,7 +534,11 @@ class ColmapDataParser(DataParser):
                 CONSOLE.print(
                     f"[bold red]Downscaled images do not exist for factor of {self._downscale_factor}.[/bold red]"
                 )
-                if Confirm.ask(f"\nWould you like to downscale the images using '{self.config.downscale_rounding_mode}' rounding mode now?", default=False, console=CONSOLE):
+                if Confirm.ask(
+                    f"\nWould you like to downscale the images using '{self.config.downscale_rounding_mode}' rounding mode now?",
+                    default=False,
+                    console=CONSOLE,
+                ):
                     # Install the method
                     self._downscale_images(
                         image_filenames,

--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -507,7 +507,7 @@ class ColmapDataParser(DataParser):
         if self._downscale_factor is None:
             if self.config.downscale_factor is None:
                 test_img = Image.open(filepath)
-                h, w = test_img.size
+                w, h = test_img.size
                 max_res = max(h, w)
                 df = 0
                 while True:

--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -56,6 +56,8 @@ class ColmapDataParserConfig(DataParserConfig):
     """How much to scale the camera origins by."""
     downscale_factor: Optional[int] = None
     """How much to downscale images. If not set, images are chosen such that the max dimension is <1600px."""
+    downscale_rounding_mode: Literal["floor", "ceil"] = "floor"
+    """How to round downscale image height and Image width."""
     scene_scale: float = 1.0
     """How much to scale the region of interest by."""
     orientation_method: Literal["pca", "up", "vertical", "none"] = "up"
@@ -355,7 +357,9 @@ class ColmapDataParser(DataParser):
             camera_type=camera_type,
         )
 
-        cameras.rescale_output_resolution(scaling_factor=1.0 / downscale_factor)
+        cameras.rescale_output_resolution(
+            scaling_factor=1.0 / downscale_factor, scale_rounding_mode=self.config.downscale_rounding_mode
+        )
 
         if "applied_transform" in meta:
             applied_transform = torch.tensor(meta["applied_transform"], dtype=transform_matrix.dtype)

--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import math
 import sys
 from dataclasses import dataclass, field
 from functools import partial
@@ -56,7 +57,7 @@ class ColmapDataParserConfig(DataParserConfig):
     """How much to scale the camera origins by."""
     downscale_factor: Optional[int] = None
     """How much to downscale images. If not set, images are chosen such that the max dimension is <1600px."""
-    downscale_rounding_mode: Literal["floor", "ceil"] = "floor"
+    downscale_rounding_mode: Literal["floor", "round", "ceil"] = "floor"
     """How to round downscale image height and Image width."""
     scene_scale: float = 1.0
     """How much to scale the region of interest by."""
@@ -456,10 +457,24 @@ class ColmapDataParser(DataParser):
             out["points3D_points2D_xy"] = torch.stack(points3D_image_xy, dim=0)
         return out
 
-    def _downscale_images(self, paths, get_fname, downscale_factor: int, nearest_neighbor: bool = False):
+    def _downscale_images(self, paths, get_fname, downscale_factor: int, downscale_rounding_mode: str = "floor",nearest_neighbor: bool = False):
+        def calculate_scaled_size(original_width, original_height, downscale_factor, mode='floor'):
+            if mode == 'floor':
+                return math.floor(original_width / downscale_factor), math.floor(original_height / downscale_factor)
+            elif mode == 'round':
+                return round(original_width / downscale_factor), round(original_height / downscale_factor)
+            elif mode == 'ceil':
+                return math.ceil(original_width / downscale_factor), math.ceil(original_height / downscale_factor)
+            else:
+                raise ValueError("Invalid mode. Choose from 'floor', 'round', or 'ceil'.")
+
         with status(msg="[bold yellow]Downscaling images...", spinner="growVertical"):
             assert downscale_factor > 1
             assert isinstance(downscale_factor, int)
+            filepath = next(iter(paths))
+            img = Image.open(filepath)
+            w,h = img.size
+            w_scaled, h_scaled = calculate_scaled_size(w, h, downscale_factor, downscale_rounding_mode)
             # Using %05d ffmpeg commands appears to be unreliable (skips images).
             for path in paths:
                 nn_flag = "" if not nearest_neighbor else ":flags=neighbor"
@@ -467,7 +482,7 @@ class ColmapDataParser(DataParser):
                 path_out.parent.mkdir(parents=True, exist_ok=True)
                 ffmpeg_cmd = [
                     f'ffmpeg -y -noautorotate -i "{path}" ',
-                    f"-q:v 2 -vf scale=iw/{downscale_factor}:ih/{downscale_factor}{nn_flag} ",
+                    f"-q:v 2 -vf scale={w_scaled}:{h_scaled}{nn_flag} ",
                     f'"{path_out}"',
                 ]
                 ffmpeg_cmd = " ".join(ffmpeg_cmd)
@@ -512,12 +527,13 @@ class ColmapDataParser(DataParser):
                 CONSOLE.print(
                     f"[bold red]Downscaled images do not exist for factor of {self._downscale_factor}.[/bold red]"
                 )
-                if Confirm.ask("\nWould you like to downscale the images now?", default=False, console=CONSOLE):
+                if Confirm.ask(f"\nWould you like to downscale the images using '{self.config.downscale_rounding_mode}' rounding mode now?", default=False, console=CONSOLE):
                     # Install the method
                     self._downscale_images(
                         image_filenames,
                         partial(get_fname, self.config.data / self.config.images_path),
                         self._downscale_factor,
+                        self.config.downscale_rounding_mode,
                         nearest_neighbor=False,
                     )
                     if len(mask_filenames) > 0:
@@ -526,6 +542,7 @@ class ColmapDataParser(DataParser):
                             mask_filenames,
                             partial(get_fname, self.config.data / self.config.masks_path),
                             self._downscale_factor,
+                            self.config.downscale_rounding_mode,
                             nearest_neighbor=True,
                         )
                     if len(depth_filenames) > 0:
@@ -534,6 +551,7 @@ class ColmapDataParser(DataParser):
                             depth_filenames,
                             partial(get_fname, self.config.data / self.config.depths_path),
                             self._downscale_factor,
+                            self.config.downscale_rounding_mode,
                             nearest_neighbor=True,
                         )
                 else:


### PR DESCRIPTION
In order to be compatible with the original format of the 360_v2 dataset without reprocessing it, I added an option to colmapDataParser to round up the image size when downscaling. This may change the image height and width in the camera.
But I'm not sure if it will have any negative impact on other parts?  If so, please let me know. Thank you!