### PR TITLE
fix: pixelated downscaled images

### DIFF
--- a/nerfstudio/process_data/process_data_utils.py
+++ b/nerfstudio/process_data/process_data_utils.py
@@ -302,7 +302,7 @@ def copy_images_list(
     # (Unfortunately, that is much slower.)
     for framenum in range(1, (1 if same_dimensions else num_frames) + 1):
         framename = f"{image_prefix}%05d" if same_dimensions else f"{image_prefix}{framenum:05d}"
-        ffmpeg_cmd = f'ffmpeg -y -noautorotate -i "{image_dir / f"{framename}{copied_image_paths[0].suffix}"}" -q:v 2 '
+        ffmpeg_cmd = f'ffmpeg -y -noautorotate -i "{image_dir / f"{framename}{copied_image_paths[0].suffix}"}" '
 
         crop_cmd = ""
         if crop_border_pixels is not None:
@@ -320,7 +320,7 @@ def copy_images_list(
 
         downscale_cmd = f' -filter_complex "{select_cmd}{crop_cmd}{downscale_chain}"' + "".join(
             [
-                f' -map "[out{i}]" "{downscale_dirs[i] / f"{framename}{copied_image_paths[0].suffix}"}"'
+                f' -map "[out{i}]" -q:v 2 "{downscale_dirs[i] / f"{framename}{copied_image_paths[0].suffix}"}"'
                 for i in range(num_downscales + 1)
             ]
         )


### PR DESCRIPTION
`ns-process-data` produces pixelated downscaled images.
Original:
![10_DSC0091](https://github.com/nerfstudio-project/nerfstudio/assets/5800038/eb2eb38e-4e73-493c-8bc9-a14b97f5b6f5)
![10_DSC0145](https://github.com/nerfstudio-project/nerfstudio/assets/5800038/d6997c39-5ea4-470b-b4cd-f90b6455d3c1)
Downscale by a factor of 2:
![frame_00011](https://github.com/nerfstudio-project/nerfstudio/assets/5800038/ea14e0ee-2b24-4829-bc5c-d89175de1066)
![frame_00017](https://github.com/nerfstudio-project/nerfstudio/assets/5800038/a5598150-3b8d-43d9-8854-0843e20abcb7)
The current implementation only applies `-q:v 2` to the original images. Placing `-q:v 2` before all the outputs fixes the issue.
Downscale by a factor of 2:
![frame_00011](https://github.com/nerfstudio-project/nerfstudio/assets/5800038/8403bed9-f48d-433c-8858-8e05d9e2a2c4)
![frame_00017](https://github.com/nerfstudio-project/nerfstudio/assets/5800038/d9afc941-5589-4ec1-b68a-77b1c26e1b09)
