### PR TITLE
Add default depth output when no gaussians visible

### DIFF
--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -667,7 +667,11 @@ class SplatfactoModel(Model):
         if self.crop_box is not None and not self.training:
             crop_ids = self.crop_box.within(self.means).squeeze()
             if crop_ids.sum() == 0:
-                return {"rgb": background.repeat(int(camera.height.item()), int(camera.width.item()), 1)}
+                return {
+                    "rgb": background.repeat(int(camera.height.item()), int(camera.width.item()), 1),
+                    "depth": torch.ones(int(camera.height.item()), int(camera.width.item()), 1) * 10,
+                    "accumulation": torch.zeros(int(camera.height.item()), int(camera.width.item()), 1),
+                }
         else:
             crop_ids = None
         camera_downscale = self._get_downscale_factor()
@@ -735,6 +739,7 @@ class SplatfactoModel(Model):
             return {
                 "rgb": background.repeat(int(camera.height.item()), int(camera.width.item()), 1),
                 "depth": torch.ones(int(camera.height.item()), int(camera.width.item()), 1) * 10,
+                "accumulation": torch.zeros(int(camera.height.item()), int(camera.width.item()), 1),
             }
 
         # Important to allow xys grads to populate properly

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -732,7 +732,10 @@ class SplatfactoModel(Model):
             tile_bounds,
         )  # type: ignore
         if (self.radii).sum() == 0:
-            return {"rgb": background.repeat(int(camera.height.item()), int(camera.width.item()), 1)}
+            return {
+                "rgb": background.repeat(int(camera.height.item()), int(camera.width.item()), 1),
+                "depth": torch.ones(int(camera.height.item()), int(camera.width.item()), 1) * 10,
+            }
 
         # Important to allow xys grads to populate properly
         if self.training:

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -669,11 +669,10 @@ class SplatfactoModel(Model):
         if self.crop_box is not None and not self.training:
             crop_ids = self.crop_box.within(self.means).squeeze()
             if crop_ids.sum() == 0:
-                return {
-                    "rgb": background.repeat(int(camera.height.item()), int(camera.width.item()), 1),
-                    "depth": torch.ones(int(camera.height.item()), int(camera.width.item()), 1) * 10,
-                    "accumulation": torch.zeros(int(camera.height.item()), int(camera.width.item()), 1),
-                }
+                rgb = background.repeat(int(camera.height.item()), int(camera.width.item()), 1)
+                depth = background.new_ones(*rgb.shape[:2], 1) * 10
+                accumulation = background.new_zeros(*rgb.shape[:2], 1)
+                return {"rgb": rgb, "depth": depth, "accumulation": accumulation}
         else:
             crop_ids = None
         camera_downscale = self._get_downscale_factor()
@@ -738,11 +737,10 @@ class SplatfactoModel(Model):
             tile_bounds,
         )  # type: ignore
         if (self.radii).sum() == 0:
-            return {
-                "rgb": background.repeat(int(camera.height.item()), int(camera.width.item()), 1),
-                "depth": torch.ones(int(camera.height.item()), int(camera.width.item()), 1) * 10,
-                "accumulation": torch.zeros(int(camera.height.item()), int(camera.width.item()), 1),
-            }
+            rgb = background.repeat(int(camera.height.item()), int(camera.width.item()), 1)
+            depth = background.new_ones(*rgb.shape[:2], 1) * 10
+            accumulation = background.new_zeros(*rgb.shape[:2], 1)
+            return {"rgb": rgb, "depth": depth, "accumulation": accumulation}
 
         # Important to allow xys grads to populate properly
         if self.training:


### PR DESCRIPTION
There should be a default `"depth"` value returned alongside `"rgb"`, or the renderer may crash if there is no gaussians in the front.

More specifically, L173 and L189 will currently crash in nerfstudio if `"depth"` is undefined:
https://github.com/nerfstudio-project/nerfstudio/blob/52cda21186a9a50b29e7480d3dec20b5b15323d3/nerfstudio/viewer/render_state_machine.py#L170-L191