### PR TITLE
Remove useless call to .with_suffix(""), which causes a bug if filename contains dots

### DIFF
--- a/nerfstudio/scripts/render.py
+++ b/nerfstudio/scripts/render.py
@@ -804,9 +804,7 @@ class DatasetRender(BaseRender):
                         image_name = f"{camera_idx:05d}"
 
                         # Try to get the original filename
-                        image_name = (
-                            dataparser_outputs.image_filenames[camera_idx].relative_to(images_root)
-                        )
+                        image_name = dataparser_outputs.image_filenames[camera_idx].relative_to(images_root)
 
                         output_path = self.output_path / split / rendered_output_name / image_name
                         output_path.parent.mkdir(exist_ok=True, parents=True)

--- a/nerfstudio/scripts/render.py
+++ b/nerfstudio/scripts/render.py
@@ -805,7 +805,7 @@ class DatasetRender(BaseRender):
 
                         # Try to get the original filename
                         image_name = (
-                            dataparser_outputs.image_filenames[camera_idx].with_suffix("").relative_to(images_root)
+                            dataparser_outputs.image_filenames[camera_idx].relative_to(images_root)
                         )
 
                         output_path = self.output_path / split / rendered_output_name / image_name


### PR DESCRIPTION
Fixes https://github.com/nerfstudio-project/nerfstudio/issues/2881