### PR TITLE
Update process_data.py to accomodate ns-process-data splatfacto

### DIFF
--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -51,7 +51,7 @@ class ProcessRecord3D(BaseConverterToNerfstudioDataset):
 
     This script does the following:
 
-    1. Scales images to a specified snum_downscalesize.
+    1. Scales images to a specified size.
     2. Converts Record3D poses into the nerfstudio format.
     """
 

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -504,7 +504,7 @@ class ProcessSplatfacto(BaseConverterToNerfstudioDataset):
             if self.eval_data is not None:
                 raise ValueError("Cannot use eval_data since cameras were already aligned with it.")
 
-            if skip_matching==False:
+            if self.skip_matching==False:
                 os.makedirs(output_path + "/distorted/sparse", exist_ok=True)
 
                 ## Feature extraction

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -578,7 +578,7 @@ class ProcessSplatfacto(BaseConverterToNerfstudioDataset):
             
                         # Resize the image to half of its original resolution
                         height, width = img.shape[:2]
-                        resized_img = cv2.resize(img, (int(width * 1/factor), int(height * 0.5)))
+                        resized_img = cv2.resize(img, (int(width * 1/factor), int(height * 1/factor)))
             
                         # Write the resized image to the output folder
                         output_path = os.path.join(output_folder, file)

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -484,7 +484,7 @@ class ProcessODM(BaseConverterToNerfstudioDataset):
 
 @dataclass
 class ProcessSplatfacto(BaseConverterToNerfstudioDataset):
-        resize:bool = False
+        resize:bool = True
         """If true, it will downscale the images by 2x, 4x, and 8x. It useful if you run ns-train splatfacto with
         extra argument --downscale-factor of 2, 4, or 8"""
         use_gpu:bool = True

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -39,6 +39,7 @@ from nerfstudio.process_data import (
     realitycapture_utils,
     record3d_utils,
 )
+
 from nerfstudio.process_data.colmap_converter_to_nerfstudio_dataset import BaseConverterToNerfstudioDataset
 from nerfstudio.process_data.images_to_nerfstudio_dataset import ImagesToNerfstudioDataset
 from nerfstudio.process_data.video_to_nerfstudio_dataset import VideoToNerfstudioDataset

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -32,6 +32,7 @@ import cv2
 from typing_extensions import Annotated
 
 from nerfstudio.process_data import (
+    colmap_utils,
     metashape_utils,
     odm_utils,
     polycam_utils,
@@ -44,8 +45,6 @@ from nerfstudio.process_data.colmap_converter_to_nerfstudio_dataset import BaseC
 from nerfstudio.process_data.images_to_nerfstudio_dataset import ImagesToNerfstudioDataset
 from nerfstudio.process_data.video_to_nerfstudio_dataset import VideoToNerfstudioDataset
 from nerfstudio.utils.rich_utils import CONSOLE
-from nerfstudio.process_data import colmap_utils
-
 
 @dataclass
 class ProcessRecord3D(BaseConverterToNerfstudioDataset):


### PR DESCRIPTION
### **Why add this `ns-process-data splatfacto`?**
It mimics `python3 convert.py -s /path/to/input/folder` from Original Inria 3DGS

### **What is special things about `python3 convert.py`?**
1. original `ns-process-data images` make "images" in output folder become smaller despite has same resolution, it hurts quality.
2. It uses `exhausive_matcher` instead of `vocab_tree_matcher` in `ns-process-data images`
3. it uses hyperparameter of `ba_global_function_tolerance = 0.000001`
4. It uses `colmap image_undistorter`

### **So what I get if I use that?**
I got extra quality boost, about 0.3 - 1 dB in PSNR evaluation of all images. I tested it on different dataset. 

### you can see my experiment in https://github.com/nerfstudio-project/nerfstudio/issues/2849. I will write my experiment in that threads gradually.

### **What is different between this implementation and `python3 convert.py.`?**
The original convert.py gives result of colmap format which does not have `transforms.json` and `sparse_pc.json`. This implementation creates that files so it compatible with `NerfstudioDataparser`.

Thanks for @jb-ye for give me inspiration of this PR.
