### PR TITLE
Call rescale_output_resolution before early return

### DIFF
--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -751,7 +751,7 @@ class SplatfactoModel(Model):
         camera.rescale_output_resolution(camera_downscale)
 
         if (self.radii).sum() == 0:
-            rgb = background.repeat(int(camera.height.item()), int(camera.width.item()), 1)
+            rgb = background.repeat(H, W, 1)
             depth = background.new_ones(*rgb.shape[:2], 1) * 10
             accumulation = background.new_zeros(*rgb.shape[:2], 1)
 

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -747,13 +747,13 @@ class SplatfactoModel(Model):
             tile_bounds,
         )  # type: ignore
 
+        # rescale the camera back to original dimensions before returning
+        camera.rescale_output_resolution(camera_downscale)
+
         if (self.radii).sum() == 0:
             rgb = background.repeat(int(camera.height.item()), int(camera.width.item()), 1)
             depth = background.new_ones(*rgb.shape[:2], 1) * 10
             accumulation = background.new_zeros(*rgb.shape[:2], 1)
-
-            # rescale the camera back to original dimensions before returning
-            camera.rescale_output_resolution(camera_downscale)
 
             return {"rgb": rgb, "depth": depth, "accumulation": accumulation, "background": background}
 

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -740,6 +740,10 @@ class SplatfactoModel(Model):
             rgb = background.repeat(int(camera.height.item()), int(camera.width.item()), 1)
             depth = background.new_ones(*rgb.shape[:2], 1) * 10
             accumulation = background.new_zeros(*rgb.shape[:2], 1)
+
+            # rescale the camera back to original dimensions before returning
+            camera.rescale_output_resolution(camera_downscale)
+            
             return {"rgb": rgb, "depth": depth, "accumulation": accumulation}
 
         # Important to allow xys grads to populate properly

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -770,8 +770,6 @@ class SplatfactoModel(Model):
         else:
             rgbs = torch.sigmoid(colors_crop[:, 0, :])
 
-        # rescale the camera back to original dimensions
-        camera.rescale_output_resolution(camera_downscale)
         assert (num_tiles_hit > 0).any()  # type: ignore
 
         # apply the compensation of screen space blurring to gaussians

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -743,7 +743,7 @@ class SplatfactoModel(Model):
 
             # rescale the camera back to original dimensions before returning
             camera.rescale_output_resolution(camera_downscale)
-            
+
             return {"rgb": rgb, "depth": depth, "accumulation": accumulation}
 
         # Important to allow xys grads to populate properly


### PR DESCRIPTION
Hello :wave:

While looking through the splatfacto implementation, I noticed that in the case of an early exit in the forward pass due to a zero radii sum the camera does not get rescaled back to its original dimensions. I think this might be a mistake? I haven't found a dataset where the condition occurs, but it seems correct to make sure the camera is rescaled back before returning.
