### PR TITLE
Fix an issue where gradient accumulation could not be passed as argument due to a type error.

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -82,7 +82,7 @@ class TrainerConfig(ExperimentConfig):
     """Path to checkpoint file."""
     log_gradients: bool = False
     """Optionally log gradients during training"""
-    gradient_accumulation_steps: Dict = field(default_factory=lambda: {})
+    gradient_accumulation_steps: Dict[str, int] = field(default_factory=lambda: {})
     """Number of steps to accumulate gradients over. Contains a mapping of {param_group:num}"""
 
 


### PR DESCRIPTION
As discussed on Discord (Thanks Brent), `--gradient-accumulation-steps` did not properly cast its values to int and would error because it received a string.
There is still a separate bug where specifying `camera_opt` on nerfacto will cause an error, and the documentation on the --gradient-accumulation-steps could be better (accepted values are currently `proposal_networks`, `fields` and `camera_opts`, but there's no way to figure this out without without diving into the code AFAICT), but that's for another time/person/PR.