### PR TITLE
Make time slider effective in viewer (Fixes #2928)

### DIFF
--- a/nerfstudio/viewer/render_state_machine.py
+++ b/nerfstudio/viewer/render_state_machine.py
@@ -129,7 +129,10 @@ class RenderStateMachine(threading.Thread):
 
         image_height, image_width = self._calculate_image_res(camera_state.aspect)
 
-        camera = get_camera(camera_state, image_height, image_width)
+        if self.viewer.include_time:
+            camera = get_camera(camera_state, image_height, image_width, self.viewer.control_panel.time)
+        else:
+            camera = get_camera(camera_state, image_height, image_width)
         camera = camera.to(self.viewer.get_model().device)
         assert isinstance(camera, Cameras)
         assert camera is not None, "render called before viewer connected"

--- a/nerfstudio/viewer/utils.py
+++ b/nerfstudio/viewer/utils.py
@@ -42,7 +42,7 @@ class CameraState:
 
 
 def get_camera(
-    camera_state: CameraState, image_height: int, image_width: Optional[Union[int, float]] = None
+    camera_state: CameraState, image_height: int, image_width: Optional[Union[int, float]] = None, time: float = 0.0
 ) -> Cameras:
     """Returns the camera intrinsics matrix and the camera to world homogeneous matrix.
 
@@ -74,7 +74,7 @@ def get_camera(
         cy=pp_h,
         camera_type=camera_state.camera_type,
         camera_to_worlds=camera_state.c2w.to(torch.float32)[None, ...],
-        times=torch.tensor([0.0], dtype=torch.float32),
+        times=torch.tensor([time], dtype=torch.float32),
     )
     return camera
 


### PR DESCRIPTION
This pull request makes the time slider in the Control panel of the viser viewer effective again, for dynamic models.

The Render panel still misses options to set a per-keyframe timestamp, but I will probably do it in a separate PR. This should do the job for now to monitor training.

For those interested, meanwhile, you can use the legacy viewer (`--vis viewer_legacy`) to create camera paths for dynamic scenes.