### PR TITLE
Update project, rasterize with block_width interface

### DIFF
--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -724,7 +724,7 @@ class SplatfactoModel(Model):
             quats_crop = self.quats
 
         colors_crop = torch.cat((features_dc_crop[:, None, :], features_rest_crop), dim=1)
-
+        BLOCK_WIDTH = 16  # this controls the tile size of rasterization, 16 is a good default
         self.xys, depths, self.radii, conics, comp, num_tiles_hit, cov3d = project_gaussians(  # type: ignore
             means_crop,
             torch.exp(scales_crop),
@@ -738,7 +738,7 @@ class SplatfactoModel(Model):
             cy,
             H,
             W,
-            block_width=16,
+            BLOCK_WIDTH,
         )  # type: ignore
 
         # rescale the camera back to original dimensions before returning
@@ -785,7 +785,7 @@ class SplatfactoModel(Model):
             opacities,
             H,
             W,
-            block_width=16,
+            BLOCK_WIDTH,
             background=background,
             return_alpha=True,
         )  # type: ignore
@@ -803,7 +803,7 @@ class SplatfactoModel(Model):
                 torch.sigmoid(opacities_crop),
                 H,
                 W,
-                block_width=16,
+                BLOCK_WIDTH,
                 background=torch.zeros(3, device=self.device),
             )[..., 0:1]  # type: ignore
             depth_im = torch.where(alpha > 0, depth_im / alpha, depth_im.detach().max())

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -707,12 +707,6 @@ class SplatfactoModel(Model):
         W, H = int(camera.width.item()), int(camera.height.item())
         self.last_size = (H, W)
         projmat = projection_matrix(0.001, 1000, fovx, fovy, device=self.device)
-        BLOCK_X, BLOCK_Y = 16, 16
-        tile_bounds = (
-            int((W + BLOCK_X - 1) // BLOCK_X),
-            int((H + BLOCK_Y - 1) // BLOCK_Y),
-            1,
-        )
 
         if crop_ids is not None:
             opacities_crop = self.opacities[crop_ids]
@@ -744,7 +738,7 @@ class SplatfactoModel(Model):
             cy,
             H,
             W,
-            tile_bounds,
+            block_width=16,
         )  # type: ignore
 
         # rescale the camera back to original dimensions before returning
@@ -791,6 +785,7 @@ class SplatfactoModel(Model):
             opacities,
             H,
             W,
+            block_width=16,
             background=background,
             return_alpha=True,
         )  # type: ignore
@@ -808,6 +803,7 @@ class SplatfactoModel(Model):
                 torch.sigmoid(opacities_crop),
                 H,
                 W,
+                block_width=16,
                 background=torch.zeros(3, device=self.device),
             )[..., 0:1]  # type: ignore
             depth_im = torch.where(alpha > 0, depth_im / alpha, depth_im.detach().max())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "xatlas",
     "trimesh>=3.20.2",
     "timm==0.6.7",
-    "gsplat>=0.1.5",
+    "gsplat>=0.1.6",
     "pytorch-msssim",
     "pathos",
     "packaging"


### PR DESCRIPTION
In gsplat==0.1.6, the interface for tile_bounds is replaced by simply specifying a block size.