### PR TITLE
Fix depth-nerfacto edge cases

### DIFF
--- a/nerfstudio/cameras/camera_optimizers.py
+++ b/nerfstudio/cameras/camera_optimizers.py
@@ -157,7 +157,7 @@ class CameraOptimizer(nn.Module):
             assert camera.metadata is not None, "Must provide id of camera in its metadata"
             assert "cam_idx" in camera.metadata, "Must provide id of camera in its metadata"
             camera_idx = camera.metadata["cam_idx"]
-            adj = self([camera_idx])  # type: ignore
+            adj = self(torch.tensor([camera_idx], dtype=torch.long, device=camera.device))  # type: ignore
             adj = torch.cat([adj, torch.Tensor([0, 0, 0, 1])[None, None].to(adj)], dim=1)
             camera.camera_to_worlds = torch.bmm(camera.camera_to_worlds, adj)
 

--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -317,7 +317,7 @@ class PixelSampler:
 
         c, y, x = (i.flatten() for i in torch.split(indices, 1, dim=-1))
         collated_batch = {
-            key: value[c][y, x]
+            key: value[c, y, x]
             for key, value in batch.items()
             if key != "image_idx" and key != "image" and key != "mask" and key != "depth_image" and value is not None
         }

--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -302,10 +302,11 @@ class PixelSampler:
         all_images = []
         all_depth_images = []
 
+        num_rays_in_batch = num_rays_per_batch // num_images
+        if num_rays_in_batch % 2 != 0:
+            num_rays_in_batch += 1
+
         if "mask" in batch:
-            num_rays_in_batch = num_rays_per_batch // num_images
-            if num_rays_in_batch % 2 != 0:
-                num_rays_in_batch += 1
             for i in range(num_images):
                 image_height, image_width, _ = batch["image"][i].shape
 
@@ -322,9 +323,6 @@ class PixelSampler:
                     all_depth_images.append(batch["depth_image"][i][indices[:, 1], indices[:, 2]])
 
         else:
-            num_rays_in_batch = num_rays_per_batch // num_images
-            if num_rays_in_batch % 2 != 0:
-                num_rays_in_batch += 1
             for i in range(num_images):
                 image_height, image_width, _ = batch["image"][i].shape
                 if i == num_images - 1:


### PR DESCRIPTION
Depth nerfacto doesn't work unless num_rays_in_batch is divisible by 2. Also, the depth images are in a list and not just a batch tensor, so I think the changes I made are needed.