### PR TITLE
Fix fisheye sampling to valid coordinates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
   "typescript.suggestionActions.enabled": false,
   "javascript.suggestionActions.enabled": false,
   "[python]": {
-    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit",
       "source.fixAll": "explicit"

--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -190,8 +190,16 @@ class PixelSampler:
             # Multiply by the batch size and height/width to get pixel indices.
             indices = torch.floor(
                 torch.stack([rand_samples[:, 0], y, x], dim=1)
-                * torch.tensor([num_images, image_height // 2, image_width // 2], device=device)
                 + torch.tensor([0, image_height // 2, image_width // 2], device=device)
+            ).long()
+
+            # Clamp the values of indices tensor to be within image bounds.
+            indices = torch.clamp(
+                indices,
+                min=torch.zeros(3, device=device),
+                max=torch.tensor(
+                    [num_images, image_height - 1, image_width - 1], device=device
+                ),
             ).long()
 
         return indices


### PR DESCRIPTION
I guess during a bug fix the exported "fisheye crop radius" changed from a 0 to 1 value to a pixel value, and so we no longer need to multiply by half the image size. Using a clamp here to ensure no values go out of bounds as well