### PR TITLE
Upgrade to latest nbformat 5.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ docs = [
     "readthedocs-sphinx-search==0.1.2",
     "myst-nb==0.16.0",
     "nbconvert==7.2.5",
-    "nbformat==5.5.0",
+    "nbformat==5.9.2",
     "sphinx==5.2.1",
     "sphinxemoji==0.2.0",
     "sphinx-argparse==0.3.1",


### PR DESCRIPTION
When I try to run:

```console
$ pip install -e .[gen,dev,docs]
...
ERROR: Cannot install None, nerfstudio[dev,docs,gen]==1.0.2 and open3d==0.18.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    nerfstudio[dev,docs,gen] 1.0.2 depends on nbformat==5.5.0; extra == "docs"
    myst-nb 0.16.0 depends on nbformat~=5.0
    nbconvert 7.2.5 depends on nbformat>=5.1
    open3d 0.18.0 depends on nbformat>=5.7.0
```

This gets fixed by upgrading to the latest `nbformat`: https://pypi.org/project/nbformat/5.9.2/#history