### PR TITLE
fix bug that opacity compentation not being applied to depth raterization

### DIFF
--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -811,7 +811,7 @@ class SplatfactoModel(Model):
                 conics,
                 num_tiles_hit,  # type: ignore
                 depths[:, None].repeat(1, 3),
-                torch.sigmoid(opacities_crop),
+                opacities,
                 H,
                 W,
                 BLOCK_WIDTH,


### PR DESCRIPTION
fix bug that opacity compentation has not being applied to depth raterization, found from @jb-ye 's new rasterization mode implementation pr

https://github.com/nerfstudio-project/nerfstudio/pull/2888#issuecomment-1961824489