### PR TITLE
doc: fix code typo in 'NeRF' method doc

### DIFF
--- a/docs/nerfology/methods/nerf.md
+++ b/docs/nerfology/methods/nerf.md
@@ -115,7 +115,7 @@ Rending RGB images is not the only type of output render supported. It is possib
 Associated nerfstudio code:
 
 ```python
-from nerfstudio.renderers.renderers import RGBRenderer
+from nerfstudio.model_components.renderers import RGBRenderer
 
 renderer_rgb = RGBRenderer(background_color=colors.WHITE)
 # Ray samples discussed in the next section


### PR DESCRIPTION
In NeRF methods doc, old code component was found. So just fix this small typo issue.

Current one:
```python
from nerfstudio.renderers.renderers import RGBRenderer
```

Correct one:
```python
from nerfstudio.model_components.renderers import RGBRenderer
```

Thanks for reviewing!