### PR TITLE
Handle alpha images properly for instant-ngp and tensorf models

### DIFF
--- a/nerfstudio/models/instant_ngp.py
+++ b/nerfstudio/models/instant_ngp.py
@@ -223,7 +223,7 @@ class NGPModel(Model):
         return metrics_dict
 
     def get_loss_dict(self, outputs, batch, metrics_dict=None):
-        image = batch["image"][..., :3].to(self.device)
+        image = batch["image"].to(self.device)
         pred_rgb, image = self.renderer_rgb.blend_background_for_loss_computation(
             pred_image=outputs["rgb"],
             pred_accumulation=outputs["accumulation"],

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -308,7 +308,7 @@ class TensoRFModel(Model):
     def get_loss_dict(self, outputs, batch, metrics_dict=None) -> Dict[str, torch.Tensor]:
         # Scaling metrics by coefficients to create the losses.
         device = outputs["rgb"].device
-        image = batch["image"][..., :3].to(device)
+        image = batch["image"].to(device)
         pred_image, image = self.renderer_rgb.blend_background_for_loss_computation(
             pred_image=outputs["rgb"],
             pred_accumulation=outputs["accumulation"],


### PR DESCRIPTION
instant-ngp and tensorf models are currently not handling training on transparent images properly as other models do, resulting in worse performance on synthetic datasets.

Currently, the alpha channel is simply being removed which prevents proper handling of background rendering which `blend_background_for_loss_computation` is supposed to handle for support of rendering random background color during training etc.

This PR just changes the code to pass the full image to be consistent with other models: 
https://github.com/nerfstudio-project/nerfstudio/blob/3a4ed804d3abe1565ccd521247a2724b68ee28e2/nerfstudio/models/nerfacto.py#L365
https://github.com/nerfstudio-project/nerfstudio/blob/3a4ed804d3abe1565ccd521247a2724b68ee28e2/nerfstudio/models/mipnerf.py#L145