### PR TITLE
Fix: Masks having wrong dimension after undistortion (causes crash in splatfacto)

### DIFF
--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -27,20 +27,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import (
-    Dict,
-    ForwardRef,
-    Generic,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-)
+from typing import Dict, ForwardRef, Generic, List, Literal, Optional, Tuple, Type, Union, cast, get_args, get_origin
 
 import cv2
 import numpy as np
@@ -48,17 +35,10 @@ import torch
 from rich.progress import track
 from torch.nn import Parameter
 
-from nerfstudio.cameras.camera_utils import (
-    fisheye624_project,
-    fisheye624_unproject_helper,
-)
+from nerfstudio.cameras.camera_utils import fisheye624_project, fisheye624_unproject_helper
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.configs.dataparser_configs import AnnotatedDataParserUnion
-from nerfstudio.data.datamanagers.base_datamanager import (
-    DataManager,
-    DataManagerConfig,
-    TDataset,
-)
+from nerfstudio.data.datamanagers.base_datamanager import DataManager, DataManagerConfig, TDataset
 from nerfstudio.data.dataparsers.base_dataparser import DataparserOutputs
 from nerfstudio.data.dataparsers.nerfstudio_dataparser import NerfstudioDataParserConfig
 from nerfstudio.data.datasets.base_dataset import InputDataset

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -27,7 +27,20 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
-from typing import Dict, ForwardRef, Generic, List, Literal, Optional, Tuple, Type, Union, cast, get_args, get_origin
+from typing import (
+    Dict,
+    ForwardRef,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
 
 import cv2
 import numpy as np
@@ -35,10 +48,17 @@ import torch
 from rich.progress import track
 from torch.nn import Parameter
 
-from nerfstudio.cameras.camera_utils import fisheye624_project, fisheye624_unproject_helper
+from nerfstudio.cameras.camera_utils import (
+    fisheye624_project,
+    fisheye624_unproject_helper,
+)
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.configs.dataparser_configs import AnnotatedDataParserUnion
-from nerfstudio.data.datamanagers.base_datamanager import DataManager, DataManagerConfig, TDataset
+from nerfstudio.data.datamanagers.base_datamanager import (
+    DataManager,
+    DataManagerConfig,
+    TDataset,
+)
 from nerfstudio.data.dataparsers.base_dataparser import DataparserOutputs
 from nerfstudio.data.dataparsers.nerfstudio_dataparser import NerfstudioDataParserConfig
 from nerfstudio.data.datasets.base_dataset import InputDataset
@@ -387,6 +407,8 @@ def _undistort_image(
                 mask = cv2.undistort(mask, K, distortion_params, None, newK)  # type: ignore
             mask = mask[y : y + h, x : x + w]
             mask = torch.from_numpy(mask).bool()
+            if len(mask.shape) == 2:
+                mask = mask[:, :, None]
         K = newK
 
     elif camera.camera_type.item() == CameraType.FISHEYE.value:
@@ -406,6 +428,8 @@ def _undistort_image(
             mask = mask.astype(np.uint8) * 255
             mask = cv2.fisheye.undistortImage(mask, K, distortion_params, None, newK)
             mask = torch.from_numpy(mask).bool()
+            if len(mask.shape) == 2:
+                mask = mask[:, :, None]
         K = newK
     elif camera.camera_type.item() == CameraType.FISHEYE624.value:
         fisheye624_params = torch.cat(
@@ -498,6 +522,8 @@ def _undistort_image(
             )
             / 255.0
         ).bool()[..., None]
+        if len(mask.shape) == 2:
+            mask = mask[:, :, None]
         assert mask.shape == (undist_h, undist_w, 1)
         K = undist_K.numpy()
     else:


### PR DESCRIPTION
I noticed that masks in splatfacto are not working after undistortion. I get an error when masks are applied in the full images datamanager in line 881 (gt_img = gt_img * mask) as the shapes are (w, h, 3) and (w, h), however they need to be (w, h, 3) and (w, h, 1).
![image](https://github.com/nerfstudio-project/nerfstudio/assets/18286310/46b339c9-7017-4c64-8fab-ed864e9e2ccc)

The resulting Error is: RuntimeError: The size of tensor a (3) must match the size of tensor b (3839) at non-singleton dimension 2
terminate called without an active exception

Please note that this issue is not present in nerfacto. Also it does not appear when using undistorted images (k- and p-params all 0)

I fixed it by adding the third dimension after undistortion. Tested both splatfacto and nerfacto as well, seems to be fixed to me.