### PR TITLE
Fix rotation_matrix for opposite float32 vectors

### DIFF
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -446,7 +446,7 @@ def radial_and_tangential_undistort(
     return torch.stack([x, y], dim=-1)
 
 
-def rotation_matrix(a: Float[Tensor, "3"], b: Float[Tensor, "3"]) -> Float[Tensor, "3 3"]:
+def rotation_matrix_between(a: Float[Tensor, "3"], b: Float[Tensor, "3"]) -> Float[Tensor, "3 3"]:
     """Compute the rotation matrix that rotates vector a to vector b.
 
     Args:
@@ -614,7 +614,7 @@ def auto_orient_and_center_poses(
                 # re-normalize
                 up = up / torch.linalg.norm(up)
 
-        rotation = rotation_matrix(up, torch.Tensor([0, 0, 1]))
+        rotation = rotation_matrix_between(up, torch.Tensor([0, 0, 1]))
         transform = torch.cat([rotation, rotation @ -translation[..., None]], dim=-1)
         oriented_poses = transform @ poses
     elif method == "none":


### PR DESCRIPTION
When tensors a and b are float32, the condition c < -1 + 1e-8 will never be triggered because of round off tolerance being too small. Also I use a more principled implementation for computing the rotation matrix when a, b are opposite. 

Test cases:

```
a=torch.rand(3, dtype=torch.float32)
b=-a
error=torch.norm(rotation_matrix(a, b) @ a[..., None] - b[..., None])
```