### PR TITLE
Support rectangle selection in viewer

### DIFF
--- a/nerfstudio/viewer/viewer_elements.py
+++ b/nerfstudio/viewer/viewer_elements.py
@@ -18,10 +18,10 @@
 
 from __future__ import annotations
 
-import warnings
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Generic, List, Literal, Optional, Tuple, Union
+import warnings
 
 import numpy as np
 import torch
@@ -172,13 +172,14 @@ class ViewerControl:
         """
         Add a callback which will be called when a scene pointer event is detected in the viewer.
         Scene pointer events include:
-         - "click": A click event, which includes the origin and direction of the click
-         - "rect-select": A rectangle selection event, which includes the screen bounds of the box selection
+        - "click": A click event, which includes the origin and direction of the click
+        - "rect-select": A rectangle selection event, which includes the screen bounds of the box selection
+
+        The callback should take a ViewerClick object as an argument if the event type is "click",
+        and a ViewerRectSelect object as an argument if the event type is "rect-select".
 
         Args:
             cb: The callback to call when a click or a rect-select is detected.
-                The callback should take a ViewerClick object as an argument if the event type is "click",
-                and a ViewerRectSelect object as an argument if the event type is "rect-select".
         """
         from nerfstudio.viewer.viewer import VISER_NERFSTUDIO_SCALE_RATIO
 
@@ -209,7 +210,7 @@ class ViewerControl:
             # Register the callback with the viser server.
             self.viser_server.on_scene_pointer(event_type=event_type)(wrapped_cb)
             # If there exists a warning, it's because a callback was overriden.
-            cb_overriden = len(w) > 0
+            cb_overriden = (len(w) > 0)
 
         if cb_overriden:
             warnings.warn(

--- a/nerfstudio/viewer/viewer_elements.py
+++ b/nerfstudio/viewer/viewer_elements.py
@@ -18,10 +18,10 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Generic, List, Literal, Optional, Tuple, Union
-import warnings
 
 import numpy as np
 import torch

--- a/nerfstudio/viewer/viewer_elements.py
+++ b/nerfstudio/viewer/viewer_elements.py
@@ -62,7 +62,7 @@ class ViewerClick:
     in world coordinates
     """
     screen_pos: Tuple[float, float]
-    """The screen position of the click in screen coordinates."""
+    """The screen position of the click in OpenCV screen coordinates, normalized to [0, 1]"""
 
 
 @dataclass

--- a/nerfstudio/viewer/viewer_elements.py
+++ b/nerfstudio/viewer/viewer_elements.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Generic, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Generic, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -36,6 +36,7 @@ from viser import (
 )
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
+from nerfstudio.utils.rich_utils import CONSOLE
 from nerfstudio.viewer.utils import CameraState, get_camera
 
 if TYPE_CHECKING:
@@ -60,16 +61,29 @@ class ViewerClick:
     The direction of the click if projected from the camera through the clicked pixel,
     in world coordinates
     """
+    screen_pos: Tuple[float, float]
+    """The screen position of the click in screen coordinates."""
+
+
+@dataclass
+class ViewerRectSelect:
+    """
+    Class representing a rectangle selection in the viewer (screen-space).
+
+    The screen coordinates follow OpenCV image coordinates, with the origin at the top-left corner,
+    but the bounds are also normalized to [0, 1] in both dimensions.
+    """
+
+    min_bounds: Tuple[float, float]
+    """The minimum bounds of the rectangle selection in screen coordinates."""
+    max_bounds: Tuple[float, float]
+    """The maximum bounds of the rectangle selection in screen coordinates."""
 
 
 class ViewerControl:
     """
     class for exposing non-gui controls of the viewer to the user
     """
-
-    def __init__(self):
-        # this should be a user-facing constructor, since it will be used inside the model/pipeline class
-        self._click_cbs = {}
 
     def _setup(self, viewer: Viewer):
         """
@@ -147,42 +161,72 @@ class ViewerControl:
         return get_camera(camera_state, img_height, img_width)
 
     def register_click_cb(self, cb: Callable):
+        """Deprecated, use register_pointer_cb instead."""
+        CONSOLE.log("`register_click_cb` is deprecated, use `register_pointer_cb` instead.")
+        self.register_pointer_cb("click", cb)
+
+    def register_pointer_cb(
+        self, event_type: Literal["click", "rect-select"], cb: Callable, done_cb: Optional[Callable] = None
+    ):
         """
-        Add a callback which will be called when a click is detected in the viewer.
+        Add a callback which will be called when a scene pointer event is detected in the viewer.
+        Scene pointer events include:
+         - "click": A click event, which includes the origin and direction of the click
+         - "rect-select": A rectangle selection event, which includes the screen bounds of the box selection
 
         Args:
-            cb: The callback to call when a click is detected.
-                The callback should take a ViewerClick object as an argument
+            cb: The callback to call when a click or a rect-select is detected.
+                The callback should take a ViewerClick object as an argument if the event type is "click",
+                and a ViewerRectSelect object as an argument if the event type is "rect-select".
         """
         from nerfstudio.viewer.viewer import VISER_NERFSTUDIO_SCALE_RATIO
 
         def wrapped_cb(scene_pointer_msg: ScenePointerEvent):
-            # only call the callback if the event is a click
-            if scene_pointer_msg.event != "click":
-                return
-            origin = scene_pointer_msg.ray_origin
-            direction = scene_pointer_msg.ray_direction
+            # Check that the event type is the same as the one we are interested in.
+            if scene_pointer_msg.event_type != event_type:
+                raise ValueError(f"Expected event type {event_type}, got {scene_pointer_msg.event_type}")
 
-            origin = tuple([x / VISER_NERFSTUDIO_SCALE_RATIO for x in origin])
-            assert len(origin) == 3
+            if scene_pointer_msg.event_type == "click":
+                origin = scene_pointer_msg.ray_origin
+                direction = scene_pointer_msg.ray_direction
+                screen_pos = scene_pointer_msg.screen_pos[0]
+                assert (origin is not None) and (
+                    direction is not None
+                ), "Origin and direction should not be None for click event."
+                origin = tuple([x / VISER_NERFSTUDIO_SCALE_RATIO for x in origin])
+                assert len(origin) == 3
+                pointer_event = ViewerClick(origin, direction, screen_pos)
+            elif scene_pointer_msg.event_type == "rect-select":
+                pointer_event = ViewerRectSelect(scene_pointer_msg.screen_pos[0], scene_pointer_msg.screen_pos[1])
+            else:
+                raise ValueError(f"Unknown event type: {scene_pointer_msg.event_type}")
 
-            click = ViewerClick(origin, direction)
-            cb(click)
+            cb(pointer_event)
 
-        self._click_cbs[cb] = wrapped_cb
-        self.viser_server.on_scene_click(wrapped_cb)
+        # Register the callback with the viser server.
+        self.viser_server.on_scene_pointer(event_type=event_type)(wrapped_cb)
 
-    def unregister_click_cb(self, cb: Callable):
+        # If there exists a cleanup callback after the pointer event is done, register it.
+        if done_cb:
+            self.viser_server.on_scene_pointer_done(done_cb)
+
+    def unregister_click_cb(self, cb: Optional[Callable] = None):
+        """Deprecated, use unregister_pointer_cb instead. `cb` is ignored."""
+        CONSOLE.log("`unregister_click_cb` is deprecated, use `unregister_pointer_cb` instead.")
+        if cb is not None:
+            # raise warning
+            CONSOLE.log("cb argument is ignored in unregister_click_cb.")
+
+        self.unregister_pointer_cb()
+
+    def unregister_pointer_cb(self):
         """
-        Remove a callback which will be called when a click is detected in the viewer.
+        Remove a callback which will be called, when a scene pointer event is detected in the viewer.
 
         Args:
             cb: The callback to remove
         """
-        if cb not in self._click_cbs:
-            raise ValueError(f"Callback {cb} not registered, cannot remove")
-        self.viser_server.remove_scene_click_callback(self._click_cbs[cb])
-        self._click_cbs.pop(cb)
+        self.viser_server.remove_scene_pointer_callback()
 
     @property
     def server(self):

--- a/nerfstudio/viewer/viewer_elements.py
+++ b/nerfstudio/viewer/viewer_elements.py
@@ -210,7 +210,7 @@ class ViewerControl:
             # Register the callback with the viser server.
             self.viser_server.on_scene_pointer(event_type=event_type)(wrapped_cb)
             # If there exists a warning, it's because a callback was overriden.
-            cb_overriden = (len(w) > 0)
+            cb_overriden = len(w) > 0
 
         if cb_overriden:
             warnings.warn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "torchvision>=0.14.1",
     "torchmetrics[image]>=1.0.1",
     "typing_extensions>=4.4.0",
-    "viser==0.1.21",
+    "viser==0.1.26",
     "nuscenes-devkit>=1.1.1",
     "wandb>=0.13.3",
     "xatlas",


### PR DESCRIPTION
Related to rect-select viser PR, linked here: https://github.com/nerfstudio-project/viser/pull/157. 

This adds `ViewerRectSelect`, a rectangular selection in 2D parameterized by its min/max bounds. This PR also adds `screen_pos` property to `ViewerClick`, the screen position associated with the click.

There's many exciting applications for this -- especially in splatfacto, where we can select groups of gaussians. One example is #3001, for floater removal (@anniezhang2288 :) )

The example video shows both interaction types, clicking and rectangular selection. More specifically, for the rectangular selection, the video shows:
* how gaussians can be selected -- only keeping the gaussians that project inside the selection box.
* ... and what happens if you continue training.


https://github.com/nerfstudio-project/nerfstudio/assets/10284938/6bfdfb99-c318-4cfc-a272-ac76e4aa899f

