### PR TITLE
Fix bug when trying to create a camera path in viewer

### DIFF
--- a/nerfstudio/viewer/render_panel.py
+++ b/nerfstudio/viewer/render_panel.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
-import scipy
+from scipy import interpolate
 import splines
 import splines.quaternion
 import viser
@@ -266,7 +266,7 @@ class CameraPath:
         if self.loop:
             # In the case of a loop, we pad the spline to match the start/end
             # slopes.
-            interpolator = scipy.interpolate.PchipInterpolator(
+            interpolator = interpolate.PchipInterpolator(
                 x=np.concatenate(
                     [
                         [-(transition_times_cumsum[-1] - transition_times_cumsum[-2])],
@@ -278,7 +278,7 @@ class CameraPath:
                 y=np.concatenate([[-1], spline_indices, [spline_indices[-1] + 1]], axis=0),
             )
         else:
-            interpolator = scipy.interpolate.PchipInterpolator(x=transition_times_cumsum, y=spline_indices)
+            interpolator = interpolate.PchipInterpolator(x=transition_times_cumsum, y=spline_indices)
 
         # Clip to account for floating point error.
         return np.clip(interpolator(time), 0, spline_indices[-1])

--- a/nerfstudio/viewer/render_panel.py
+++ b/nerfstudio/viewer/render_panel.py
@@ -24,11 +24,11 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
-from scipy import interpolate
 import splines
 import splines.quaternion
 import viser
 import viser.transforms as tf
+from scipy import interpolate
 
 from nerfstudio.viewer.control_panel import ControlPanel
 


### PR DESCRIPTION
This PR fixes the issue that I see when trying to add multiple keyframes in the viewer to generate a camera path for rendering. I get the following error:

```
  File "repos/nerfstudio/nerfstudio/viewer/render_panel.py", line 269, in spline_t_from_t_sec                                                                                                             interpolator = scipy.interpolate.PchipInterpolator(                                                                                                                                                            
AttributeError: module 'scipy' has no attribute 'interpolate'  
```
FYI, I don't see this error when trying to create a camera path running the legacy viewer i.e. when I try to create a path after running `ns-viewer --load-config outputs/test_data/nerfacto/2024-03-23_151802/config.yml  --vis viewer-legacy` instead of `ns-viewer --load-config outputs/test_data/nerfacto/2024-03-23_151802/config.yml`