### PR TITLE
Added All pixel Sampler

### DIFF
--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -531,3 +531,35 @@ class PairPixelSampler(PixelSampler):  # pylint: disable=too-few-public-methods
         pair_indices += indices
         indices = torch.hstack((indices, pair_indices)).view(rays_to_sample * 2, 3)
         return indices
+
+
+@dataclass
+class AllPixelSamplerConfig(PixelSamplerConfig):
+    _target : Type = field(default_factory=lambda: AllPixelSampler)
+
+class AllPixelSampler(PixelSampler):
+    config: AllPixelSamplerConfig
+
+    def sample(self, image_batch: Dict):
+        """
+        Samples all pixels from a single image. The image is selected randomly from the batch.
+        """
+        device = image_batch["image"][0].device
+        num_images, image_height, image_width, _ = image_batch["image"].shape
+
+        image_index = torch.randint(num_images, (1,), device=device)
+        i, j= torch.meshgrid(   
+            torch.arange(image_height, device=device),
+            torch.arange(image_width, device=device),
+            indexing='ij'
+        )
+        
+        pixels = torch.stack([j, i], dim=-1).reshape(-1, 2)
+        pixels = torch.cat((image_index.repeat(pixels.shape[0], 1), pixels), dim=1)
+
+        collated_batch = {}
+        collated_batch['image'] = image_batch['image'][image_index]
+        collated_batch['indices'] = pixels
+
+        return collated_batch
+


### PR DESCRIPTION
A sampler that selects a specific image and samples all pixels from that image.

I believe this could be a useful class where the neural field is optimised per image. This is used in [nerf2mesh](https://github.com/ashawkey/nerf2mesh), where the pixels must be sampled from a single image to generate rays, which are then used to rasterise the image from the coarse mesh.

I [use](https://github.com/IamMohitM/nerf2mesh-nerfstudio/blob/12d43c429449b23441d1e1ef64de8b2d3aba0810/nerf2mesh/datamanager.py#L29) this pixel sampler in my [implementation of nerf2mesh](https://github.com/IamMohitM/nerf2mesh-nerfstudio/blob/12d43c429449b23441d1e1ef64de8b2d3aba0810/nerf2mesh/sampler.py#L13) using nerfstudio.


Happy to make any edits if required. 