### PR TITLE
Fix core tests with Pillow>=10.3.0

### DIFF
--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -69,7 +69,7 @@ class InputDataset(Dataset):
         if self.scale_factor != 1.0:
             width, height = pil_image.size
             newsize = (int(width * self.scale_factor), int(height * self.scale_factor))
-            pil_image = pil_image.resize(newsize, resample=Image.BILINEAR)
+            pil_image = pil_image.resize(newsize, resample=Image.Resampling.BILINEAR)
         image = np.array(pil_image, dtype="uint8")  # shape is (h, w) or (h, w, 3 or 4)
         if len(image.shape) == 2:
             image = image[:, :, None].repeat(3, axis=2)

--- a/nerfstudio/data/utils/data_utils.py
+++ b/nerfstudio/data/utils/data_utils.py
@@ -30,7 +30,7 @@ def get_image_mask_tensor_from_path(filepath: Path, scale_factor: float = 1.0) -
     if scale_factor != 1.0:
         width, height = pil_mask.size
         newsize = (int(width * scale_factor), int(height * scale_factor))
-        pil_mask = pil_mask.resize(newsize, resample=Image.NEAREST)
+        pil_mask = pil_mask.resize(newsize, resample=Image.Resampling.NEAREST)
     mask_tensor = torch.from_numpy(np.array(pil_mask)).unsqueeze(-1).bool()
     if len(mask_tensor.shape) != 3:
         raise ValueError("The mask image should have 1 channel")
@@ -50,7 +50,7 @@ def get_semantics_and_mask_tensors_from_path(
     if scale_factor != 1.0:
         width, height = pil_image.size
         newsize = (int(width * scale_factor), int(height * scale_factor))
-        pil_image = pil_image.resize(newsize, resample=Image.NEAREST)
+        pil_image = pil_image.resize(newsize, resample=Image.Resampling.NEAREST)
     semantics = torch.from_numpy(np.array(pil_image, dtype="int64"))[..., None]
     mask = torch.sum(semantics == mask_indices, dim=-1, keepdim=True) == 0
     return semantics, mask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "nerfacc==0.5.2",
     "open3d>=0.16.0",
     "opencv-python==4.8.0.76",
-    "Pillow>=9.3.0",
+    "Pillow>=10.3.0",
     "plotly>=5.7.0",
     "protobuf<=3.20.3,!=3.20.0",
     # TODO(1480) enable when pycolmap windows wheels are available


### PR DESCRIPTION
The latest version update of Pillow will break nerfstudio since it is using a deprecated API field. 