### PR TITLE
Fix config loading for Eyeful Tower dataset

### DIFF
--- a/nerfstudio/scripts/downloads/eyeful_tower.py
+++ b/nerfstudio/scripts/downloads/eyeful_tower.py
@@ -261,6 +261,7 @@ class EyefulTowerDownload(DatasetDownload):
         output["frames"] = frames
         output["train_filenames"] = split_filenames["train"]
         output["val_filenames"] = split_filenames["test"]
+        output["test_filenames"] = []
         return output
 
     @staticmethod


### PR DESCRIPTION
Support for the Eyeful Tower dataset in Nerfstudio was added earlier this year and it mostly works well. However, when trying to load a checkpoint for this dataset using config.yml (either with ns-viewer or ns-render), an error message shows up.

`ns-viewer --load-config outputs/images-jpeg-1k/nerfacto/2024-04-06_181030/config.yml`

> RuntimeError: The dataset's list of filenames for split test is missing

Since there is no specific test set for this dataset, having an empty "test_filenames" entry in the transforms.json seems to be enough to deal with this issue. This PR adds a single line of code making this change. 