### PR TITLE
Remove image size limits.

### DIFF
--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -43,7 +43,7 @@ from nerfstudio.utils.rich_utils import CONSOLE, status
 from nerfstudio.utils.scripts import run_command
 
 MAX_AUTO_RESOLUTION = 1600
-
+Image.MAX_IMAGE_PIXELS = None
 
 @dataclass
 class ColmapDataParserConfig(DataParserConfig):

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -37,7 +37,7 @@ from nerfstudio.utils.io import load_from_json
 from nerfstudio.utils.rich_utils import CONSOLE
 
 MAX_AUTO_RESOLUTION = 1600
-
+Image.MAX_IMAGE_PIXELS = None
 
 @dataclass
 class NerfstudioDataParserConfig(DataParserConfig):

--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -33,6 +33,7 @@ from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.data.dataparsers.base_dataparser import DataparserOutputs
 from nerfstudio.data.utils.data_utils import get_image_mask_tensor_from_path
 
+Image.MAX_IMAGE_PIXELS = None
 
 class InputDataset(Dataset):
     """Dataset that returns images.

--- a/nerfstudio/data/datasets/depth_dataset.py
+++ b/nerfstudio/data/datasets/depth_dataset.py
@@ -32,6 +32,7 @@ from nerfstudio.model_components import losses
 from nerfstudio.utils.misc import torch_compile
 from nerfstudio.utils.rich_utils import CONSOLE
 
+Image.MAX_IMAGE_PIXELS = None
 
 class DepthDataset(InputDataset):
     """Dataset that returns images and depths. If no depths are found, then we generate them with Zoe Depth.

--- a/nerfstudio/data/utils/data_utils.py
+++ b/nerfstudio/data/utils/data_utils.py
@@ -21,6 +21,7 @@ import numpy as np
 import torch
 from PIL import Image
 
+Image.MAX_IMAGE_PIXELS = None
 
 def get_image_mask_tensor_from_path(filepath: Path, scale_factor: float = 1.0) -> torch.Tensor:
     """

--- a/nerfstudio/generative/deepfloyd.py
+++ b/nerfstudio/generative/deepfloyd.py
@@ -28,7 +28,7 @@ from torch.cuda.amp.grad_scaler import GradScaler
 from nerfstudio.utils.rich_utils import CONSOLE
 
 IMG_DIM = 64
-
+Image.MAX_IMAGE_PIXELS = None
 
 class DeepFloyd(nn.Module):
     """DeepFloyd diffusion model

--- a/nerfstudio/process_data/realitycapture_utils.py
+++ b/nerfstudio/process_data/realitycapture_utils.py
@@ -25,6 +25,7 @@ from PIL import Image
 from nerfstudio.process_data.process_data_utils import CAMERA_MODELS
 from nerfstudio.utils.rich_utils import CONSOLE
 
+Image.MAX_IMAGE_PIXELS = None
 
 def realitycapture_to_json(
     image_filename_map: Dict[str, Path],

--- a/nerfstudio/scripts/datasets/process_project_aria.py
+++ b/nerfstudio/scripts/datasets/process_project_aria.py
@@ -34,6 +34,7 @@ except ImportError:
     sys.exit(1)
 
 ARIA_CAMERA_MODEL = "FISHEYE624"
+Image.MAX_IMAGE_PIXELS = None
 
 # The Aria coordinate system is different than the Blender/NerfStudio coordinate system.
 # Blender / Nerfstudio: +Z = back, +Y = up, +X = right

--- a/tests/dataparsers/test_nerfstudio_dataparser.py
+++ b/tests/dataparsers/test_nerfstudio_dataparser.py
@@ -10,6 +10,7 @@ import pytest
 from PIL import Image
 from pytest import fixture
 
+Image.MAX_IMAGE_PIXELS = None
 
 @fixture
 def mocked_dataset(tmp_path: Path):

--- a/tests/process_data/test_process_images.py
+++ b/tests/process_data/test_process_images.py
@@ -20,6 +20,7 @@ from nerfstudio.data.utils.colmap_parsing_utils import (
 )
 from nerfstudio.process_data.images_to_nerfstudio_dataset import ImagesToNerfstudioDataset
 
+Image.MAX_IMAGE_PIXELS = None
 
 def random_quaternion(num_poses: int):
     """


### PR DESCRIPTION
I suggest to remove the default image size limits from PIL. This causes training of models in nerfstudio to crash with the error:
DecompressionBombError: Image size (340840656 pixels) exceeds limit of 178956970 pixels, could be decompression 
bomb DOS attack.

I see this is meant to be a security feature, however it prevents the usage of large images. I assume people are using mainly their own images in nerfstudio and don't see this as a security issue. Please let me know what you think about it.

Alternatively, there should be at least a param/option to allow large images.

I remove the image size limit at all occurances in the code where PIL is used, however this might not be necessary. E.g. the tests shouldn't be affected at all but I want to keep it consistent and avoid future issues.

Happy to get your feedback.