### PR TITLE
Adding lock for Viser Element callbacks

### DIFF
--- a/nerfstudio/scripts/viewer/run_viewer.py
+++ b/nerfstudio/scripts/viewer/run_viewer.py
@@ -16,6 +16,7 @@
 """
 Starts viewer in eval mode.
 """
+
 from __future__ import annotations
 
 import time

--- a/nerfstudio/scripts/viewer/run_viewer.py
+++ b/nerfstudio/scripts/viewer/run_viewer.py
@@ -22,6 +22,7 @@ import time
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Literal
+from threading import Lock
 
 import tyro
 
@@ -89,12 +90,14 @@ def _start_viewer(config: TrainerConfig, pipeline: Pipeline, step: int):
     viewer_log_path = base_dir / config.viewer.relative_log_filename
     banner_messages = None
     viewer_state = None
+    viewer_callback_lock = Lock()
     if config.vis == "viewer_legacy":
         viewer_state = ViewerLegacyState(
             config.viewer,
             log_filename=viewer_log_path,
             datapath=pipeline.datamanager.get_datapath(),
             pipeline=pipeline,
+            train_lock=viewer_callback_lock,
         )
         banner_messages = [f"Legacy viewer at: {viewer_state.viewer_url}"]
     if config.vis == "viewer":
@@ -104,6 +107,7 @@ def _start_viewer(config: TrainerConfig, pipeline: Pipeline, step: int):
             datapath=pipeline.datamanager.get_datapath(),
             pipeline=pipeline,
             share=config.viewer.make_share_url,
+            train_lock=viewer_callback_lock,
         )
         banner_messages = viewer_state.viewer_info
 

--- a/nerfstudio/scripts/viewer/run_viewer.py
+++ b/nerfstudio/scripts/viewer/run_viewer.py
@@ -21,8 +21,8 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Literal
 from threading import Lock
+from typing import Literal
 
 import tyro
 

--- a/nerfstudio/viewer/viewer.py
+++ b/nerfstudio/viewer/viewer.py
@@ -15,8 +15,8 @@
 """ Manage the state of the viewer """
 from __future__ import annotations
 
-import threading
 import contextlib
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional

--- a/nerfstudio/viewer/viewer.py
+++ b/nerfstudio/viewer/viewer.py
@@ -214,6 +214,7 @@ class Viewer:
             def cb_lock(element):
                 with self.train_lock if self.train_lock is not None else contextlib.nullcontext():
                     prev_cb(element)
+                    
             return cb_lock
         
         def nested_folder_install(folder_labels: List[str], prev_labels: List[str], element: ViewerElement):

--- a/nerfstudio/viewer/viewer.py
+++ b/nerfstudio/viewer/viewer.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Manage the state of the viewer """
+"""Manage the state of the viewer"""
+
 from __future__ import annotations
 
 import contextlib
@@ -214,9 +215,9 @@ class Viewer:
             def cb_lock(element):
                 with self.train_lock if self.train_lock is not None else contextlib.nullcontext():
                     prev_cb(element)
-                    
+
             return cb_lock
-        
+
         def nested_folder_install(folder_labels: List[str], prev_labels: List[str], element: ViewerElement):
             if len(folder_labels) == 0:
                 element.install(self.viser_server)

--- a/nerfstudio/viewer/viewer.py
+++ b/nerfstudio/viewer/viewer.py
@@ -212,6 +212,9 @@ class Viewer:
         viewer_gui_folders = dict()
 
         def prev_cb_wrapper(prev_cb):
+            # We wrap the callbacks in the train_lock so that the callbacks are thread-safe with the
+            # concurrently executing render thread. This may block rendering, however this can be necessary
+            # if the callback uses get_outputs internally.
             def cb_lock(element):
                 with self.train_lock if self.train_lock is not None else contextlib.nullcontext():
                     prev_cb(element)

--- a/nerfstudio/viewer/viewer.py
+++ b/nerfstudio/viewer/viewer.py
@@ -213,7 +213,6 @@ class Viewer:
         def prev_cb_wrapper(prev_cb):
             def cb_lock(element):
                 with self.train_lock if self.train_lock is not None else contextlib.nullcontext():
-                    print(f"Running {element}", str(self.train_lock))
                     prev_cb(element)
             return cb_lock
         


### PR DESCRIPTION
I added a wrapper around the viser element callback so the render thread is blocked while the callback is called to avoid crashing. I also added a lock in run_viewer.py so this issue is addressed for both ns-train and ns-viewer. 

Test: I added time.sleep() in the callback and confirmed the render thread was blocked.