### PR TITLE
Hloc fix for image_ids (camera per image)

### DIFF
--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -102,7 +102,8 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     same_dimensions: bool = True
     """Whether to assume all images are same dimensions and so to use fast downscaling with no autorotation."""
     use_single_camera_mode: bool = True
-    """Whether to assume all images taken with the same camera characteristics, set to False for multifocal case."""
+    """Whether to assume all images taken with the same camera characteristics, set to False for multiple cameras in colmap (only works with hloc sfm_tool).
+    """
 
     @staticmethod
     def default_colmap_path() -> Path:
@@ -199,7 +200,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
 
         # check that sfm_tool is hloc if using use_single_camera_mode
         if not self.use_single_camera_mode:
-            assert sfm_tool == "hloc", "use_single_camera_mode only works with sfm_tool hloc"
+            assert sfm_tool == "hloc", "not_use_single_camera_mode only works with sfm_tool hloc"
 
         # set the image_dir if didn't copy
         if self.skip_image_processing:

--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -101,7 +101,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     """If --use-sfm-depth and this flag is True, also export debug images showing Sf overlaid upon input images."""
     same_dimensions: bool = True
     """Whether to assume all images are same dimensions and so to use fast downscaling with no autorotation."""
-    same_camera: bool = True
+    use_single_camera_mode: bool = True
     """Whether to assume all images taken with the same camera characteristics, set to False for multifocal case."""
 
     @staticmethod
@@ -138,6 +138,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                     image_id_to_depth_path=image_id_to_depth_path,
                     camera_mask_path=camera_mask_path,
                     image_rename_map=image_rename_map,
+                    use_single_camera_mode=self.use_single_camera_mode,
                 )
                 summary_log.append(f"Colmap matched {num_matched_frames} images")
             summary_log.append(colmap_utils.get_matching_summary(num_frames, num_matched_frames))
@@ -196,9 +197,9 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
         if self.refine_pixsfm:
             assert sfm_tool == "hloc", "refine_pixsfm only works with sfm_tool hloc"
 
-        # check that sfm_tool is hloc if using same_camera
-        if not self.same_camera:
-            assert sfm_tool == "hloc", "no_same_camera only works with sfm_tool hloc"
+        # check that sfm_tool is hloc if using use_single_camera_mode
+        if not self.use_single_camera_mode:
+            assert sfm_tool == "hloc", "use_single_camera_mode only works with sfm_tool hloc"
 
         # set the image_dir if didn't copy
         if self.skip_image_processing:
@@ -234,7 +235,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                 feature_type=feature_type,
                 matcher_type=matcher_type,
                 refine_pixsfm=self.refine_pixsfm,
-                same_camera=self.same_camera,
+                use_single_camera_mode=self.use_single_camera_mode,
             )
         else:
             raise RuntimeError("Invalid combination of sfm_tool, feature_type, and matcher_type, " "exiting")

--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -101,6 +101,8 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     """If --use-sfm-depth and this flag is True, also export debug images showing Sf overlaid upon input images."""
     same_dimensions: bool = True
     """Whether to assume all images are same dimensions and so to use fast downscaling with no autorotation."""
+    same_camera: bool = True
+    """Whether to assume all images taken with the same camera characteristics, set to False for multifocal case."""
 
     @staticmethod
     def default_colmap_path() -> Path:
@@ -194,6 +196,10 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
         if self.refine_pixsfm:
             assert sfm_tool == "hloc", "refine_pixsfm only works with sfm_tool hloc"
 
+        # check that sfm_tool is hloc if using same_camera
+        if not self.same_camera:
+            assert sfm_tool == "hloc", "no_same_camera only works with sfm_tool hloc"
+
         # set the image_dir if didn't copy
         if self.skip_image_processing:
             image_dir = self.data
@@ -228,6 +234,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                 feature_type=feature_type,
                 matcher_type=matcher_type,
                 refine_pixsfm=self.refine_pixsfm,
+                same_camera=self.same_camera,
             )
         else:
             raise RuntimeError("Invalid combination of sfm_tool, feature_type, and matcher_type, " "exiting")

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -464,12 +464,11 @@ def colmap_to_json(
             depth_path = image_id_to_depth_path[im_id]
             frame["depth_file_path"] = str(depth_path.relative_to(depth_path.parent.parent))
 
-        if use_single_camera_mode is True:  # add the camera for this frame
+        if use_single_camera_mode is False:  # add the camera for this frame
             frame.update(parse_colmap_camera_params(cam_id_to_camera[im_id]))
 
         frames.append(frame)
 
-    out = parse_colmap_camera_params(cam_id_to_camera[1])
     out["frames"] = frames
 
     applied_transform = None

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -420,7 +420,7 @@ def colmap_to_json(
     cam_id_to_camera = read_cameras_binary(recon_dir / "cameras.bin")
     im_id_to_image = read_images_binary(recon_dir / "images.bin")
     if set(cam_id_to_camera.keys()) != {1}:
-        print(f"Warning: More than one camera is found in {recon_dir / "cameras.bin"}.")
+        CONSOLE.print(f"[bold yellow]Warning: More than one camera is found in {recon_dir+"/"+"cameras.bin"}")
         print(cam_id_to_camera)
         use_single_camera_mode = False  # update bool: one camera per frame
         out = {}  # out = {"camera_model": parse_colmap_camera_params(cam_id_to_camera[1])["camera_model"]}

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -418,13 +418,12 @@ def colmap_to_json(
     # im_id_to_image = recon.images
     cam_id_to_camera = read_cameras_binary(recon_dir / "cameras.bin")
     im_id_to_image = read_images_binary(recon_dir / "images.bin")
-
-    multifocal=False  # one camera for all frames (distort_fixed=True)
+    multifocal = False  # one camera for all frames (distort_fixed=True)
     if set(cam_id_to_camera.keys()) != {1}:
         print("Only single camera shared for all images is supported.")
         print(cam_id_to_camera)
-        multifocal=True  # one camera per frame (distort_fixed=False)
-        out = {"camera_model":parse_colmap_camera_params(cam_id_to_camera[1])["camera_model"]}
+        multifocal = True  # one camera per frame (distort_fixed=False)
+        out = {"camera_model": parse_colmap_camera_params(cam_id_to_camera[1])["camera_model"]}
     else:
         out = parse_colmap_camera_params(cam_id_to_camera[1])
 

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -420,7 +420,7 @@ def colmap_to_json(
     cam_id_to_camera = read_cameras_binary(recon_dir / "cameras.bin")
     im_id_to_image = read_images_binary(recon_dir / "images.bin")
     if set(cam_id_to_camera.keys()) != {1}:
-        CONSOLE.print(f"[bold yellow]Warning: More than one camera is found in {recon_dir+"/"+"cameras.bin"}")
+        CONSOLE.print(f"[bold yellow]Warning: More than one camera is found in {recon_dir}")
         print(cam_id_to_camera)
         use_single_camera_mode = False  # update bool: one camera per frame
         out = {}  # out = {"camera_model": parse_colmap_camera_params(cam_id_to_camera[1])["camera_model"]}

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -464,8 +464,8 @@ def colmap_to_json(
             depth_path = image_id_to_depth_path[im_id]
             frame["depth_file_path"] = str(depth_path.relative_to(depth_path.parent.parent))
 
-        if use_single_camera_mode is False:  # add the camera for this frame
-            frame.update(parse_colmap_camera_params(cam_id_to_camera[im_id]))
+        if not use_single_camera_mode:  # add the camera parameters for this frame
+            frame.update(parse_colmap_camera_params(cam_id_to_camera[im_data.camera_id]))
 
         frames.append(frame)
 

--- a/nerfstudio/process_data/hloc_utils.py
+++ b/nerfstudio/process_data/hloc_utils.py
@@ -71,7 +71,7 @@ def run_hloc(
     ] = "superglue",
     num_matched: int = 50,
     refine_pixsfm: bool = False,
-    same_camera: bool = True,
+    use_single_camera_mode: bool = True,
 ) -> None:
     """Runs hloc on the images.
 
@@ -86,7 +86,7 @@ def run_hloc(
         matcher_type: Type of feature matcher to use.
         num_matched: Number of image pairs for loc.
         refine_pixsfm: If True, refine the reconstruction using pixel-perfect-sfm.
-        same_camera: If True, uses one camera for all frames. Otherwise uses one camera per frame.
+        use_single_camera_mode: If True, uses one camera for all frames. Otherwise uses one camera per frame.
     """
     if not _HAS_HLOC:
         CONSOLE.print(
@@ -122,7 +122,7 @@ def run_hloc(
 
     image_options = pycolmap.ImageReaderOptions(camera_model=camera_model.value)  # type: ignore
 
-    if same_camera:  # one camera per all frames
+    if use_single_camera_mode:  # one camera per all frames
         camera_mode = pycolmap.CameraMode.SINGLE  # type: ignore
     else:  # one camera per frame
         camera_mode = pycolmap.CameraMode.PER_IMAGE  # type: ignore

--- a/nerfstudio/process_data/hloc_utils.py
+++ b/nerfstudio/process_data/hloc_utils.py
@@ -134,7 +134,7 @@ def run_hloc(
             features,
             matches,
             image_list=references,
-            camera_mode=pycolmap.CameraMode.SINGLE,  # type: ignore
+            camera_mode=pycolmap.CameraMode.PER_IMAGE,  # type: ignore
             image_options=image_options,
             verbose=verbose,
         )
@@ -147,7 +147,8 @@ def run_hloc(
             sfm_pairs,
             features,
             matches,
-            camera_mode=pycolmap.CameraMode.SINGLE,  # type: ignore
+            image_list=references,
+            camera_mode=pycolmap.CameraMode.PER_IMAGE,  # type: ignore
             image_options=image_options,
             verbose=verbose,
         )

--- a/nerfstudio/process_data/hloc_utils.py
+++ b/nerfstudio/process_data/hloc_utils.py
@@ -71,6 +71,7 @@ def run_hloc(
     ] = "superglue",
     num_matched: int = 50,
     refine_pixsfm: bool = False,
+    same_camera: bool = True,
 ) -> None:
     """Runs hloc on the images.
 
@@ -85,6 +86,7 @@ def run_hloc(
         matcher_type: Type of feature matcher to use.
         num_matched: Number of image pairs for loc.
         refine_pixsfm: If True, refine the reconstruction using pixel-perfect-sfm.
+        same_camera: If True, uses one camera for all frames. Otherwise uses one camera per frame.
     """
     if not _HAS_HLOC:
         CONSOLE.print(
@@ -119,6 +121,12 @@ def run_hloc(
     match_features.main(matcher_conf, sfm_pairs, features=features, matches=matches)  # type: ignore
 
     image_options = pycolmap.ImageReaderOptions(camera_model=camera_model.value)  # type: ignore
+
+    if same_camera:  # one camera per all frames
+        camera_mode = pycolmap.CameraMode.SINGLE  # type: ignore
+    else:  # one camera per frame
+        camera_mode = pycolmap.CameraMode.PER_IMAGE  # type: ignore
+
     if refine_pixsfm:
         sfm = PixSfM(  # type: ignore
             conf={
@@ -134,7 +142,7 @@ def run_hloc(
             features,
             matches,
             image_list=references,
-            camera_mode=pycolmap.CameraMode.PER_IMAGE,  # type: ignore
+            camera_mode=camera_mode,  # type: ignore
             image_options=image_options,
             verbose=verbose,
         )
@@ -147,8 +155,7 @@ def run_hloc(
             sfm_pairs,
             features,
             matches,
-            image_list=references,
-            camera_mode=pycolmap.CameraMode.PER_IMAGE,  # type: ignore
+            camera_mode=camera_mode,  # type: ignore
             image_options=image_options,
             verbose=verbose,
         )


### PR DESCRIPTION
Hloc gets a single image_ids [here](https://github.com/cvg/Hierarchical-Localization/blob/master/hloc/reconstruction.py#L129) so that it is unable to get the matching between images. Thus it gets an error on not finding images "frame_XXX not found". This little fix in `hloc_utils.py` is solving this issue https://github.com/nerfstudio-project/nerfstudio/issues/3059

Found this error on using `--no_same_dimensions` with `disk` features and `disk+lightglue` matching

