### PR TITLE
Allow alpha transparency training for blender datasets input

### DIFF
--- a/nerfstudio/data/dataparsers/blender_dataparser.py
+++ b/nerfstudio/data/dataparsers/blender_dataparser.py
@@ -41,8 +41,9 @@ class BlenderDataParserConfig(DataParserConfig):
     """Directory specifying location of data."""
     scale_factor: float = 1.0
     """How much to scale the camera origins by."""
-    alpha_color: str = "white"
-    """alpha color of background"""
+    alpha_color: Optional[str] = "white"
+    """alpha color of background, when set to None, InputDataset that consumes DataparserOutputs will not attempt 
+    to blend with alpha_colors using image's alpha channel data. Thus rgba image will be directly used in training. """
     ply_path: Optional[Path] = None
     """Path to PLY file to load 3D points from, defined relative to the dataset directory. This is helpful for
     Gaussian splatting and generally unused otherwise. If `None`, points are initialized randomly."""


### PR DESCRIPTION
It is a simple change such that user can use the following commands to do [alpha transparency](https://github.com/nerfstudio-project/nerfstudio/pull/2889) training on blender dataset:
```
ns-train splatfacto-big --data materials/ \
--pipeline.model.background-color random \
--pipeline.model.random_scale 2.6 \
--logging.local-writer.max-log-size=0 \
blender-data --alpha_color=None
```