### PR TITLE
Fix bug in pixel sampler

### DIFF
--- a/nerfstudio/data/utils/pixel_sampling_utils.py
+++ b/nerfstudio/data/utils/pixel_sampling_utils.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Pixel sampling utils such as eroding of valid masks that we sample from. """
+"""Pixel sampling utils such as eroding of valid masks that we sample from."""
+
+import math
+from typing import List
 
 import torch
 from jaxtyping import Float
@@ -63,3 +66,25 @@ def erode_mask(tensor: Float[Tensor, "bs 1 H W"], pixel_radius: int = 1):
     """
     kernel_size = 1 + 2 * pixel_radius
     return erode(tensor, kernel_size=kernel_size)
+
+
+def divide_rays_per_image(num_rays_per_batch: int, num_images: int) -> List[int]:
+    """Divide the batch of rays per image. Finds the optimal number of rays per image such that
+    it's still divisible by 2 and sums to the total number of rays.
+
+    Args:
+        num_rays_per_batch: Number of rays in the batch.
+        num_images: Number of images in the batch.
+
+    Returns:
+        num_rays_per_image: A list of the number of rays per image.
+    """
+    num_rays_per_image = num_rays_per_batch / num_images
+    residual = num_rays_per_image % 2
+    num_rays_per_image_under = int(num_rays_per_image - residual)
+    num_rays_per_image_over = int(num_rays_per_image_under + 2)
+    num_images_under = math.ceil(num_images * (1 - residual / 2))
+    num_images_over = num_images - num_images_under
+    num_rays_per_image = num_images_under * [num_rays_per_image_under] + num_images_over * [num_rays_per_image_over]
+    num_rays_per_image[-1] += num_rays_per_batch - sum(num_rays_per_image)
+    return num_rays_per_image


### PR DESCRIPTION
Current sampling will oversample the first (num_images - 1) images, and might return a negative number of rays for the last image. The proposed fix finds an optimal ratio of rays per image such that the constraint of always being divisible by 2 is still satisfied.