### PR TITLE
Fix edge case of depth colormap

### DIFF
--- a/nerfstudio/utils/colormaps.py
+++ b/nerfstudio/utils/colormaps.py
@@ -134,8 +134,8 @@ def apply_depth_colormap(
         Colored depth image with colors in [0, 1]
     """
 
-    near_plane = near_plane or float(torch.min(depth))
-    far_plane = far_plane or float(torch.max(depth))
+    near_plane = near_plane if near_plane is not None else float(torch.min(depth))
+    far_plane = far_plane if far_plane is not None else float(torch.max(depth))
 
     depth = (depth - near_plane) / (far_plane - near_plane + 1e-10)
     depth = torch.clip(depth, 0, 1)


### PR DESCRIPTION
If the user sets near_plane as 0.0, the "or" will take the second term (float(torch.min(depth))) instead of using the 0.0 value.  We fix this by checking explicitely for a "None" variable