### PR TITLE
remove redundant code in full_images_datamanager.py

### DIFF
--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -307,15 +307,7 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
         """Returns the next evaluation batch
 
         Returns a Camera instead of raybundle"""
-        image_idx = self.eval_unseen_cameras.pop(random.randint(0, len(self.eval_unseen_cameras) - 1))
-        # Make sure to re-populate the unseen cameras list if we have exhausted it
-        if len(self.eval_unseen_cameras) == 0:
-            self.eval_unseen_cameras = [i for i in range(len(self.eval_dataset))]
-        data = deepcopy(self.cached_eval[image_idx])
-        data["image"] = data["image"].to(self.device)
-        assert len(self.eval_dataset.cameras.shape) == 1, "Assumes single batch dimension"
-        camera = self.eval_dataset.cameras[image_idx : image_idx + 1].to(self.device)
-        return camera, data
+        return self.next_eval_image(step=step)
 
     def next_eval_image(self, step: int) -> Tuple[Cameras, Dict]:
         """Returns the next evaluation batch


### PR DESCRIPTION
Currently, [next_eval](https://github.com/nerfstudio-project/nerfstudio/blob/8d5502db1a599c1ccb68807aa364482a931fb60c/nerfstudio/data/datamanagers/full_images_datamanager.py#L306) and [next_eval_image](https://github.com/nerfstudio-project/nerfstudio/blob/8d5502db1a599c1ccb68807aa364482a931fb60c/nerfstudio/data/datamanagers/full_images_datamanager.py#L320) in the [full_images_datamanager.py](https://github.com/nerfstudio-project/nerfstudio/blob/8d5502db1a599c1ccb68807aa364482a931fb60c/nerfstudio/data/datamanagers/full_images_datamanager.py) do exactly the same in a redundant fashion.
As both function's might be used, to reduce the redundancy, I made one function call the other.