### PR TITLE
Fixing resize_image and adding additional distortion check

### DIFF
--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -161,7 +161,7 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 f'The size of image ({data["image"].shape[1]}, {data["image"].shape[0]}) loaded '
                 f'does not match the camera parameters ({camera.width.item(), camera.height.item()})'
             )
-            if camera.distortion_params is None:
+            if camera.distortion_params is None or torch.all(camera.distortion_params == 0):
                 return data
             K = camera.get_intrinsics_matrices().numpy()
             distortion_params = camera.distortion_params.numpy()

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -91,6 +91,7 @@ def resize_image(image: torch.Tensor, d: int):
     """
     import torch.nn.functional as tf
 
+    image = image.to(torch.float32)
     weight = (1.0 / (d * d)) * torch.ones((1, 1, d, d), dtype=torch.float32, device=image.device)
     return tf.conv2d(image.permute(2, 0, 1)[:, None, ...], weight, stride=d).squeeze(1).permute(1, 2, 0)
 


### PR DESCRIPTION
There is a runtime error when boolean masks are fed into `splatfacto`: (For me, this happened when testing with aria data)

<img width="786" alt="image" src="https://github.com/nerfstudio-project/nerfstudio/assets/47730496/87d0cc7b-8416-4ef3-814b-079b91599efb">


Additionally, when the distortion parameters are all 0 (meaning there is no distortion in the image), splatfacto will still try to distort the image because `distortion_params` are not None, so adding a quick check on that prevents images from being fed to the undistort function when there is no distortion.