### PR TITLE
Fix: when --use-sfm-depth is enabled and the model is given by --colm…

### DIFF
--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -162,7 +162,9 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
             depth_dir = self.output_dir / "depth"
             depth_dir.mkdir(parents=True, exist_ok=True)
             image_id_to_depth_path = colmap_utils.create_sfm_depth(
-                recon_dir=self.output_dir / self.default_colmap_path(),
+                recon_dir=self.absolute_colmap_model_path
+                if self.skip_colmap
+                else self.output_dir / self.default_colmap_path(),
                 output_dir=depth_dir,
                 include_depth_debug=self.include_depth_debug,
                 input_images_dir=self.image_dir,


### PR DESCRIPTION
in `ns-process-data`
if the user provides an existing colmap reconstruction model by `--colmap-model-path` and also enables `--use-sfm-depth`, nerfstudio still tries to search `points3D.bin` in the output colmap reconstruction directory instead of the user provided colmap model path.

This is a small fix for it