### PR TITLE
Ignore gsplat 1.0 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "xatlas",
     "trimesh>=3.20.2",
     "timm==0.6.7",
-    "gsplat>=0.1.11",
+    "gsplat>=0.1.11,<1.0.0",
     "pytorch-msssim",
     "pathos",
     "packaging",


### PR DESCRIPTION
@liruilong940607 @maturk  Apparently the new 1.0 release has API-breaking changes, which breaks fresh installs, as observed in discord https://discord.com/channels/1025504971606724712/1167872346707738664/1248794449148907644

i guess yall drafting an update ( https://github.com/nerfstudio-project/nerfstudio/tree/gsplatv1.0 ) but does not appear to be in PR yet.  so mebbe wanna fix `main` with this patch for now?