### PR TITLE
Update splatfacto with gsplat 1.0

### DIFF
--- a/docs/nerfology/methods/splat.md
+++ b/docs/nerfology/methods/splat.md
@@ -39,7 +39,7 @@ We provide a few additional variants:
 | `splatfacto-big` | More Gaussians, Higher Quality | ~12GB  | Slower  |
 
 
-A full evalaution of Nerfstudio's implementation of Gaussian Splatting against the original Inria method can be found [here](https://docs.gsplat.studio/tests/eval.html).
+A full evalaution of Nerfstudio's implementation of Gaussian Splatting against the original Inria method can be found [here](https://docs.gsplat.studio/main/tests/eval.html).
 
 #### Quality and Regularization
 The default settings provided maintain a balance between speed, quality, and splat file size, but if you care more about quality than training speed or size, you can decrease the alpha cull threshold 

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -658,7 +658,7 @@ method_configs["splatfacto-big"] = TrainerConfig(
         model=SplatfactoModelConfig(
             cull_alpha_thresh=0.005,
             continue_cull_post_densification=False,
-            densify_grad_thresh=0.0006,
+            # densify_grad_thresh=0.0006,
         ),
     ),
     optimizers={

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -658,7 +658,7 @@ method_configs["splatfacto-big"] = TrainerConfig(
         model=SplatfactoModelConfig(
             cull_alpha_thresh=0.005,
             continue_cull_post_densification=False,
-            # densify_grad_thresh=0.0006,
+            densify_grad_thresh=0.0006,
         ),
     ),
     optimizers={

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -62,7 +62,7 @@ class FullImageDatamanagerConfig(DataManagerConfig):
     new images. If -1, never pick new images."""
     eval_image_indices: Optional[Tuple[int, ...]] = (0,)
     """Specifies the image indices to use during eval; if None, uses all."""
-    cache_images: Literal["cpu", "gpu"] = "cpu"
+    cache_images: Literal["cpu", "gpu"] = "gpu"
     """Whether to cache images in memory. If "cpu", caches on cpu. If "gpu", caches on device."""
     cache_images_type: Literal["uint8", "float32"] = "float32"
     """The image type returned from manager, caching images in uint8 saves memory"""
@@ -200,11 +200,15 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
                 cache["image"] = cache["image"].to(self.device)
                 if "mask" in cache:
                     cache["mask"] = cache["mask"].to(self.device)
+                if "depth" in cache:
+                    cache["depth"] = cache["depth"].to(self.device)
+                self.train_cameras = self.train_dataset.cameras.to(self.device)
         elif cache_images_device == "cpu":
             for cache in undistorted_images:
                 cache["image"] = cache["image"].pin_memory()
                 if "mask" in cache:
                     cache["mask"] = cache["mask"].pin_memory()
+                self.train_cameras = self.train_dataset.cameras
         else:
             assert_never(cache_images_device)
 
@@ -293,11 +297,11 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
         if len(self.train_unseen_cameras) == 0:
             self.train_unseen_cameras = [i for i in range(len(self.train_dataset))]
 
-        data = deepcopy(self.cached_train[image_idx])
+        data = self.cached_train[image_idx]
         data["image"] = data["image"].to(self.device)
 
-        assert len(self.train_dataset.cameras.shape) == 1, "Assumes single batch dimension"
-        camera = self.train_dataset.cameras[image_idx : image_idx + 1].to(self.device)
+        assert len(self.train_cameras.shape) == 1, "Assumes single batch dimension"
+        camera = self.train_cameras[image_idx : image_idx + 1].to(self.device)
         if camera.metadata is None:
             camera.metadata = {}
         camera.metadata["cam_idx"] = image_idx

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -719,12 +719,7 @@ class SplatfactoModel(Model):
         )
 
         # apply the compensation of screen space blurring to gaussians
-        if self.config.rasterize_mode == "antialiased":
-            assert NotImplementedError("Antialiased mode is not implemented yet")
-            # opacities = torch.sigmoid(opacities_crop) * comp[:, None]
-        elif self.config.rasterize_mode == "classic":
-            opacities = torch.sigmoid(opacities_crop)
-        else:
+        if self.config.rasterize_mode not in ["antialiased", "classic"]:
             raise ValueError("Unknown rasterize_mode: %s", self.config.rasterize_mode)
 
         if self.config.output_depth_during_training or not self.training:
@@ -755,6 +750,7 @@ class SplatfactoModel(Model):
             sh_degree=sh_degree_to_use,
             sparse_grad=False,
             compute_means2d_absgrad=True,
+            rasterize_mode=self.config.rasterize_mode,
             radius_clip=0 if self.training else 3,  # faster visualization
         )
         if self.training and info["means2d"].requires_grad:

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -736,7 +736,7 @@ class SplatfactoModel(Model):
             means=means_crop,
             quats=quats_crop / quats_crop.norm(dim=-1, keepdim=True),
             scales=torch.exp(scales_crop),
-            opacities=opacities.squeeze(-1),
+            opacities=torch.sigmoid(opacities_crop).squeeze(-1),
             colors=colors_crop,
             viewmats=viewmat[None, :, :],  # [1, 4, 4]
             Ks=K[None],  # [1, 3, 3]

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -776,6 +776,7 @@ class SplatfactoModel(Model):
             render_mode=render_mode,
             sh_degree=sh_degree_to_use,
             sparse_grad=False,
+            radius_clip=0 if self.training else 3, # faster visualization
         )
         if self.training:
             info["means2d"].retain_grad()

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -72,7 +72,7 @@ def RGB2SH(rgb):
     Converts from RGB values [0,1] to the 0th spherical harmonic coefficient
     """
     C0 = 0.28209479177387814
-    return rgb / C0
+    return (rgb - 0.5) / C0
 
 
 def SH2RGB(sh):
@@ -80,7 +80,7 @@ def SH2RGB(sh):
     Converts from the 0th spherical harmonic coefficient to RGB values [0,1]
     """
     C0 = 0.28209479177387814
-    return sh * C0
+    return sh * C0 + 0.5
 
 
 def resize_image(image: torch.Tensor, d: int):

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -25,13 +25,13 @@ from typing import Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
-from gsplat._torch_impl import quat_to_rotmat
+from gsplat.cuda_legacy._torch_impl import quat_to_rotmat
 
 try:
-    from gsplat.rendering_v2 import rasterization
+    from gsplat.rendering import rasterization
 except ImportError:
     print("install via: pip install git+https://github.com/nerfstudio-project/gsplat.git@v1.0")
-from gsplat.sh import num_sh_bases
+from gsplat.cuda_legacy._wrapper import num_sh_bases
 from pytorch_msssim import SSIM
 from torch.nn import Parameter
 from typing_extensions import Literal

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -98,23 +98,22 @@ def resize_image(image: torch.Tensor, d: int):
     return tf.conv2d(image.permute(2, 0, 1)[:, None, ...], weight, stride=d).squeeze(1).permute(1, 2, 0)
 
 
-@torch.compile(dynamic=False)
+@torch.compile()
 def get_viewmat(optimized_camera_to_world):
     """
     function that converts c2w to gsplat world2camera matrix, using compile for some speed
     """
-    # shift the camera to center of scene looking at center
-    R = optimized_camera_to_world[:3, :3]  # 3 x 3
-    T = optimized_camera_to_world[:3, 3:4]  # 3 x 1
-
+    R = optimized_camera_to_world[:,:3, :3]  # 3 x 3
+    T = optimized_camera_to_world[:,:3, 3:4]  # 3 x 1
     # flip the z and y axes to align with gsplat conventions
-    R = R * torch.tensor([[1, -1, -1]], device=R.device, dtype=R.dtype)
+    R = R * torch.tensor([[[1, -1, -1]]], device=R.device, dtype=R.dtype)
     # analytic matrix inverse to get world2camera matrix
-    R_inv = R.T
-    T_inv = -R_inv @ T
-    viewmat = torch.eye(4, device=R.device, dtype=R.dtype)
-    viewmat[:3, :3] = R_inv
-    viewmat[:3, 3:4] = T_inv
+    R_inv = R.transpose(1,2)
+    T_inv = -torch.bmm(R_inv, T)
+    viewmat = torch.zeros(R.shape[0],4, 4, device=R.device, dtype=R.dtype)
+    viewmat[:,3,3] = 1.0#homogenous
+    viewmat[:,:3, :3] = R_inv
+    viewmat[:,:3, 3:4] = T_inv
     return viewmat
 
 

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -30,7 +30,7 @@ from gsplat.cuda_legacy._torch_impl import quat_to_rotmat
 try:
     from gsplat.rendering import rasterization
 except ImportError:
-    print("install via: pip install git+https://github.com/nerfstudio-project/gsplat.git@v1.0")
+    print("Please install gsplat>=1.0.0")
 from gsplat.cuda_legacy._wrapper import num_sh_bases
 from pytorch_msssim import SSIM
 from torch.nn import Parameter

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -757,10 +757,10 @@ class SplatfactoModel(Model):
         rgb = torch.clamp(rgb, 0.0, 1.0)
         if render_mode == "RGB+ED":
             depth_im = render[:, ..., 3:4]
-            depth_im = torch.where(alpha > 0, depth_im, depth_im.detach().max())
+            depth_im = torch.where(alpha > 0, depth_im, depth_im.detach().max()).squeeze(0)
         else:
             depth_im = None
-        return {"rgb": rgb.squeeze(0), "depth": depth_im.squeeze(0), "accumulation": alpha.squeeze(0), "background": background}  # type: ignore
+        return {"rgb": rgb.squeeze(0), "depth": depth_im, "accumulation": alpha.squeeze(0), "background": background}  # type: ignore
 
     def get_gt_img(self, image: torch.Tensor):
         """Compute groundtruth image with iteration dependent downscale factor for evaluation purpose

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -743,7 +743,7 @@ class SplatfactoModel(Model):
             render_mode=render_mode,
             sh_degree=sh_degree_to_use,
             sparse_grad=False,
-            compute_means2d_absgrad=True,
+            absgrad=True,
             rasterize_mode=self.config.rasterize_mode,
             radius_clip=0 if self.training else 3,  # faster visualization
         )

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -104,17 +104,17 @@ def get_viewmat(optimized_camera_to_world):
     """
     function that converts c2w to gsplat world2camera matrix, using compile for some speed
     """
-    R = optimized_camera_to_world[:,:3, :3]  # 3 x 3
-    T = optimized_camera_to_world[:,:3, 3:4]  # 3 x 1
+    R = optimized_camera_to_world[:, :3, :3]  # 3 x 3
+    T = optimized_camera_to_world[:, :3, 3:4]  # 3 x 1
     # flip the z and y axes to align with gsplat conventions
     R = R * torch.tensor([[[1, -1, -1]]], device=R.device, dtype=R.dtype)
     # analytic matrix inverse to get world2camera matrix
-    R_inv = R.transpose(1,2)
+    R_inv = R.transpose(1, 2)
     T_inv = -torch.bmm(R_inv, T)
-    viewmat = torch.zeros(R.shape[0],4, 4, device=R.device, dtype=R.dtype)
-    viewmat[:,3,3] = 1.0#homogenous
-    viewmat[:,:3, :3] = R_inv
-    viewmat[:,:3, 3:4] = T_inv
+    viewmat = torch.zeros(R.shape[0], 4, 4, device=R.device, dtype=R.dtype)
+    viewmat[:, 3, 3] = 1.0  # homogenous
+    viewmat[:, :3, :3] = R_inv
+    viewmat[:, :3, 3:4] = T_inv
     return viewmat
 
 
@@ -714,7 +714,7 @@ class SplatfactoModel(Model):
         colors_crop = torch.cat((features_dc_crop[:, None, :], features_rest_crop), dim=1)
         BLOCK_WIDTH = 16  # this controls the tile size of rasterization, 16 is a good default
         K = camera.get_intrinsics_matrices().cuda()
-        K[:,:2,:] *= camera_scale_fac
+        K[:, :2, :] *= camera_scale_fac
         # apply the compensation of screen space blurring to gaussians
         if self.config.rasterize_mode not in ["antialiased", "classic"]:
             raise ValueError("Unknown rasterize_mode: %s", self.config.rasterize_mode)

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -748,7 +748,8 @@ class SplatfactoModel(Model):
             sparse_grad=False,
             absgrad=True,
             rasterize_mode=self.config.rasterize_mode,
-            radius_clip=0 if self.training else 3,  # faster visualization
+            # set some threshold to disregrad small gaussians for faster rendering.
+            # radius_clip=3.0,
         )
         if self.training and info["means2d"].requires_grad:
             info["means2d"].retain_grad()

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -152,6 +152,9 @@ class ProcessPolycam(BaseConverterToNerfstudioDataset):
                 zip_ref.extractall(self.output_dir)
                 extracted_folder = zip_ref.namelist()[0].split("/")[0]
             self.data = self.output_dir / extracted_folder
+            if not (self.data / "keyframes").exists():
+                # new versions of polycam data have a different structure, strip the last dir off
+                self.data = self.output_dir
 
         if (self.data / "keyframes" / "corrected_images").exists() and not self.use_uncorrected_images:
             polycam_image_dir = self.data / "keyframes" / "corrected_images"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "xatlas",
     "trimesh>=3.20.2",
     "timm==0.6.7",
-    "gsplat>=0.1.11",
+    "gsplat==1.0.0",
     "pytorch-msssim",
     "pathos",
     "packaging"


### PR DESCRIPTION
- Pin dependence to `gsplat==1.0.0`
- A few slight improvements on splatfacto model and its data loading, by @kerrj 

This is a hot fix as the `pip install nerfstudio` would be failing currently because of #3197  so we need to bump a version that either pins to `gsplat==1.0.0` or pins to `gsplat <=1.0.0` asap.