### PR TITLE
Making install_checks use colmap_cmd

### DIFF
--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -246,7 +246,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     def __post_init__(self) -> None:
         super().__post_init__()
         install_checks.check_ffmpeg_installed()
-        install_checks.check_colmap_installed()
+        install_checks.check_colmap_installed(self.colmap_cmd)
 
         if self.crop_bottom < 0.0 or self.crop_bottom > 1:
             raise RuntimeError("crop_bottom must be set between 0 and 1.")

--- a/nerfstudio/utils/install_checks.py
+++ b/nerfstudio/utils/install_checks.py
@@ -15,6 +15,7 @@
 """Helpers for checking if programs are installed"""
 
 import shutil
+import subprocess
 import sys
 
 from nerfstudio.utils.rich_utils import CONSOLE
@@ -29,10 +30,10 @@ def check_ffmpeg_installed():
         sys.exit(1)
 
 
-def check_colmap_installed():
+def check_colmap_installed(colmap_cmd: str):
     """Checks if colmap is installed."""
-    colmap_path = shutil.which("colmap")
-    if colmap_path is None:
+    out = subprocess.run(f"{colmap_cmd} -h", capture_output=True, shell=True, check=False)
+    if out.returncode != 0:
         CONSOLE.print("[bold red]Could not find COLMAP. Please install COLMAP.")
         print("See https://colmap.github.io/install.html for installation instructions.")
         sys.exit(1)


### PR DESCRIPTION
check_colmap_installed() in nerfstudio.utils.install_checks.py previously didn't use the colmap_cmd attribute of ColmapConverterToNerfstudioDataset. This change addresses that so an alternative colmap_cmd can actually be used. This addresses issue #3195 