### PR TITLE
Small fix when evaluating splatfacto model, running ns-eval

### DIFF
--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -677,7 +677,7 @@ class SplatfactoModel(Model):
             if self.training:
                 background = torch.rand(3, device=self.device)
             else:
-                background = self.background_color
+                background = self.background_color.to(self.device)
         elif self.config.background_color == "white":
             background = torch.ones(3, device=self.device)
         elif self.config.background_color == "black":


### PR DESCRIPTION
In the `_get_background_color()` function in splatfacto.py, `self.background_color` is allocated on the cpu, when calling `get_outputs()`, we get a runtime error "RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!". Added a `.to(self.device)` to ensure this doesn't happen
