### PR TITLE
Allow viser to pass cam_idx through metadata

### DIFF
--- a/nerfstudio/viewer/utils.py
+++ b/nerfstudio/viewer/utils.py
@@ -42,6 +42,8 @@ class CameraState:
     """Type of camera to render."""
     time: float = 0.0
     """The rendering time of the camera state."""
+    idx: int = 0
+    """The index of the current camera."""
 
 
 def get_camera(
@@ -78,6 +80,7 @@ def get_camera(
         camera_type=camera_state.camera_type,
         camera_to_worlds=camera_state.c2w.to(torch.float32)[None, ...],
         times=torch.tensor([camera_state.time], dtype=torch.float32),
+        metadata={"cam_idx": camera_state.idx},
     )
     return camera
 


### PR DESCRIPTION
This allows viser to pass cam_idx through metadata to the model. Changes shouldn't have any affect on current models (tested on splatfacto and nerfacto), but it would be useful for models to track the appearance embedding through cam_idx.