### PR TITLE
force setuptools version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ WORKDIR /home/${USERNAME}
 ENV PATH="${PATH}:/home/${USERNAME}/.local/bin"
 
 # Upgrade pip and install packages.
-RUN python3.10 -m pip install --no-cache-dir --upgrade pip setuptools pathtools promise pybind11 omegaconf
+RUN python3.10 -m pip install --no-cache-dir --upgrade pip "setuptools<70" pathtools promise pybind11 omegaconf
 
 # Install pytorch and submodules
 # echo "${CUDA_VERSION}" | sed 's/.$//' | tr -d '.' -- CUDA_VERSION -> delete last digit -> delete all '.'


### PR DESCRIPTION
Docker container fails to build on main since setuptools released [v70.0.0](https://github.com/pypa/setuptools/releases/tag/v70.0.0)


Repro:

```
sudo docker build --tag nerfstudio -f Dockerfile .
...
ImportError: cannot import name 'packaging' from 'pkg_resources' 
```

Fix:

Force setuptools to be strictly less than v70 in the Dockerfile, and it builds correctly.
