### PR TITLE
Render specific frames, panoramic views from specific poses, or uniformly sampled from camera path 

### DIFF
--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -307,15 +307,7 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
         """Returns the next evaluation batch
 
         Returns a Camera instead of raybundle"""
-        image_idx = self.eval_unseen_cameras.pop(random.randint(0, len(self.eval_unseen_cameras) - 1))
-        # Make sure to re-populate the unseen cameras list if we have exhausted it
-        if len(self.eval_unseen_cameras) == 0:
-            self.eval_unseen_cameras = [i for i in range(len(self.eval_dataset))]
-        data = deepcopy(self.cached_eval[image_idx])
-        data["image"] = data["image"].to(self.device)
-        assert len(self.eval_dataset.cameras.shape) == 1, "Assumes single batch dimension"
-        camera = self.eval_dataset.cameras[image_idx : image_idx + 1].to(self.device)
-        return camera, data
+        return self.next_eval_image(step=step)
 
     def next_eval_image(self, step: int) -> Tuple[Cameras, Dict]:
         """Returns the next evaluation batch

--- a/nerfstudio/scripts/render.py
+++ b/nerfstudio/scripts/render.py
@@ -1132,6 +1132,7 @@ Commands = tyro.conf.FlagConversionOff[
     Union[
         Annotated[RenderCameraPath, tyro.conf.subcommand(name="camera-path")],
         Annotated[RenderInterpolated, tyro.conf.subcommand(name="interpolate")],
+        Annotated[RenderPoseView, tyro.conf.subcommand(name="pose-view")],
         Annotated[SpiralRender, tyro.conf.subcommand(name="spiral")],
         Annotated[DatasetRender, tyro.conf.subcommand(name="dataset")],
     ]


### PR DESCRIPTION
Hi,

as described in #2811 I added the following functionality:

* Enter a desired eye position in world coordinates, and optionally a desired target, and get in return the images of the  panoramic view from that pose in parallel to the floor. Anything is adjustable: eye, target, view angle, intermediate steps
* Example usage: `ns-render pose-view --output-format images --load-config outputs/room1/splatfacto/2024-06-07_104843/config.yml --eye "0 0 -2" --load-dataparser-transforms outputs/room5/splatfacto/2024-06-07_104843/dataparser_transforms.json`

* Sample uniformly from the camera path and get the views from the corresponding view points
* Example usage: `ns-render pose-view --output-format images --load-config outputs/room1/splatfacto/2024-06-07_104843/config.yml --viewpoints 3`