### PR TITLE
Fix numpy upgrade to 2.x unexpectedly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pyquaternion>=0.9.9",
     # TODO we can switch back to (non-new) rawpy if they start releasing arm64
     # wheels. https://github.com/letmaik/rawpy/issues/171#issuecomment-1572627747
-    "rawpy>=0.18.1; platform_machine != 'arm64'",
+    "rawpy>=0.18.1,<0.22.0; platform_machine != 'arm64'",
     "newrawpy>=1.0.0b0; platform_machine == 'arm64'",
     "requests",
     "rich>=12.5.1",


### PR DESCRIPTION
[rawpy](https://github.com/letmaik/rawpy/releases) release 0.22.0 two days ago and drop the numpy 1.x support. But some libraries required by nerfstudio are not compatible with numpy 2.x  yet.

Related issue: https://github.com/nerfstudio-project/nerfstudio/issues/3250