### PR TITLE
Fix parsing of non ascii image names in colmap's images.bin

### DIFF
--- a/nerfstudio/data/utils/colmap_parsing_utils.py
+++ b/nerfstudio/data/utils/colmap_parsing_utils.py
@@ -235,11 +235,12 @@ def read_images_binary(path_to_model_file):
             qvec = np.array(binary_image_properties[1:5])
             tvec = np.array(binary_image_properties[5:8])
             camera_id = binary_image_properties[8]
-            image_name = ""
+            image_name = b""
             current_char = read_next_bytes(fid, 1, "c")[0]
             while current_char != b"\x00":  # look for the ASCII 0 entry
-                image_name += current_char.decode("utf-8")
+                image_name += current_char
                 current_char = read_next_bytes(fid, 1, "c")[0]
+            image_name = image_name.decode("utf-8")
             num_points2D = read_next_bytes(fid, num_bytes=8, format_char_sequence="Q")[0]
             x_y_id_s = read_next_bytes(fid, num_bytes=24 * num_points2D, format_char_sequence="ddq" * num_points2D)
             xys = np.column_stack([tuple(map(float, x_y_id_s[0::3])), tuple(map(float, x_y_id_s[1::3]))])


### PR DESCRIPTION
If colmap image file name is non ascii an error will be thrown in the line `current_char.decode("utf-8")` while trying to parse the file `images.bin`
It is thrown because it tries to decode a single byte as `utf-8`, And non ascii chars are represented using more bytes than 1.

My solution proposal is to read all the bytes, and than decode it.
I tested it and it worked OK

