### PR TITLE
Compatibility for numpy 2.0

### DIFF
--- a/nerfstudio/cameras/cameras.py
+++ b/nerfstudio/cameras/cameras.py
@@ -15,6 +15,7 @@
 """
 Camera Models
 """
+
 import base64
 import math
 from dataclasses import dataclass

--- a/nerfstudio/cameras/lie_groups.py
+++ b/nerfstudio/cameras/lie_groups.py
@@ -15,6 +15,7 @@
 """
 Helper for Lie group operations. Currently only used for pose optimization.
 """
+
 import torch
 from jaxtyping import Float
 from torch import Tensor

--- a/nerfstudio/cameras/rays.py
+++ b/nerfstudio/cameras/rays.py
@@ -15,6 +15,7 @@
 """
 Some ray datastructures.
 """
+
 import random
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Literal, Optional, Tuple, Union, overload
@@ -153,15 +154,13 @@ class RaySamples(TensorDataclass):
     @staticmethod
     def get_weights_and_transmittance_from_alphas(
         alphas: Float[Tensor, "*batch num_samples 1"], weights_only: Literal[True]
-    ) -> Float[Tensor, "*batch num_samples 1"]:
-        ...
+    ) -> Float[Tensor, "*batch num_samples 1"]: ...
 
     @overload
     @staticmethod
     def get_weights_and_transmittance_from_alphas(
         alphas: Float[Tensor, "*batch num_samples 1"], weights_only: Literal[False] = False
-    ) -> Tuple[Float[Tensor, "*batch num_samples 1"], Float[Tensor, "*batch num_samples 1"]]:
-        ...
+    ) -> Tuple[Float[Tensor, "*batch num_samples 1"], Float[Tensor, "*batch num_samples 1"]]: ...
 
     @staticmethod
     def get_weights_and_transmittance_from_alphas(

--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -14,7 +14,6 @@
 
 """Base Configs"""
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/nerfstudio/data/datamanagers/parallel_datamanager.py
+++ b/nerfstudio/data/datamanagers/parallel_datamanager.py
@@ -15,6 +15,7 @@
 """
 Parallel data manager that generates training data in multiple python processes.
 """
+
 from __future__ import annotations
 
 import concurrent.futures

--- a/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/arkitscenes_dataparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Data parser for ARKitScenes dataset"""
+
 import math
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/nerfstudio/data/dataparsers/blender_dataparser.py
+++ b/nerfstudio/data/dataparsers/blender_dataparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Data parser for blender dataset"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Data parser for nerfstudio datasets. """
+"""Data parser for nerfstudio datasets."""
 
 from __future__ import annotations
 

--- a/nerfstudio/data/dataparsers/dnerf_dataparser.py
+++ b/nerfstudio/data/dataparsers/dnerf_dataparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Data parser for blender dataset"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/nerfstudio/data/dataparsers/dycheck_dataparser.py
+++ b/nerfstudio/data/dataparsers/dycheck_dataparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Data parser for DyCheck (https://arxiv.org/abs/2210.13445) dataset of `iphone` subset"""
+
 from __future__ import annotations
 
 import math

--- a/nerfstudio/data/dataparsers/nerfosr_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfosr_dataparser.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Data parser for NeRF-OSR datasets
+"""Data parser for NeRF-OSR datasets
 
-    Presented in the paper: https://4dqv.mpi-inf.mpg.de/NeRF-OSR/
+Presented in the paper: https://4dqv.mpi-inf.mpg.de/NeRF-OSR/
 
 """
 

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Data parser for nerfstudio datasets. """
+"""Data parser for nerfstudio datasets."""
 
 from __future__ import annotations
 

--- a/nerfstudio/data/dataparsers/nuscenes_dataparser.py
+++ b/nerfstudio/data/dataparsers/nuscenes_dataparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Data parser for NuScenes dataset"""
+
 import math
 import os
 from dataclasses import dataclass, field

--- a/nerfstudio/data/dataparsers/phototourism_dataparser.py
+++ b/nerfstudio/data/dataparsers/phototourism_dataparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Phototourism dataset parser. Datasets and documentation here: http://phototour.cs.washington.edu/datasets/"""
+
 from __future__ import annotations
 
 import math

--- a/nerfstudio/data/dataparsers/scannet_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannet_dataparser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Data parser for ScanNet dataset"""
+
 import math
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/nerfstudio/data/dataparsers/scannetpp_dataparser.py
+++ b/nerfstudio/data/dataparsers/scannetpp_dataparser.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Data parser for ScanNet++ datasets. """
+"""Data parser for ScanNet++ datasets."""
 
 from __future__ import annotations
 

--- a/nerfstudio/data/datasets/base_dataset.py
+++ b/nerfstudio/data/datasets/base_dataset.py
@@ -15,6 +15,7 @@
 """
 Dataset.
 """
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/nerfstudio/data/utils/data_utils.py
+++ b/nerfstudio/data/utils/data_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Utility functions to allow easy re-use of common operations across dataloaders"""
+
 from pathlib import Path
 from typing import List, Tuple, Union
 

--- a/nerfstudio/data/utils/dataparsers_utils.py
+++ b/nerfstudio/data/utils/dataparsers_utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Data parser utils for nerfstudio datasets. """
+"""Data parser utils for nerfstudio datasets."""
 
 import math
 import os

--- a/nerfstudio/engine/callbacks.py
+++ b/nerfstudio/engine/callbacks.py
@@ -15,6 +15,7 @@
 """
 Callback code used for training iterations
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/nerfstudio/engine/optimizers.py
+++ b/nerfstudio/engine/optimizers.py
@@ -15,6 +15,7 @@
 """
 Optimizers class.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -15,6 +15,7 @@
 """
 Code to train model.
 """
+
 from __future__ import annotations
 
 import dataclasses

--- a/nerfstudio/exporter/exporter_utils.py
+++ b/nerfstudio/exporter/exporter_utils.py
@@ -16,7 +16,6 @@
 Export utils such as structs, point cloud generation, and rendering code.
 """
 
-
 from __future__ import annotations
 
 import sys

--- a/nerfstudio/exporter/texture_utils.py
+++ b/nerfstudio/exporter/texture_utils.py
@@ -16,7 +16,6 @@
 Texture utils.
 """
 
-
 from __future__ import annotations
 
 import math

--- a/nerfstudio/exporter/tsdf_utils.py
+++ b/nerfstudio/exporter/tsdf_utils.py
@@ -16,7 +16,6 @@
 TSDF utils.
 """
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/nerfstudio/field_components/__init__.py
+++ b/nerfstudio/field_components/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """init field modules"""
+
 from .base_field_component import FieldComponent as FieldComponent
 from .encodings import Encoding as Encoding, ScalingAndOffset as ScalingAndOffset
 from .mlp import MLP as MLP

--- a/nerfstudio/field_components/base_field_component.py
+++ b/nerfstudio/field_components/base_field_component.py
@@ -15,6 +15,7 @@
 """
 The field module baseclass.
 """
+
 from abc import abstractmethod
 from typing import Optional
 

--- a/nerfstudio/field_components/embedding.py
+++ b/nerfstudio/field_components/embedding.py
@@ -16,7 +16,6 @@
 Code for embeddings.
 """
 
-
 import torch
 from jaxtyping import Shaped
 from torch import Tensor

--- a/nerfstudio/field_components/field_heads.py
+++ b/nerfstudio/field_components/field_heads.py
@@ -15,6 +15,7 @@
 """
 Collection of render heads
 """
+
 from enum import Enum
 from typing import Callable, Optional, Union
 

--- a/nerfstudio/field_components/mlp.py
+++ b/nerfstudio/field_components/mlp.py
@@ -15,6 +15,7 @@
 """
 Multi Layer Perceptron
 """
+
 from typing import Literal, Optional, Set, Tuple, Union
 
 import numpy as np

--- a/nerfstudio/fields/density_fields.py
+++ b/nerfstudio/fields/density_fields.py
@@ -16,7 +16,6 @@
 Proposal network field.
 """
 
-
 from typing import Literal, Optional, Tuple
 
 import torch

--- a/nerfstudio/fields/generfacto_field.py
+++ b/nerfstudio/fields/generfacto_field.py
@@ -16,7 +16,6 @@
 Field for Generfacto model
 """
 
-
 from typing import Dict, Literal, Optional, Tuple
 
 import numpy as np

--- a/nerfstudio/fields/nerfacto_field.py
+++ b/nerfstudio/fields/nerfacto_field.py
@@ -16,7 +16,6 @@
 Field for compound nerf model, adds scene contraction and image embeddings to instant ngp
 """
 
-
 from typing import Dict, Literal, Optional, Tuple
 
 import torch

--- a/nerfstudio/fields/semantic_nerf_field.py
+++ b/nerfstudio/fields/semantic_nerf_field.py
@@ -15,6 +15,7 @@
 """
 Semantic NeRF field implementation.
 """
+
 from typing import Dict, Optional, Tuple
 
 import torch

--- a/nerfstudio/fields/tensorf_field.py
+++ b/nerfstudio/fields/tensorf_field.py
@@ -14,7 +14,6 @@
 
 """TensoRF Field"""
 
-
 from typing import Dict, Optional
 
 import torch

--- a/nerfstudio/fields/vanilla_nerf_field.py
+++ b/nerfstudio/fields/vanilla_nerf_field.py
@@ -14,7 +14,6 @@
 
 """Classic NeRF field"""
 
-
 from typing import Dict, Optional, Tuple, Type
 
 import torch

--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -15,6 +15,7 @@
 """
 Collection of Losses.
 """
+
 from enum import Enum
 from typing import Dict, Literal, Optional, Tuple, cast
 

--- a/nerfstudio/model_components/ray_generators.py
+++ b/nerfstudio/model_components/ray_generators.py
@@ -15,6 +15,7 @@
 """
 Ray generator.
 """
+
 from jaxtyping import Int
 from torch import Tensor, nn
 

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -379,8 +379,7 @@ class DensityFn(Protocol):
 
     def __call__(
         self, positions: Float[Tensor, "*batch 3"], times: Optional[Float[Tensor, "*batch 1"]] = None
-    ) -> Float[Tensor, "*batch 1"]:
-        ...
+    ) -> Float[Tensor, "*batch 1"]: ...
 
 
 class VolumetricSampler(Sampler):

--- a/nerfstudio/model_components/renderers.py
+++ b/nerfstudio/model_components/renderers.py
@@ -26,6 +26,7 @@ Example:
     rgb = rgb_renderer(rgb=field_outputs[FieldHeadNames.RGB], weights=weights)
 
 """
+
 import contextlib
 import math
 from typing import Generator, Literal, Optional, Tuple, Union

--- a/nerfstudio/model_components/shaders.py
+++ b/nerfstudio/model_components/shaders.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Shaders for rendering."""
+
 from typing import Optional
 
 from jaxtyping import Float

--- a/nerfstudio/models/mipnerf.py
+++ b/nerfstudio/models/mipnerf.py
@@ -15,6 +15,7 @@
 """
 Implementation of mip-NeRF.
 """
+
 from __future__ import annotations
 
 from typing import Dict, List, Tuple

--- a/nerfstudio/pipelines/base_pipeline.py
+++ b/nerfstudio/pipelines/base_pipeline.py
@@ -15,6 +15,7 @@
 """
 Abstracts for the Pipeline class.
 """
+
 from __future__ import annotations
 
 import typing

--- a/nerfstudio/plugins/types.py
+++ b/nerfstudio/plugins/types.py
@@ -15,6 +15,7 @@
 """
 This package contains specifications used to register plugins.
 """
+
 from dataclasses import dataclass
 
 from nerfstudio.engine.trainer import TrainerConfig

--- a/nerfstudio/scripts/docs/build_docs.py
+++ b/nerfstudio/scripts/docs/build_docs.py
@@ -14,6 +14,7 @@
 
 #!/usr/bin/env python
 """Simple yaml debugger"""
+
 import subprocess
 import sys
 

--- a/nerfstudio/scripts/downloads/download_data.py
+++ b/nerfstudio/scripts/downloads/download_data.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Download datasets and specific captures from the datasets."""
+
 from __future__ import annotations
 
 import json

--- a/nerfstudio/scripts/eval.py
+++ b/nerfstudio/scripts/eval.py
@@ -16,6 +16,7 @@
 """
 eval.py
 """
+
 from __future__ import annotations
 
 import json

--- a/nerfstudio/scripts/exporter.py
+++ b/nerfstudio/scripts/exporter.py
@@ -16,7 +16,6 @@
 Script for exporting NeRF into other formats.
 """
 
-
 from __future__ import annotations
 
 import json

--- a/nerfstudio/scripts/github/run_actions.py
+++ b/nerfstudio/scripts/github/run_actions.py
@@ -14,6 +14,7 @@
 
 #!/usr/bin/env python
 """Simple yaml debugger"""
+
 import subprocess
 import sys
 

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -506,8 +506,7 @@ class ProcessODM(BaseConverterToNerfstudioDataset):
 
 @dataclass
 class NotInstalled:
-    def main(self) -> None:
-        ...
+    def main(self) -> None: ...
 
 
 Commands = Union[

--- a/nerfstudio/scripts/render.py
+++ b/nerfstudio/scripts/render.py
@@ -16,6 +16,7 @@
 """
 render.py
 """
+
 from __future__ import annotations
 
 import gzip

--- a/nerfstudio/scripts/viewer/sync_viser_message_defs.py
+++ b/nerfstudio/scripts/viewer/sync_viser_message_defs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Generate viser message definitions for TypeScript, by parsing Python dataclasses."""
+
 import json
 import pathlib
 from datetime import datetime

--- a/nerfstudio/utils/colormaps.py
+++ b/nerfstudio/utils/colormaps.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Helper functions for visualizing outputs """
+"""Helper functions for visualizing outputs"""
 
 from dataclasses import dataclass
 from typing import Literal, Optional

--- a/nerfstudio/utils/colors.py
+++ b/nerfstudio/utils/colors.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Common Colors"""
+
 from typing import Union
 
 import torch

--- a/nerfstudio/utils/comms.py
+++ b/nerfstudio/utils/comms.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """functionality to handle multiprocessing syncing and communicating"""
+
 import torch.distributed as dist
 
 LOCAL_PROCESS_GROUP = None

--- a/nerfstudio/utils/decorators.py
+++ b/nerfstudio/utils/decorators.py
@@ -15,6 +15,7 @@
 """
 Decorator definitions
 """
+
 from typing import Callable, List
 
 from nerfstudio.utils import comms

--- a/nerfstudio/utils/eval_utils.py
+++ b/nerfstudio/utils/eval_utils.py
@@ -15,6 +15,7 @@
 """
 Evaluation utils
 """
+
 from __future__ import annotations
 
 import os

--- a/nerfstudio/utils/math.py
+++ b/nerfstudio/utils/math.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Math Helper Functions """
+"""Math Helper Functions"""
 
 import itertools
 import math

--- a/nerfstudio/utils/misc.py
+++ b/nerfstudio/utils/misc.py
@@ -16,7 +16,6 @@
 Miscellaneous helper code.
 """
 
-
 import platform
 import typing
 import warnings

--- a/nerfstudio/utils/profiler.py
+++ b/nerfstudio/utils/profiler.py
@@ -15,6 +15,7 @@
 """
 Profiler base class and functionality
 """
+
 from __future__ import annotations
 
 import functools
@@ -41,13 +42,11 @@ CallableT = TypeVar("CallableT", bound=Callable)
 
 
 @overload
-def time_function(name_or_func: CallableT) -> CallableT:
-    ...
+def time_function(name_or_func: CallableT) -> CallableT: ...
 
 
 @overload
-def time_function(name_or_func: str) -> ContextManager[Any]:
-    ...
+def time_function(name_or_func: str) -> ContextManager[Any]: ...
 
 
 def time_function(name_or_func: Union[CallableT, str]) -> Union[CallableT, ContextManager[Any]]:

--- a/nerfstudio/utils/writer.py
+++ b/nerfstudio/utils/writer.py
@@ -15,6 +15,7 @@
 """
 Generic Writer class
 """
+
 from __future__ import annotations
 
 import enum

--- a/nerfstudio/viewer/control_panel.py
+++ b/nerfstudio/viewer/control_panel.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Control panel for the viewer """
+"""Control panel for the viewer"""
+
 from collections import defaultdict
 from typing import Callable, DefaultDict, List, Tuple, get_args
 

--- a/nerfstudio/viewer/render_state_machine.py
+++ b/nerfstudio/viewer/render_state_machine.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" This file contains the render state machine, which is responsible for deciding when to render the image """
+"""This file contains the render state machine, which is responsible for deciding when to render the image"""
+
 from __future__ import annotations
 
 import contextlib

--- a/nerfstudio/viewer/server/viewer_elements.py
+++ b/nerfstudio/viewer/server/viewer_elements.py
@@ -16,4 +16,5 @@
 
 Resolves issues like: https://github.com/ayaanzhaque/instruct-nerf2nerf/pull/88
 """
+
 from ..viewer_elements import *  # noqa

--- a/nerfstudio/viewer/viewer_elements.py
+++ b/nerfstudio/viewer/viewer_elements.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-""" Viewer GUI elements for the nerfstudio viewer """
-
+"""Viewer GUI elements for the nerfstudio viewer"""
 
 from __future__ import annotations
 
@@ -172,8 +171,7 @@ class ViewerControl:
         event_type: Literal["click"],
         cb: Callable[[ViewerClick], None],
         removed_cb: Optional[Callable[[], None]] = None,
-    ):
-        ...
+    ): ...
 
     @overload
     def register_pointer_cb(
@@ -181,8 +179,7 @@ class ViewerControl:
         event_type: Literal["rect-select"],
         cb: Callable[[ViewerRectSelect], None],
         removed_cb: Optional[Callable[[], None]] = None,
-    ):
-        ...
+    ): ...
 
     def register_pointer_cb(
         self,
@@ -388,8 +385,7 @@ class ViewerParameter(ViewerElement[TValue], Generic[TValue]):
         self.gui_handle.on_update(lambda _: self.cb_hook(self))
 
     @abstractmethod
-    def _create_gui_handle(self, viser_server: ViserServer) -> None:
-        ...
+    def _create_gui_handle(self, viser_server: ViserServer) -> None: ...
 
     @property
     def value(self) -> TValue:

--- a/nerfstudio/viewer_legacy/app/run_deploy.py
+++ b/nerfstudio/viewer_legacy/app/run_deploy.py
@@ -16,6 +16,7 @@
 Code for deploying the built viewer folder to a server and handing versioning.
 We use the library sshconf (https://github.com/sorend/sshconf) for working with the ssh config file.
 """
+
 import json
 import subprocess
 from os.path import expanduser

--- a/nerfstudio/viewer_legacy/server/control_panel.py
+++ b/nerfstudio/viewer_legacy/server/control_panel.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Control panel for the viewer """
+"""Control panel for the viewer"""
+
 from collections import defaultdict
 from typing import Callable, DefaultDict, List, Tuple, get_args
 

--- a/nerfstudio/viewer_legacy/server/gui_utils.py
+++ b/nerfstudio/viewer_legacy/server/gui_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Utilities for generating custom gui elements in the viewer """
+"""Utilities for generating custom gui elements in the viewer"""
 
 from __future__ import annotations
 

--- a/nerfstudio/viewer_legacy/server/path.py
+++ b/nerfstudio/viewer_legacy/server/path.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Path class
-"""
-
+"""Path class"""
 
 from typing import Tuple
 

--- a/nerfstudio/viewer_legacy/server/render_state_machine.py
+++ b/nerfstudio/viewer_legacy/server/render_state_machine.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" This file contains the render state machine, which is responsible for deciding when to render the image """
+"""This file contains the render state machine, which is responsible for deciding when to render the image"""
+
 from __future__ import annotations
 
 import contextlib

--- a/nerfstudio/viewer_legacy/server/utils.py
+++ b/nerfstudio/viewer_legacy/server/utils.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Generic utility functions
-"""
+"""Generic utility functions"""
 
 from typing import List, Optional, Tuple, Union
 

--- a/nerfstudio/viewer_legacy/server/viewer_elements.py
+++ b/nerfstudio/viewer_legacy/server/viewer_elements.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-""" Viewer GUI elements for the nerfstudio viewer """
-
+"""Viewer GUI elements for the nerfstudio viewer"""
 
 from __future__ import annotations
 
@@ -263,8 +262,7 @@ class ViewerParameter(ViewerElement[TValue], Generic[TValue]):
         self.gui_handle.on_update(lambda _: self.cb_hook(self))
 
     @abstractmethod
-    def _create_gui_handle(self, viser_server: ViserServer) -> None:
-        ...
+    def _create_gui_handle(self, viser_server: ViserServer) -> None: ...
 
     @property
     def value(self) -> TValue:

--- a/nerfstudio/viewer_legacy/server/viewer_state.py
+++ b/nerfstudio/viewer_legacy/server/viewer_state.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Manage the state of the viewer """
+"""Manage the state of the viewer"""
+
 from __future__ import annotations
 
 import threading

--- a/nerfstudio/viewer_legacy/server/viewer_utils.py
+++ b/nerfstudio/viewer_legacy/server/viewer_utils.py
@@ -14,6 +14,7 @@
 
 
 """Code to interface with the `vis/` (the JS viewer)."""
+
 from __future__ import annotations
 
 import os

--- a/nerfstudio/viewer_legacy/viser/__init__.py
+++ b/nerfstudio/viewer_legacy/viser/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Viser is used for the nerfstudio viewer backend """
-
+"""Viser is used for the nerfstudio viewer backend"""
 
 from .message_api import GuiHandle as GuiHandle, GuiSelectHandle as GuiSelectHandle
 from .messages import NerfstudioMessage as NerfstudioMessage

--- a/nerfstudio/viewer_legacy/viser/gui.py
+++ b/nerfstudio/viewer_legacy/viser/gui.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 
-""" Manages GUI communication.
+"""Manages GUI communication.
 
 Should be almost identical to: https://github.com/brentyi/viser/blob/main/viser/_gui.py
 """
+
 from __future__ import annotations
 
 import dataclasses

--- a/nerfstudio/viewer_legacy/viser/message_api.py
+++ b/nerfstudio/viewer_legacy/viser/message_api.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" This module contains the MessageApi class, which is the interface for sending messages to the Viewer"""
-
+"""This module contains the MessageApi class, which is the interface for sending messages to the Viewer"""
 
 from __future__ import annotations
 
@@ -274,8 +273,7 @@ class MessageApi(abc.ABC):
         options: List[TLiteralString],
         initial_value: Optional[TLiteralString] = None,
         hint: Optional[str] = None,
-    ) -> GuiSelectHandle[TLiteralString]:
-        ...
+    ) -> GuiSelectHandle[TLiteralString]: ...
 
     @overload
     def add_gui_select(
@@ -284,8 +282,7 @@ class MessageApi(abc.ABC):
         options: List[str],
         initial_value: Optional[str] = None,
         hint: Optional[str] = None,
-    ) -> GuiSelectHandle[str]:
-        ...
+    ) -> GuiSelectHandle[str]: ...
 
     def add_gui_select(
         self,
@@ -325,8 +322,7 @@ class MessageApi(abc.ABC):
         name: str,
         options: List[TLiteralString],
         initial_value: Optional[TLiteralString] = None,
-    ) -> GuiHandle[TLiteralString]:
-        ...
+    ) -> GuiHandle[TLiteralString]: ...
 
     @overload
     def add_gui_button_group(
@@ -334,8 +330,7 @@ class MessageApi(abc.ABC):
         name: str,
         options: List[str],
         initial_value: Optional[str] = None,
-    ) -> GuiHandle[str]:
-        ...
+    ) -> GuiHandle[str]: ...
 
     def add_gui_button_group(
         self,

--- a/nerfstudio/viewer_legacy/viser/server.py
+++ b/nerfstudio/viewer_legacy/viser/server.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Core Viser Server """
-
+"""Core Viser Server"""
 
 from __future__ import annotations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "msgpack_numpy>=0.4.8",
     "nerfacc==0.5.2",
     "open3d>=0.16.0",
-    "opencv-python==4.8.0.76",
+    "opencv-python==4.10.0.84",
     "Pillow>=10.3.0",
     "plotly>=5.7.0",
     "protobuf<=3.20.3,!=3.20.0",
@@ -92,7 +92,7 @@ dev = [
     "pytest==7.1.2",
     "pytest-xdist==2.5.0",
     "typeguard==2.13.3",
-    "ruff==0.1.13",
+    "ruff>=0.4.8",
     "sshconf==0.2.5",
     "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions
     "diffusers==0.16.1",
@@ -165,7 +165,7 @@ pythonPlatform = "Linux"
 [tool.ruff]
 line-length = 120
 respect-gitignore = false
-select = [
+lint.select = [
     "E",  # pycodestyle errors.
     "F",  # Pyflakes rules.
     "I",  # isort formatting.
@@ -173,8 +173,9 @@ select = [
     "PLE",  # Pylint errors.
     "PLR",  # Pylint refactor recommendations.
     "PLW",  # Pylint warnings.
+    "NPY201" # NumPY 2.0 migration https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin
 ]
-ignore = [
+lint.ignore = [
     "E501",  # Line too long.
     "F722",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.
     "F821",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.

--- a/tests/cameras/test_cameras.py
+++ b/tests/cameras/test_cameras.py
@@ -1,6 +1,7 @@
 """
 Test the camera classes.
 """
+
 import dataclasses
 from itertools import product
 

--- a/tests/field_components/test_embedding.py
+++ b/tests/field_components/test_embedding.py
@@ -1,6 +1,7 @@
 """
 Embedding tests
 """
+
 from nerfstudio.field_components.embedding import Embedding
 
 

--- a/tests/field_components/test_encodings.py
+++ b/tests/field_components/test_encodings.py
@@ -1,6 +1,7 @@
 """
 Encoding Tests
 """
+
 import pytest
 import torch
 

--- a/tests/field_components/test_field_outputs.py
+++ b/tests/field_components/test_field_outputs.py
@@ -1,6 +1,7 @@
 """
 Field output tests
 """
+
 import pytest
 import torch
 from torch import nn

--- a/tests/field_components/test_fields.py
+++ b/tests/field_components/test_fields.py
@@ -1,6 +1,7 @@
 """
 Test the fields
 """
+
 import torch
 
 from nerfstudio.cameras.rays import Frustums, RaySamples

--- a/tests/field_components/test_mlp.py
+++ b/tests/field_components/test_mlp.py
@@ -1,6 +1,7 @@
 """
 MLP Test
 """
+
 import torch
 from torch import nn
 

--- a/tests/field_components/test_temporal_distortions.py
+++ b/tests/field_components/test_temporal_distortions.py
@@ -1,6 +1,7 @@
 """
 Test if temporal distortions run properly
 """
+
 import torch
 
 from nerfstudio.field_components.temporal_distortions import DNeRFDistortion

--- a/tests/model_components/test_renderers.py
+++ b/tests/model_components/test_renderers.py
@@ -1,6 +1,7 @@
 """
 Test renderers
 """
+
 import pytest
 import torch
 

--- a/tests/pipelines/test_vanilla_pipeline.py
+++ b/tests/pipelines/test_vanilla_pipeline.py
@@ -1,6 +1,7 @@
 """
 Test pipeline
 """
+
 from pathlib import Path
 
 import torch

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -1,6 +1,7 @@
 """
 Tests for the nerfstudio.plugins.registry module.
 """
+
 import os
 import sys
 from dataclasses import dataclass, field

--- a/tests/process_data/test_process_images.py
+++ b/tests/process_data/test_process_images.py
@@ -1,6 +1,7 @@
 """
 Process images test
 """
+
 import os
 from pathlib import Path
 

--- a/tests/utils/test_aabb_intersection.py
+++ b/tests/utils/test_aabb_intersection.py
@@ -1,6 +1,7 @@
 """
 Test AABB intersection
 """
+
 import importlib
 import math
 import os

--- a/tests/utils/test_tensor_dataclass.py
+++ b/tests/utils/test_tensor_dataclass.py
@@ -1,6 +1,7 @@
 """
 Test tensor dataclass
 """
+
 from dataclasses import dataclass, field
 from typing import Generic, Optional, TypeVar
 

--- a/tests/utils/test_visualization.py
+++ b/tests/utils/test_visualization.py
@@ -1,6 +1,7 @@
 """
 Test colormaps
 """
+
 import torch
 
 from nerfstudio.utils import colormaps, plotly_utils


### PR DESCRIPTION
WIP for supporting numpy 2.0. Our builds were breaking because of numpy 2.0, I added the automatic ruff linting as described [here](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#ruff-plugin), and also upgraded OpenCV to 4.10 as described [here](https://github.com/opencv/opencv-python/issues/943).

@jb-ye @f-dy I seem to remember there was some reason we pinned OpenCV to 4.8 related to the undistorting code, do you know if that's still important?