### PR TITLE
Update pytorch in Dockerfile to 2.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,18 +127,18 @@ WORKDIR /home/${USERNAME}
 ENV PATH="${PATH}:/home/${USERNAME}/.local/bin"
 
 # Upgrade pip and install packages.
-RUN python3.10 -m pip install --no-cache-dir --upgrade pip setuptools pathtools promise pybind11 omegaconf
+RUN python3.10 -m pip install --no-cache-dir --upgrade pip setuptools==69.5.1 pathtools promise pybind11 omegaconf
 
 # Install pytorch and submodules
 # echo "${CUDA_VERSION}" | sed 's/.$//' | tr -d '.' -- CUDA_VERSION -> delete last digit -> delete all '.'
 RUN CUDA_VER=$(echo "${CUDA_VERSION}" | sed 's/.$//' | tr -d '.') && python3.10 -m pip install --no-cache-dir \
-    torch==2.0.1+cu${CUDA_VER} \
-    torchvision==0.15.2+cu${CUDA_VER} \
+    torch==2.1.2+cu${CUDA_VER} \
+    torchvision==0.16.2+cu${CUDA_VER} \
         --extra-index-url https://download.pytorch.org/whl/cu${CUDA_VER}
 
 # Install tiny-cuda-nn (we need to set the target architectures as environment variable first).
 ENV TCNN_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
-RUN python3.10 -m pip install --no-cache-dir git+https://github.com/NVlabs/tiny-cuda-nn.git@v1.6#subdirectory=bindings/torch
+RUN python3.10 -m pip install --no-cache-dir git+https://github.com/NVlabs/tiny-cuda-nn.git#subdirectory=bindings/torch
 
 # Install pycolmap, required by hloc.
 RUN git clone --branch v0.4.0 --recursive https://github.com/colmap/pycolmap.git && \


### PR DESCRIPTION
Update pytorch to fix gsplat incompatibilities with versions >= 1.0.0
Additionally, version pinning of tinycudann as 1.6 was removed as it is not compatible with the new pytorch
setuptools is now fixed to 69.5.1 also because of incompatibilities
Currently, numpy 2 creates an error but as others are already working on fixing this in nerfstudio I'm skipping it in the Dockerfile. In case you need to fix it now please pin the version in nerfstudio dependencies or add a line in the Dockerfile before the ns-install-cli command:
RUN python3.10 -m pip install --no-cache-dir numpy==1.26.4

Fixes #3235 