### PR TITLE
Make `awscli` an optional dependency

### DIFF
--- a/docs/quickstart/existing_dataset.md
+++ b/docs/quickstart/existing_dataset.md
@@ -17,6 +17,7 @@ ns-download-data blender
 ns-download-data nerfstudio --capture-name nerfstudio-dataset
 
 # Download a few room-scale scenes from the EyefulTower dataset at different resolutions
+pip install awscli # Install `awscli` for EyefulTower downloads.
 ns-download-data eyefultower --capture-name riverview seating_area apartment --resolution-name jpeg_1k jpeg_2k
 
 # Download the full D-NeRF dataset of dynamic synthetic scenes
@@ -87,3 +88,10 @@ In the tables below, each dataset was placed into a bucket based on the table's 
 [record3d]: https://record3d.app/
 [sdfstudio]: https://github.com/autonomousvision/sdfstudio/blob/master/docs/sdfstudio-data.md#Existing-dataset
 [sitcoms3d]: https://github.com/ethanweber/sitcoms3D/blob/master/METADATA.md
+
+### Eyeful Tower
+Downloading Eyeful Tower scenes requires installing the AWS CLI, an optional dependency. To do so, run:
+```bash
+conda activate nerfstudio
+pip install awscli
+```

--- a/nerfstudio/scripts/downloads/download_data.py
+++ b/nerfstudio/scripts/downloads/download_data.py
@@ -554,7 +554,7 @@ Commands = Union[
 
 
 @dataclass
-class NotInstalled:
+class NotInstalled(DatasetDownload):
     def main(self) -> None: ...
 
 

--- a/nerfstudio/scripts/downloads/download_data.py
+++ b/nerfstudio/scripts/downloads/download_data.py
@@ -32,7 +32,6 @@ import tyro
 from typing_extensions import Annotated
 
 from nerfstudio.process_data import process_data_utils
-from nerfstudio.scripts.downloads.eyeful_tower import EyefulTowerDownload
 from nerfstudio.scripts.downloads.utils import DatasetDownload
 from nerfstudio.utils import install_checks
 from nerfstudio.utils.scripts import run_command
@@ -551,8 +550,38 @@ Commands = Union[
     Annotated[SDFstudioDemoDownload, tyro.conf.subcommand(name="sdfstudio")],
     Annotated[NeRFOSRDownload, tyro.conf.subcommand(name="nerfosr")],
     Annotated[Mill19Download, tyro.conf.subcommand(name="mill19")],
-    Annotated[EyefulTowerDownload, tyro.conf.subcommand(name="eyefultower")],
 ]
+
+
+@dataclass
+class NotInstalled:
+    def main(self) -> None: ...
+
+
+# Add eyefultower subcommand if awscli is installed.
+try:
+    import awscli
+except ImportError:
+    awscli = None
+
+if awscli is not None:
+    from nerfstudio.scripts.downloads.eyeful_tower import EyefulTowerDownload
+
+    Commands = Union[
+        Commands,
+        Annotated[EyefulTowerDownload, tyro.conf.subcommand(name="eyefultower")],
+    ]
+else:
+    Commands = Union[
+        Commands,
+        Annotated[
+            NotInstalled,
+            tyro.conf.subcommand(
+                name="eyefultower",
+                description="**Not installed.** Downloading EyefulTower data requires `pip install awscli`.",
+            ),
+        ],
+    ]
 
 
 def main(

--- a/nerfstudio/scripts/downloads/eyeful_tower.py
+++ b/nerfstudio/scripts/downloads/eyeful_tower.py
@@ -16,14 +16,20 @@
 import collections
 import copy
 import json
+import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Tuple
 
-import awscli.clidriver
 import numpy as np
 import tyro
+
+try:
+    import awscli.clidriver
+except ImportError:
+    print("awscli is required for EyefulTower download. Please install it with `pip install awscli`.")
+    sys.exit(1)
 
 from nerfstudio.scripts.downloads.utils import DatasetDownload
 from nerfstudio.utils.rich_utils import CONSOLE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ dev = [
     "projectaria-tools>=1.3.1; sys_platform != 'win32'",
     # pin torch to <=2.1 to fix https://github.com/pytorch/pytorch/issues/118736
     "torch>=1.13.1,<2.2",
+    "awscli==1.33.18"
 ]
 
 # Documentation related packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
 dependencies = [
     "appdirs>=1.4",
     "av>=9.2.0",
-    "awscli>=1.31.10",
     "comet_ml>=3.33.8",
     "cryptography>=38",
     "tyro>=0.6.6",


### PR DESCRIPTION
As discussed in #3269, removes `awscli` from the main project dependencies in favor of a manual install by Eyeful Tower users. 

Main changes:
* Removes `awscli` from `pyproject.toml`.
* Adds error handling on `eyefultower.py` prompting users to install `awscli` on `ImportError`. 
* Adds error handling to `download_data.py` for case when `awscli` is not installed.
* Adds lines to documentation instructing Eyeful Tower users to manually install `awscli`.  