### PR TITLE
Upgraded Polycam Error

### DIFF
--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -150,8 +150,9 @@ class ProcessPolycam(BaseConverterToNerfstudioDataset):
         if self.data.suffix == ".zip":
             with zipfile.ZipFile(self.data, "r") as zip_ref:
                 zip_ref.extractall(self.output_dir)
-                extracted_folder = zip_ref.namelist()[0].split("/")[0]
-            self.data = self.output_dir / extracted_folder
+                # extracted_folder = zip_ref.namelist()[0].split("/")[0]
+            # self.data = self.output_dir / extracted_folder
+            self.data = self.output_dir
             if not (self.data / "keyframes").exists():
                 # new versions of polycam data have a different structure, strip the last dir off
                 self.data = self.output_dir


### PR DESCRIPTION
Fixed directory path issue after upgrading Polycam app.
This will work for the extracted data from the upgraded Polycam app.