### PR TITLE
merge mesh initialization to splatfacto

### DIFF
--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -27,6 +27,8 @@ import torch
 from PIL import Image
 from rich.prompt import Confirm
 
+import trimesh
+
 from nerfstudio.cameras import camera_utils
 from nerfstudio.cameras.cameras import CAMERA_MODEL_TO_TYPE, Cameras
 from nerfstudio.data.dataparsers.base_dataparser import DataParser, DataParserConfig, DataparserOutputs
@@ -41,6 +43,7 @@ from nerfstudio.data.utils.dataparsers_utils import (
 from nerfstudio.process_data.colmap_utils import parse_colmap_camera_params
 from nerfstudio.utils.rich_utils import CONSOLE, status
 from nerfstudio.utils.scripts import run_command
+from nerfstudio.utils.general_utils import MeshPointCloud, rotx
 
 MAX_AUTO_RESOLUTION = 1600
 
@@ -63,11 +66,11 @@ class ColmapDataParserConfig(DataParserConfig):
     """How much to scale the region of interest by."""
     orientation_method: Literal["pca", "up", "vertical", "none"] = "up"
     """The method to use for orientation."""
-    center_method: Literal["poses", "focus", "none"] = "poses"
+    center_method: Literal["poses", "focus", "none"] = "none"
     """The method to use to center the poses."""
     auto_scale_poses: bool = True
     """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
-    assume_colmap_world_coordinate_convention: bool = True
+    assume_colmap_world_coordinate_convention: bool = False
     """Colmap optimized world often have y direction of the first camera pointing towards down direction,
     while nerfstudio world set z direction to be up direction for viewer. Therefore, we usually need to apply an extra
     transform when orientation_method=none. This parameter has no effects if orientation_method is set other than none.
@@ -392,13 +395,49 @@ class ColmapDataParser(DataParser):
         return dataparser_outputs
 
     def _load_3D_points(self, colmap_path: Path, transform_matrix: torch.Tensor, scale_factor: float):
+        points3D = None
+        if (colmap_path / "scene.obj").exists():
+            mesh_scene = trimesh.load(colmap_path / "scene.obj", force='mesh')
+            vertices = mesh_scene.vertices # (num_pt, 3)
+            faces = mesh_scene.faces # (num_faces, 3)
+            triangles = torch.tensor(mesh_scene.triangles).float()  # equal vertices[faces]
+            # rotated y-up world frame to z-up world frame
+            vertices = np.einsum('ij,kj->ki', rotx(np.pi / 2), vertices)
+            vertices = torch.from_numpy(vertices.astype(np.float32))
+
+            num_pts_each_triangle = 1 #self.config.num_splats
+            num_pts = num_pts_each_triangle * triangles.shape[0]
+            print('triangle face number', triangles.shape[0])
+            print('points total', vertices.shape[0])
+
+            # We create random points inside the bounds traingles
+            alpha = torch.rand(
+                triangles.shape[0],
+                num_pts_each_triangle,
+                3
+            )
+
+            print("alpha sum max is:", alpha.sum(dim=2, keepdim=False).max())
+
+            xyz = torch.matmul(
+                alpha,
+                triangles
+            )
+            points3D = xyz.reshape(num_pts, 3)
+            
         if (colmap_path / "points3D.bin").exists():
             colmap_points = colmap_utils.read_points3D_binary(colmap_path / "points3D.bin")
+            
         elif (colmap_path / "points3D.txt").exists():
             colmap_points = colmap_utils.read_points3D_text(colmap_path / "points3D.txt")
+
         else:
             raise ValueError(f"Could not find points3D.txt or points3D.bin in {colmap_path}")
-        points3D = torch.from_numpy(np.array([p.xyz for p in colmap_points.values()], dtype=np.float32))
+        
+        if points3D is None:
+            points3D = torch.from_numpy(np.array([p.xyz for p in colmap_points.values()], dtype=np.float32))
+        
+        
         points3D = (
             torch.cat(
                 (
@@ -411,6 +450,29 @@ class ColmapDataParser(DataParser):
         )
         points3D *= scale_factor
 
+        pcd = None
+        if (colmap_path / "scene.obj").exists():
+            vertices = (
+                torch.cat(
+                    (
+                        vertices,
+                        torch.ones_like(vertices[..., :1]),
+                    ),
+                    -1,
+                )
+                @ transform_matrix.T
+            )
+            vertices *= scale_factor
+            
+
+            pcd = MeshPointCloud(
+                alpha=alpha,
+                points=points3D,
+                vertices=vertices,
+                faces=faces,
+                triangles=triangles.cuda()
+            )
+
         # Load point colours
         points3D_rgb = torch.from_numpy(np.array([p.rgb for p in colmap_points.values()], dtype=np.uint8))
         points3D_num_points = torch.tensor([len(p.image_ids) for p in colmap_points.values()], dtype=torch.int64)
@@ -420,6 +482,9 @@ class ColmapDataParser(DataParser):
             "points3D_error": torch.from_numpy(np.array([p.error for p in colmap_points.values()], dtype=np.float32)),
             "points3D_num_points2D": points3D_num_points,
         }
+        if pcd is not None:
+            out["points3D_pcd"] = pcd
+
         if self.config.max_2D_matches_per_3D_point != 0:
             if (colmap_path / "images.txt").exists():
                 im_id_to_image = colmap_utils.read_images_text(colmap_path / "images.txt")

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -44,6 +44,7 @@ from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.utils.colors import get_color
 from nerfstudio.utils.misc import torch_compile
 from nerfstudio.utils.rich_utils import CONSOLE
+from nerfstudio.utils.general_utils import MeshPointCloud, rot_to_quat_batch
 
 
 def random_quat_tensor(N):
@@ -96,7 +97,7 @@ def resize_image(image: torch.Tensor, d: int):
     return tf.conv2d(image.permute(2, 0, 1)[:, None, ...], weight, stride=d).squeeze(1).permute(1, 2, 0)
 
 
-@torch_compile()
+# @torch_compile()
 def get_viewmat(optimized_camera_to_world):
     """
     function that converts c2w to gsplat world2camera matrix, using compile for some speed
@@ -185,6 +186,11 @@ class SplatfactoModelConfig(ModelConfig):
     camera_optimizer: CameraOptimizerConfig = field(default_factory=lambda: CameraOptimizerConfig(mode="off"))
     """Config of the camera optimizer to use"""
 
+    use_mesh_initialization: bool = False
+    """If enable, will try to initialize gaussain from mesh""" 
+    num_splats_per_face: int = 1
+    """number of splats to imitialize gaussian on each mesh face"""
+
 
 class SplatfactoModel(Model):
     """Nerfstudio's implementation of Gaussian Splatting
@@ -204,42 +210,71 @@ class SplatfactoModel(Model):
         self.seed_points = seed_points
         super().__init__(*args, **kwargs)
 
-    def populate_modules(self):
-        if self.seed_points is not None and not self.config.random_init:
-            means = torch.nn.Parameter(self.seed_points[0])  # (Location, Color)
-        else:
-            means = torch.nn.Parameter((torch.rand((self.config.num_random, 3)) - 0.5) * self.config.random_scale)
-        self.xys_grad_norm = None
-        self.max_2Dsize = None
-        distances, _ = self.k_nearest_sklearn(means.data, 3)
-        distances = torch.from_numpy(distances)
-        # find the average of the three nearest neighbors for each point and use that as the scale
-        avg_dist = distances.mean(dim=-1, keepdim=True)
-        scales = torch.nn.Parameter(torch.log(avg_dist.repeat(1, 3)))
-        num_points = means.shape[0]
-        quats = torch.nn.Parameter(random_quat_tensor(num_points))
-        dim_sh = num_sh_bases(self.config.sh_degree)
+        # use_scale_regularization and use_mesh_initialization can't be able at the same time
+        # Now just simply set use_scale_regularization to false
+        if self.config.use_scale_regularization and self.config.use_mesh_initialization:
+            raise ValueError("use_scale_regularization and use_mesh_initialization can't be able at the same time")
+        
 
-        if (
-            self.seed_points is not None
-            and not self.config.random_init
-            # We can have colors without points.
-            and self.seed_points[1].shape[0] > 0
-        ):
-            shs = torch.zeros((self.seed_points[1].shape[0], dim_sh, 3)).float().cuda()
-            if self.config.sh_degree > 0:
-                shs[:, 0, :3] = RGB2SH(self.seed_points[1] / 255)
-                shs[:, 1:, 3:] = 0.0
-            else:
-                CONSOLE.log("use color only optimization with sigmoid activation")
-                shs[:, 0, :3] = torch.logit(self.seed_points[1] / 255, eps=1e-10)
-            features_dc = torch.nn.Parameter(shs[:, 0, :])
-            features_rest = torch.nn.Parameter(shs[:, 1:, :])
-        else:
+
+    def populate_modules(self):
+        if self.config.use_mesh_initialization:
+            pcd = self.seed_points[2]
+            if pcd is None:
+                raise ValueError("Trying to use_mesh_initialization, scene.obj must be under sparse/0 folder")
+            
+            print("init gaussian from mesh")
+
+            (means, 
+            scales, 
+            quats) = create_from_pcd(pcd, self.config.sh_degree)
+
+            num_points = means.shape[0]
+            dim_sh = num_sh_bases(self.config.sh_degree)
             features_dc = torch.nn.Parameter(torch.rand(num_points, 3))
             features_rest = torch.nn.Parameter(torch.zeros((num_points, dim_sh - 1, 3)))
+            opacities = torch.nn.Parameter(torch.logit(0.1 * torch.ones(num_points, 1)))
 
-        opacities = torch.nn.Parameter(torch.logit(0.1 * torch.ones(num_points, 1)))
+            self.xys_grad_norm = None
+            self.max_2Dsize = None
+        else:
+            if self.seed_points is not None and not self.config.random_init:
+                means = torch.nn.Parameter(self.seed_points[0])  # (Location, Color)
+            else:
+                means = torch.nn.Parameter((torch.rand((self.config.num_random, 3)) - 0.5) * self.config.random_scale)
+            self.xys_grad_norm = None
+            self.max_2Dsize = None
+            distances, _ = self.k_nearest_sklearn(means.data, 3)
+            distances = torch.from_numpy(distances)
+            # find the average of the three nearest neighbors for each point and use that as the scale
+            avg_dist = distances.mean(dim=-1, keepdim=True)
+            scales = torch.nn.Parameter(torch.log(avg_dist.repeat(1, 3)))
+            num_points = means.shape[0]
+            quats = torch.nn.Parameter(random_quat_tensor(num_points))
+            dim_sh = num_sh_bases(self.config.sh_degree)
+
+            if (
+                self.seed_points is not None
+                and not self.config.random_init
+                # We can have colors without points.
+                and self.seed_points[1].shape[0] > 0
+            ):
+                shs = torch.zeros((self.seed_points[1].shape[0], dim_sh, 3)).float().cuda()
+                if self.config.sh_degree > 0:
+                    shs[:, 0, :3] = RGB2SH(self.seed_points[1] / 255)
+                    shs[:, 1:, 3:] = 0.0
+                else:
+                    CONSOLE.log("use color only optimization with sigmoid activation")
+                    shs[:, 0, :3] = torch.logit(self.seed_points[1] / 255, eps=1e-10)
+                features_dc = torch.nn.Parameter(shs[:, 0, :])
+                features_rest = torch.nn.Parameter(shs[:, 1:, :])
+            else:
+                features_dc = torch.nn.Parameter(torch.rand(num_points, 3))
+                features_rest = torch.nn.Parameter(torch.zeros((num_points, dim_sh - 1, 3)))
+
+            opacities = torch.nn.Parameter(torch.logit(0.1 * torch.ones(num_points, 1)))
+        
+        
         self.gauss_params = torch.nn.ParameterDict(
             {
                 "means": means,
@@ -940,3 +975,135 @@ class SplatfactoModel(Model):
         images_dict = {"img": combined_rgb}
 
         return metrics_dict, images_dict
+
+
+def create_from_pcd(pcd: MeshPointCloud, max_sh_degree: int):
+    print("Creating GaussianMeshModel from MeshPointCloud")
+
+    pcd_alpha_shape = pcd.alpha.shape
+    print("Number of faces: ", pcd_alpha_shape[0])
+    print("Number of points at initialisation in face: ", pcd_alpha_shape[1])
+
+    alpha_point_cloud = pcd.alpha.float().cuda()
+    scale = torch.ones((pcd.points.shape[0], 1)).float().cuda()
+
+    print("Number of points at initialisation : ",
+        alpha_point_cloud.shape[0] * alpha_point_cloud.shape[1])
+
+    ## use alpha, vertex, face to init self._xyz
+    alpha = update_alpha(pcd) ## _alpha means a1,a2,a3 in paper, controlling the gaussians centers
+    vertices = torch.tensor(pcd.vertices).float()
+    faces = torch.tensor(pcd.faces).long()
+    xyz = calc_xyz(alpha, vertices, faces).float()
+    ## use vertex, face and scale to init self._scaling and self._rotation
+    scale = torch.ones((pcd.points.shape[0], 1)).float() ## _scale means ro in paper, controlling the scale of gaussian
+    scaling, quat = calc_scaling_rot(alpha, scale, vertices, faces)
+    scaling = scaling.float()
+    quat = quat.float()
+    xyz = torch.nn.Parameter(xyz)
+    scaling = torch.nn.Parameter(scaling)
+    quat = torch.nn.Parameter(quat)
+
+    return xyz, scaling, quat
+
+
+def update_alpha(pcd: MeshPointCloud):
+    """
+    Function to control the alpha value.
+
+    Alpha is the distance of the center of the gauss
+        from the vertex of the triangle of the mesh.
+    Thus, for each center of the gauss, 3 alphas
+    are determined: alpha1+ alpha2+ alpha3.
+    For a point to be in the center of the vertex,
+    the alphas must meet the assumptions:
+    alpha1 + alpha2 + alpha3 = 1
+    and alpha1, alpha2, alpha3 >= 0
+
+    #TODO
+    check:
+    # self.alpha = torch.relu(self._alpha)
+    # self.alpha = self.alpha / self.alpha.sum(dim=-1, keepdim=True)
+
+    """
+    alpha_relu = torch.relu(pcd.alpha.float()) + 1e-8
+    alpha = alpha_relu / alpha_relu.sum(dim=-1, keepdim=True)
+    return alpha
+
+def calc_xyz(alpha, vertices, faces):
+        """
+        Calculate the 3D Gaussian center in the coordinates xyz.
+
+        The alphas that are taken into account are the distances
+        to the vertices and the coordinates of
+        the triangles forming the mesh.
+
+        Returns:
+            None
+        """
+        xyz = torch.matmul(alpha, vertices[faces])
+        print("Shape of xyz: ", xyz.shape)
+        xyz = xyz.reshape(xyz.shape[0] * xyz.shape[1], 3)
+        print("re Shape of xyz: ", xyz.shape)
+        return xyz
+
+        
+def calc_scaling_rot(alpha, scale, vertices, faces, eps=1e-8):
+    """
+    approximate covariance matrix and calculate scaling/rotation tensors
+
+    covariance matrix is [v0, v1, v2], where
+    v0 is a normal vector to each face
+    v1 is a vector from centroid of each face and 1st vertex
+    v2 is obtained by orthogonal projection of a vector from centroid to 2nd vertex onto subspace spanned by v0 and v1
+
+    Arguments:
+    scale (torch.Tensor): float tensor with shape of [num_face * num_splat, 3]
+
+    returns:
+    rotations (torch.Tensor): float tensor with shape of [num_face * num_splat, 4]
+    scaling (torch.Tensor): float tensor with shape of [num_face * num_splat, 3]
+    """
+    def dot(v, u):
+        return (v * u).sum(dim=-1, keepdim=True)
+    
+    def proj(v, u):
+        """
+        projection of vector v onto subspace spanned by u
+
+        vector u is assumed to be already normalized
+        """
+        coef = dot(v, u)
+        return coef * u
+
+    triangles = vertices[faces] # (num_face, 3, 3)
+    normals = torch.linalg.cross(
+        triangles[:, 1] - triangles[:, 0],
+        triangles[:, 2] - triangles[:, 0],
+        dim=1
+    ) # (num_face , 3)
+    v0 = normals / (torch.linalg.vector_norm(normals, dim=-1, keepdim=True) + eps) # (num_face, 3)
+    means = torch.mean(triangles, dim=1) # (num_face ,3) centers of triangles
+    v1 = triangles[:, 1] - means # (num_face, 3) vectors from center to second vertex of triangles
+    v1_norm = torch.linalg.vector_norm(v1, dim=-1, keepdim=True) + eps # (num_face, 1)
+    v1 = v1 / v1_norm # (num_face , 3)
+    v2_init = triangles[:, 2] - means # (num_face, 3) vectors from center to third vertex of triangles
+    v2 = v2_init - proj(v2_init, v0) - proj(v2_init, v1) # (num_face, 3) Gram-Schmidt
+    v2 = v2 / (torch.linalg.vector_norm(v2, dim=-1, keepdim=True) + eps) # (num_face, 3)
+
+    s1 = v1_norm / 2. # (num_face , 1)
+    s2 = dot(v2_init, v2) / 2. # (num_face, 1)
+    s0 = eps * torch.ones_like(s1) # (num_face , 1)
+    scales = torch.concat((s0, s1, s2), dim=1).unsqueeze(dim=1) # (num_face, 1, 3)
+    scales = scales.broadcast_to((*alpha.shape[:2], 3)) # (num_face, num_splat, 3) scale for each gaussian sampled on mesh faces
+    scaling = torch.log(
+        torch.nn.functional.relu(scale * scales.flatten(start_dim=0, end_dim=1)) + eps
+    ) # (num_face * num_splat, 3) scale vectors for each gaussian
+
+    rotation = torch.stack((v0, v1, v2), dim=1).unsqueeze(dim=1) # (num_face, 1, 3, 3)
+    rotation = rotation.broadcast_to((*alpha.shape[:2], 3, 3)).flatten(start_dim=0, end_dim=1) # (num_face * num_splat, 3, 3) all points on the same face have same scaling and rotation.
+    rotation = rotation.transpose(-2, -1) # (num_face * num_splat, 3, 3)
+    rotation = rot_to_quat_batch(rotation) # (num_face * num_splat, 4) rotation matrix to quarternion
+
+    return scaling, rotation
+

--- a/nerfstudio/pipelines/base_pipeline.py
+++ b/nerfstudio/pipelines/base_pipeline.py
@@ -264,7 +264,8 @@ class VanillaPipeline(Pipeline):
         ):
             pts = self.datamanager.train_dataparser_outputs.metadata["points3D_xyz"]
             pts_rgb = self.datamanager.train_dataparser_outputs.metadata["points3D_rgb"]
-            seed_pts = (pts, pts_rgb)
+            pcd = self.datamanager.train_dataparser_outputs.metadata["points3D_pcd"]
+            seed_pts = (pts, pts_rgb, pcd)
         self.datamanager.to(device)
         # TODO(ethan): get rid of scene_bounds from the model
         assert self.datamanager.train_dataset is not None, "Missing input dataset"

--- a/nerfstudio/utils/general_utils.py
+++ b/nerfstudio/utils/general_utils.py
@@ -1,0 +1,308 @@
+#
+# Copyright (C) 2023, Inria
+# GRAPHDECO research group, https://team.inria.fr/graphdeco
+# All rights reserved.
+#
+# This software is free for non-commercial, research and evaluation use 
+# under the terms of the LICENSE.md file.
+#
+# For inquiries contact  george.drettakis@inria.fr
+#
+from PIL import Image
+from typing import NamedTuple
+
+import torch
+import torch.nn.functional as F
+
+import sys
+from datetime import datetime
+import numpy as np
+import random
+
+
+class MeshPointCloud(NamedTuple):
+    alpha: torch.Tensor
+    points: torch.Tensor
+    vertices: np.array
+    faces: np.array
+    triangles: torch.Tensor
+
+
+def rotx(t):
+    ''' 3D Rotation about the x-axis. '''
+    c = np.cos(t)
+    s = np.sin(t)
+    return np.array([[1, 0, 0],
+                     [0, c, -s],
+                     [0, s, c]])
+
+
+def standardize_quaternion(quaternions: torch.Tensor) -> torch.Tensor:
+    """
+    Convert a unit quaternion to a standard form: one in which the real
+    part is non negative.
+
+    Args:
+        quaternions: Quaternions with real part first,
+            as tensor of shape (..., 4).
+
+    Returns:
+        Standardized quaternions as tensor of shape (..., 4).
+    """
+    return torch.where(quaternions[..., 0:1] < 0, -quaternions, quaternions)
+
+def _sqrt_positive_part(x: torch.Tensor) -> torch.Tensor:
+    """
+    Returns torch.sqrt(torch.max(0, x))
+    but with a zero subgradient where x is 0.
+    """
+    ret = torch.zeros_like(x)
+    positive_mask = x > 0
+    ret[positive_mask] = torch.sqrt(x[positive_mask])
+    return ret
+
+def rot_to_quat_batch(rot: torch.Tensor):
+    """
+    Implementation based on pytorch3d implementation
+    https://pytorch3d.readthedocs.io/en/latest/_modules/pytorch3d/transforms/rotation_conversions.html#matrix_to_quaternion
+    Convert rotations given as rotation matrices to quaternions.
+
+    Args:
+        matrix: Rotation matrices as tensor of shape (..., 3, 3).
+
+    Returns:
+        quaternions with real part first, as tensor of shape (..., 4).
+    """
+    if rot.size(-1) != 3 or rot.size(-2) != 3:
+        raise ValueError(f"Invalid rotation matrix shape {rot.shape}.")
+    
+    m00, m01, m02, m10, m11, m12, m20, m21, m22 = torch.unbind(
+        rot.reshape(-1, 9), dim=-1
+    )
+
+    q_abs = _sqrt_positive_part(
+        torch.stack(
+            [
+                1.0 + m00 + m11 + m22,
+                1.0 + m00 - m11 - m22,
+                1.0 - m00 + m11 - m22,
+                1.0 - m00 - m11 + m22,
+            ],
+            dim=-1,
+        )
+    )
+
+    # we produce the desired quaternion multiplied by each of r, i, j, k
+    quat_by_rijk = torch.stack(
+        [
+            torch.stack([q_abs[..., 0] ** 2, m21 - m12, m02 - m20, m10 - m01], dim=-1),
+            torch.stack([m21 - m12, q_abs[..., 1] ** 2, m10 + m01, m02 + m20], dim=-1),
+            torch.stack([m02 - m20, m10 + m01, q_abs[..., 2] ** 2, m12 + m21], dim=-1),
+            torch.stack([m10 - m01, m20 + m02, m21 + m12, q_abs[..., 3] ** 2], dim=-1),
+        ],
+        dim=-2,
+    )
+
+    # We floor here at 0.1 but the exact level is not important; if q_abs is small,
+    # the candidate won't be picked.
+    flr = torch.tensor(0.1).to(dtype=q_abs.dtype, device=q_abs.device)
+    quat_candidates = quat_by_rijk / (2.0 * q_abs[..., None].max(flr))
+
+    # if not for numerical problems, quat_candidates[i] should be same (up to a sign),
+    # forall i; we pick the best-conditioned one (with the largest denominator)
+    out = quat_candidates[
+        F.one_hot(q_abs.argmax(dim=-1), num_classes=4) > 0.5, :
+    ].reshape(-1, 4)
+
+    return standardize_quaternion(out)
+
+
+def inverse_sigmoid(x):
+    return torch.log(x/(1-x))
+
+
+def PILtoTorch(pil_image, resolution):
+    resized_image_PIL = pil_image.resize(resolution, resample=Image.BOX)
+
+    resized_image = torch.from_numpy(np.array(resized_image_PIL)) / 255.0
+    if len(resized_image.shape) == 3:
+        return resized_image.permute(2, 0, 1)
+    else:
+        return resized_image.unsqueeze(dim=-1).permute(2, 0, 1)
+
+
+def get_expon_lr_func(
+    lr_init, lr_final, lr_delay_steps=0, lr_delay_mult=1.0, max_steps=1000000
+):
+    """
+    Copied from Plenoxels
+
+    Continuous learning rate decay function. Adapted from JaxNeRF
+    The returned rate is lr_init when step=0 and lr_final when step=max_steps, and
+    is log-linearly interpolated elsewhere (equivalent to exponential decay).
+    If lr_delay_steps>0 then the learning rate will be scaled by some smooth
+    function of lr_delay_mult, such that the initial learning rate is
+    lr_init*lr_delay_mult at the beginning of optimization but will be eased back
+    to the normal learning rate when steps>lr_delay_steps.
+    :param conf: config subtree 'lr' or similar
+    :param max_steps: int, the number of steps during optimization.
+    :return HoF which takes step as input
+    """
+
+    def helper(step):
+        if step < 0 or (lr_init == 0.0 and lr_final == 0.0):
+            # Disable this parameter
+            return 0.0
+        if lr_delay_steps > 0:
+            # A kind of reverse cosine decay.
+            delay_rate = lr_delay_mult + (1 - lr_delay_mult) * np.sin(
+                0.5 * np.pi * np.clip(step / lr_delay_steps, 0, 1)
+            )
+        else:
+            delay_rate = 1.0
+        t = np.clip(step / max_steps, 0, 1)
+        log_lerp = np.exp(np.log(lr_init) * (1 - t) + np.log(lr_final) * t)
+        return delay_rate * log_lerp
+
+    return helper
+
+
+def strip_lowerdiag(L):
+    uncertainty = torch.zeros((L.shape[0], 6), dtype=torch.float, device="cuda")
+
+    uncertainty[:, 0] = L[:, 0, 0]
+    uncertainty[:, 1] = L[:, 0, 1]
+    uncertainty[:, 2] = L[:, 0, 2]
+    uncertainty[:, 3] = L[:, 1, 1]
+    uncertainty[:, 4] = L[:, 1, 2]
+    uncertainty[:, 5] = L[:, 2, 2]
+    return uncertainty
+
+
+def strip_symmetric(sym):
+    return strip_lowerdiag(sym)
+
+
+def build_rotation(r):
+    norm = torch.sqrt(r[:,0]*r[:,0] + r[:,1]*r[:,1] + r[:,2]*r[:,2] + r[:,3]*r[:,3])
+
+    q = r / norm[:, None]
+
+    R = torch.zeros((q.size(0), 3, 3), device=r.device)
+
+    r = q[:, 0]
+    x = q[:, 1]
+    y = q[:, 2]
+    z = q[:, 3]
+
+    R[:, 0, 0] = 1 - 2 * (y*y + z*z)
+    R[:, 0, 1] = 2 * (x*y - r*z)
+    R[:, 0, 2] = 2 * (x*z + r*y)
+    R[:, 1, 0] = 2 * (x*y + r*z)
+    R[:, 1, 1] = 1 - 2 * (x*x + z*z)
+    R[:, 1, 2] = 2 * (y*z - r*x)
+    R[:, 2, 0] = 2 * (x*z - r*y)
+    R[:, 2, 1] = 2 * (y*z + r*x)
+    R[:, 2, 2] = 1 - 2 * (x*x + y*y)
+    return R
+
+
+def rotmat2qvec(R: torch.Tensor):
+    Rxx, Ryx, Rzx, Rxy, Ryy, Rzy, Rxz, Ryz, Rzz = R.flatten()
+    K = torch.Tensor([[Rxx - Ryy - Rzz, 0, 0, 0],
+                      [Ryx + Rxy, Ryy - Rxx - Rzz, 0, 0],
+                      [Rzx + Rxz, Rzy + Ryz, Rzz - Rxx - Ryy, 0],
+                      [Ryz - Rzy, Rzx - Rxz, Rxy - Ryx, Rxx + Ryy + Rzz]]) / 3.0
+    eigvals, eigvecs = torch.linalg.eigh(K)
+    qvec = eigvecs[[3, 0, 1, 2], torch.argmax(eigvals)]
+    if qvec[0] < 0:
+        qvec *= -1
+    return qvec
+
+
+def mul_quaternion(q1, q2):
+    return torch.stack([- q1[..., 1] * q2[..., 1] - q1[..., 2] * q2[..., 2] - q1[..., 3] * q2[..., 3] + q1[..., 0] * q2[..., 0],
+                        q1[..., 0] * q2[..., 1] - q1[..., 3] * q2[..., 2] + q1[..., 2] * q2[..., 3] + q1[..., 1] * q2[..., 0],
+                        q1[..., 3] * q2[..., 1] + q1[..., 0] * q2[..., 2] - q1[..., 1] * q2[..., 3] + q1[..., 2] * q2[..., 0],
+                        - q1[..., 2] * q2[..., 1] + q1[..., 1] * q2[..., 2] + q1[..., 0] * q2[..., 3] + q1[..., 3] * q2[..., 0]], -1)
+
+
+def quaternion_conjugate(q):
+    return torch.cat([q[..., :1], -q[..., 1:]], -1)
+
+
+def rotate_vec(q, v):
+    v = torch.cat([torch.zeros_like(v[..., :1]), v], -1)
+    return mul_quaternion(mul_quaternion(q, v), quaternion_conjugate(q))[..., 1:]
+
+
+def dist_quaternion(q1, q2):
+    theta = 2 * torch.arccos((q1 * q2).sum(-1, keepdim=True).clamp(-1, 1))
+    return theta
+
+
+def quat_log_map(q):
+    theta = torch.arccos(q[..., :1].clamp(-1, 1))
+    l = q[..., 1:] / (q[..., 1:].norm(dim=-1, keepdim=True) + 1e-8)
+    return torch.cat([torch.zeros_like(q[..., :1]), l * theta], -1)
+
+
+def quat_exp_map(log_q):
+    theta = log_q.norm(dim=-1, keepdim=True)
+    l = log_q / (theta + 1e-8)
+    w = torch.cos(theta)
+    q = torch.cat([w, torch.sin(theta) * l[..., 1:]], -1)
+    return torch.nn.functional.normalize(q, dim=-1)
+
+
+def slerp(q1, q2, coeff):
+    """shperical linear interpolation
+
+    Args:
+        q1, q2 (torch.Tensor): quaternion (qw, qx, qy, qz) that is a Tensor of shape (*, 4)
+
+    Returns:
+        q (torch.Tensor): quaternion (qw, qx, qy, qz) that is a Tensor of shape (*, 4)
+    """
+    q1 = torch.nn.functional.normalize(q1, dim=-1)
+    q2 = torch.nn.functional.normalize(q2, dim=-1)
+    theta = 0.5 * dist_quaternion(q1, q2)
+    inv_sin_theta = 1. / torch.sin(theta)
+    q = inv_sin_theta * (torch.sin(coeff * theta) * q1 + torch.sin((1 - coeff) * theta) * q2)
+    return q
+
+
+def build_scaling_rotation(s, r):
+    L = torch.zeros((s.shape[0], 3, 3), dtype=torch.float, device="cuda")
+    R = build_rotation(r)
+
+    L[:,0,0] = s[:,0]
+    L[:,1,1] = s[:,1]
+    L[:,2,2] = s[:,2]
+
+    L = R @ L
+    return L
+
+
+def safe_state(silent):
+    old_f = sys.stdout
+    class F:
+        def __init__(self, silent):
+            self.silent = silent
+
+        def write(self, x):
+            if not self.silent:
+                if x.endswith("\n"):
+                    old_f.write(x.replace("\n", " [{}]\n".format(str(datetime.now().strftime("%d/%m %H:%M:%S")))))
+                else:
+                    old_f.write(x)
+
+        def flush(self):
+            old_f.flush()
+
+    sys.stdout = F(silent)
+
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
+    torch.cuda.set_device(torch.device("cuda:0"))


### PR DESCRIPTION
Summary:

Add new feature let will use arkit mesh to initialize 3D gaussian.
Add `--pipeline.model.use_mesh_initialization True` to enable this feature, while put scene.obj under`colmap/sparse/0/`

Details:
1. load mesh in colmap reader and create MeshPointCloud.
2. Use MeshPointCloud to initialize 3D gaussian with mean and covariance.
3. Throw error if use_scale_regularization and use_mesh_initialization is set to true at the same time.

Risk: use_scale_regularization and use_mesh_initialization is set to true at the same time.


