### PR TITLE
Swap out opencv-python for opencv-python-headless

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "msgpack_numpy>=0.4.8",
     "nerfacc==0.5.2",
     "open3d>=0.16.0",
-    "opencv-python==4.10.0.84",
+    "opencv-python-headless==4.10.0.84",
     "Pillow>=10.3.0",
     "plotly>=5.7.0",
     "protobuf<=3.20.3,!=3.20.0",


### PR DESCRIPTION
Related issues: #1223 and #2179

Currently, Nerfstudio/colmap depends on specific GUI libraries to be installed/available, even on headless systems.
Is there any reason to not simply swap out opencv-python for opencv-python-headless? 
I don't think there's anything Nerfstudio does that relies on running a GUI locally, directly, and swapping it out for `-headless` seems to have worked for a number of people.

I would think most headless Linux systems would be affected, though mine are too "contaminated" to confirm.  
At the very least, WSL2 Ubuntu is affected, as it does not ship with these GUI libraries.

Fixes issues like this on headless Linux/WSL2 installations:
```
[01:43:53] 🎉 Done converting video to images.                                                 process_data_utils.py:219
──  💀 💀 💀 ERROR 💀 💀 💀  ─
Error running command: colmap feature_extractor --database_path data/nerfstudio/output/colmap/database.db --image_path
data/nerfstudio/output/images --ImageReader.single_camera 1 --ImageReader.camera_model OPENCV --SiftExtraction.use_gpu 1
──────────────
QObject::moveToThread: Current thread (0x5617ac4fc070) is not the object's thread (0x5617ac502ce0).
Cannot move to target thread (0x5617ac4fc070)

qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in
"/home/username/miniconda3/envs/nerfstudio/lib/python3.8/site-packages/cv2/qt/plugins" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may
fix this problem.

Available platform plugins are: xcb, eglfs, linuxfb, minimal, minimalegl, offscreen, vnc.

 Aborted at 1722087834 (unix time) try "date -d @1722087834" if you are using GNU date 
PC: @                0x0 (unknown)
 SIGABRT (@0x3e80000b16b) received by PID 45419 (TID 0x7f8f8c554080) from PID 45419; stack trace: 
    @     0x7f8f92104046 (unknown)
    @     0x7f8f903aa520 (unknown)
    @     0x7f8f903fe9fc pthread_kill
    @     0x7f8f903aa476 raise
    @     0x7f8f903907f3 abort
    @     0x7f8f909a0ba3 QMessageLogger::fatal()
    @     0x7f8f90fa7713 QGuiApplicationPrivate::createPlatformIntegration()
    @     0x7f8f90fa7c08 QGuiApplicationPrivate::createEventDispatcher()
    @     0x7f8f90bd0b17 QCoreApplicationPrivate::init()
    @     0x7f8f90faab70 QGuiApplicationPrivate::init()
    @     0x7f8f916beced QApplicationPrivate::init()
    @     0x5617aaa173dd colmap::RunFeatureExtractor()
    @     0x5617aaa09499 main
    @     0x7f8f90391d90 (unknown)
    @     0x7f8f90391e40 __libc_start_main
    @     0x5617aaa0c3e5 _start
Aborted
```