### PR TITLE
make np.array compatible with numpy 2.0

### DIFF
--- a/nerfstudio/cameras/camera_utils.py
+++ b/nerfstudio/cameras/camera_utils.py
@@ -54,7 +54,7 @@ def quaternion_from_matrix(matrix: NDArray, isprecise: bool = False) -> np.ndarr
         matrix: rotation matrix to obtain quaternion
         isprecise: if True, input matrix is assumed to be precise rotation matrix and a faster algorithm is used.
     """
-    M = np.array(matrix, dtype=np.float64, copy=False)[:4, :4]
+    M = np.array(matrix, dtype=np.float64, copy=None)[:4, :4]
     if isprecise:
         q = np.empty((4,))
         t = np.trace(M)


### PR DESCRIPTION
Parameter `copy` in np.array

in [version 2.0](https://numpy.org/doc/stable/reference/generated/numpy.array.html):

> **copy:bool, optional**
If `True `(default), then the array data is copied. If `None`, a copy will only be made if `__array__ `returns a copy, if obj is a nested sequence, or if a copy is needed to satisfy any of the other requirements (dtype, order, etc.). Note that any copy of the data is shallow, i.e., for arrays with object dtype, the new array will point to the same objects. See Examples for [ndarray.copy](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.copy.html#numpy.ndarray.copy). **For `False` it raises a ValueError if a copy cannot be avoided**. Default: True.

in [version 1.x](https://numpy.org/doc/1.26/reference/generated/numpy.array.html):

> **copybool, optional**
If `true` (default), then the object is copied. Otherwise, a copy will only be made if `__array__` returns a copy, if obj is a nested sequence, or if a copy is needed to satisfy any of the other requirements (dtype, order, etc.).
