### PR TITLE
Lazy import for open3d in Blender DataParser

### DIFF
--- a/nerfstudio/data/dataparsers/blender_dataparser.py
+++ b/nerfstudio/data/dataparsers/blender_dataparser.py
@@ -22,7 +22,6 @@ from typing import Optional, Type
 
 import imageio
 import numpy as np
-import open3d as o3d
 import torch
 
 from nerfstudio.cameras.cameras import Cameras, CameraType
@@ -116,6 +115,8 @@ class Blender(DataParser):
         return dataparser_outputs
 
     def _load_3D_points(self, ply_file_path: Path):
+        import open3d as o3d  # Importing open3d is slow, so we only do it if we need it.
+
         pcd = o3d.io.read_point_cloud(str(ply_file_path))
 
         points3D = torch.from_numpy(np.asarray(pcd.points, dtype=np.float32) * self.config.scale_factor)


### PR DESCRIPTION
I'm following this reference code to improve the speed of importing the Blender DataParser. We should only import Open3D when we need it.

https://github.com/nerfstudio-project/nerfstudio/blob/b0dd3d473094fb0942b357ef436b362df1ef77cd/nerfstudio/data/dataparsers/scannet_dataparser.py#L207