### PR TITLE
Update exporter.py to export sh_degree 0 case

### DIFF
--- a/nerfstudio/scripts/exporter.py
+++ b/nerfstudio/scripts/exporter.py
@@ -47,6 +47,7 @@ from nerfstudio.models.splatfacto import SplatfactoModel
 from nerfstudio.pipelines.base_pipeline import Pipeline, VanillaPipeline
 from nerfstudio.utils.eval_utils import eval_setup
 from nerfstudio.utils.rich_utils import CONSOLE
+from nerfstudio.models.splatfacto import RGB2SH
 
 
 @dataclass
@@ -576,6 +577,11 @@ class ExportGaussianSplat(Exporter):
                 shs_rest = shs_rest.reshape((n, -1))
                 for i in range(shs_rest.shape[-1]):
                     map_to_tensors[f"f_rest_{i}"] = shs_rest[:, i, None]
+            elif model.config.sh_degree == 0:
+                shs_0 = model.shs_0.contiguous().cpu().numpy()
+                for i in range(shs_0.shape[1]):
+                    map_to_tensors[f"f_dc_{i}"] = RGB2SH(
+                        torch.clamp(model.colors.clone(), 0.0, 1.0).data.cpu().numpy())[:, i]
             else:
                 colors = torch.clamp(model.colors.clone(), 0.0, 1.0).data.cpu().numpy()
                 map_to_tensors["colors"] = (colors * 255).astype(np.uint8)


### PR DESCRIPTION
Current exporter with sh_degree 0 gives color values instead of spherical harmonics coefficients

Which cannot be rendered with sh_degree 0 renderers such as [WebGL Viewer by antimatter15](https://antimatter15.com/splat/)

Current exporter's ply
![image](https://github.com/user-attachments/assets/d64b52e6-e201-4d79-8be3-33f330c629a8)

Edited exporter's ply 
![image](https://github.com/user-attachments/assets/6ea5e4b9-0efb-4def-81e9-6bbcb87c70d7)

If directly reference shs_0 value with model.shs_0, it makes infinity values and check 

If a model trained with sh degree 0 is directly referenced as model.shs_0 in the exporter, 
an infinite value occurs, so the cases are divided and recover sh value with colors.