### PR TITLE
Updating camera intrinsics (principal points) when the undistorted image is cropped

### DIFF
--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -332,8 +332,13 @@ class FullImageDatamanager(DataManager, Generic[TDataset]):
         return {}
 
     def get_train_rays_per_batch(self):
-        # TODO: fix this to be the resolution of the last image rendered
-        return 800 * 800
+        """Returns resolution of the image returned from datamanager."""
+        if len(self.cached_train) != 0:
+            h = self.cached_train[0]["image"].shape[0]
+            w = self.cached_train[0]["image"].shape[1]
+            return h * w
+        else:
+            return 800 * 800
 
     def next_train(self, step: int) -> Tuple[Cameras, Dict]:
         """Returns the next training batch

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -423,8 +423,8 @@ def _undistort_image(
         x, y, w, h = roi
         image = image[y : y + h, x : x + w]
         # update the principal point based on our cropped region of interest (ROI)
-        newK[0, 1] -= x
-        newK[0, 2] -= y
+        newK[0, 2] -= x
+        newK[1, 2] -= y
         if "depth_image" in data:
             data["depth_image"] = data["depth_image"][y : y + h, x : x + w]
         if "mask" in data:

--- a/nerfstudio/data/datamanagers/full_images_datamanager.py
+++ b/nerfstudio/data/datamanagers/full_images_datamanager.py
@@ -391,6 +391,8 @@ def _undistort_image(
             "We doesn't support the 4th Brown parameter for image undistortion, "
             "Only k1, k2, k3, p1, p2 can be non-zero."
         )
+        # because OpenCV expects the order of distortion parameters to be (k1, k2, p1, p2, k3), we need to reorder them
+        # see https://docs.opencv.org/4.x/dc/dbb/tutorial_py_calibration.html
         distortion_params = np.array(
             [
                 distortion_params[0],
@@ -416,6 +418,9 @@ def _undistort_image(
         # crop the image and update the intrinsics accordingly
         x, y, w, h = roi
         image = image[y : y + h, x : x + w]
+        # update the principal point based on our cropped region of interest (ROI)
+        newK[0, 1] -= x
+        newK[0, 2] -= y
         if "depth_image" in data:
             data["depth_image"] = data["depth_image"][y : y + h, x : x + w]
         if "mask" in data:


### PR DESCRIPTION
**Problems and Background**

- When an image is undistorted by OpenCV's `undistort` for perspective cameras, there could be a returned Region-Of-Interest (ROI) where the image's pixels are well defined.

- Nerfstudio does crop the image according to OpenCV's returned ROI, but it does not update the camera intrinsics to reflect where the new principal point has shifted, (usually the crop is very tiny <= 1 pixel or doesn't exist at all) so this isn't that noticeable.

**Overview of Changes**
- Added some notes explaining the processing to use OpenCV
- Fixed the updated principal points in the returned intrinsic matrix