### PR TITLE
Add an example on how to customize dataparser with ns-train

### DIFF
--- a/docs/reference/cli/ns_train.md
+++ b/docs/reference/cli/ns_train.md
@@ -29,3 +29,11 @@ By default the nerfstudio dataparser is used. If you would like to use a differe
 ```bash
 ns-train {method} {dataparser} --help
 ```
+
+For example, if you want to specify the `eval_mode` of the nerfstudio dataparser to be `filename` when training your `splatfacto` model via the `ns-train` cli, you can do
+
+```
+ns-train splatfacto [method args] nerfstudio-data --eval-mode filename
+```
+
+Notice that the custom dataparser and its arguments are passed after specifying the training method and its arguments.


### PR DESCRIPTION
It's challenging to find specific examples on how to configure dataparser when training models with `ns-train` cli.

### Overview of Changes

Add a specific example where we specify the dataparser we choose to use, along with its arguments, after we specify the training method and its configurations.