### PR TITLE
Add eval data to image_rename_map

### DIFF
--- a/nerfstudio/process_data/images_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/images_to_nerfstudio_dataset.py
@@ -74,6 +74,9 @@ class ImagesToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
                 same_dimensions=self.same_dimensions,
                 keep_image_dir=False,
             )
+            image_rename_map = dict(
+                (a.relative_to(self.data).as_posix(), b.name) for a, b in image_rename_map_paths.items()
+            )
             if self.eval_data is not None:
                 eval_image_rename_map_paths = process_data_utils.copy_images(
                     self.eval_data,
@@ -85,11 +88,11 @@ class ImagesToNerfstudioDataset(ColmapConverterToNerfstudioDataset):
                     same_dimensions=self.same_dimensions,
                     keep_image_dir=True,
                 )
-                image_rename_map_paths.update(eval_image_rename_map_paths)
+                image_rename_map_eval = dict(
+                    (a.relative_to(self.eval_data).as_posix(), b.name) for a, b in eval_image_rename_map_paths.items()
+                )
+                image_rename_map.update(image_rename_map_eval)
 
-            image_rename_map = dict(
-                (a.relative_to(self.data).as_posix(), b.name) for a, b in image_rename_map_paths.items()
-            )
             num_frames = len(image_rename_map)
             summary_log.append(f"Starting with {num_frames} images")
 


### PR DESCRIPTION
I tried to run COLMAP with both training images and eval images but had an error message saying that 
- ".../INPUT_eval_data_path/frame_eval_00001.PNG' is not in the subpath of '...INPUT_data' OR one path is relative and the other is absolute."

I spent some time and found that in `images_to_nerfstudio_dataset.py` file (line 90-92), only train image folder (self.data) is in the relative_to(), while `image_rename_map_paths` contains both train and test images.

Therefore, I have tried to create a `image_rename_map_eval` for self.eval_data and update the `image_rename_map` with it. Now the COLMAP can successfully run with both train and test dataset.