### PR TITLE
Adding glomap support to ns-process-data, requires latest version of COLMAP

### DIFF
--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -222,6 +222,19 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                 refine_intrinsics=self.refine_intrinsics,
                 colmap_cmd=self.colmap_cmd,
             )
+        elif sfm_tool == "glomap":
+            colmap_utils.run_colmap(
+                image_dir=image_dir,
+                colmap_dir=self.absolute_colmap_path,
+                camera_model=CAMERA_MODELS[self.camera_type],
+                camera_mask_path=mask_path,
+                gpu=self.gpu,
+                verbose=self.verbose,
+                matching_method=self.matching_method,
+                refine_intrinsics=self.refine_intrinsics,
+                colmap_cmd=self.colmap_cmd,
+                glomap_toggle=True,
+            )
         elif sfm_tool == "hloc":
             if mask_path is not None:
                 raise RuntimeError("Cannot use a mask with hloc. Please remove the cropping options " "and try again.")

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -99,6 +99,7 @@ def run_colmap(
     matching_method: Literal["vocab_tree", "exhaustive", "sequential"] = "vocab_tree",
     refine_intrinsics: bool = True,
     colmap_cmd: str = "colmap",
+    glomap_toggle: bool = False,
 ) -> None:
     """Runs COLMAP on the images.
 
@@ -153,12 +154,20 @@ def run_colmap(
     # Bundle adjustment
     sparse_dir = colmap_dir / "sparse"
     sparse_dir.mkdir(parents=True, exist_ok=True)
-    mapper_cmd = [
-        f"{colmap_cmd} mapper",
-        f"--database_path {colmap_dir / 'database.db'}",
-        f"--image_path {image_dir}",
-        f"--output_path {sparse_dir}",
-    ]
+    if glomap_toggle:
+        mapper_cmd = [
+            f"glomap mapper",
+            f"--database_path {colmap_dir / 'database.db'}",
+            f"--image_path {image_dir}",
+            f"--output_path {sparse_dir}",
+        ]
+    else:
+        mapper_cmd = [
+            f"{colmap_cmd} mapper",
+            f"--database_path {colmap_dir / 'database.db'}",
+            f"--image_path {image_dir}",
+            f"--output_path {sparse_dir}",
+        ]
     if colmap_version >= Version("3.7"):
         mapper_cmd.append("--Mapper.ba_global_function_tolerance=1e-6")
 


### PR DESCRIPTION
**Problems and Background**
- GLOMAP is orders of magnitudes faster than COLMAP On average, it finds camera poses and intrinsics 100x faster than COLMAP, and it would great to support this in Nerfstudio and already has been [requested](https://github.com/nerfstudio-project/nerfstudio/issues/3402)

**Overview of Changes**
- Adding a GLOMAP toggle in `ns-process-data` script, which uses the GLOMAP mapper 
