### PR TITLE
Zipnerf point cloud and tsdf mesh export support

### DIFF
--- a/nerfstudio/scripts/exporter.py
+++ b/nerfstudio/scripts/exporter.py
@@ -73,8 +73,13 @@ def validate_pipeline(normal_method: str, normal_output_name: str, pipeline: Pip
         directions = torch.ones_like(origins)
         pixel_area = torch.ones_like(origins[..., :1])
         camera_indices = torch.zeros_like(origins[..., :1])
+        metadata = {"directions_norm": torch.linalg.vector_norm(directions, dim=-1, keepdim=True)}
         ray_bundle = RayBundle(
-            origins=origins, directions=directions, pixel_area=pixel_area, camera_indices=camera_indices
+            origins=origins,
+            directions=directions,
+            pixel_area=pixel_area,
+            camera_indices=camera_indices,
+            metadata=metadata,
         )
         outputs = pipeline.model(ray_bundle)
         if normal_output_name not in outputs:


### PR DESCRIPTION
Support for exporting point clouds and tsdf meshes with zipnerf (marching cubes and Poisson mesh methods still unsupported)

- [PR](https://github.com/SuLvXiangXin/zipnerf-pytorch/pull/109) to the zipnerf-pytorch repo with relevant changes
- Updated `validate_pipeline` for compatibility with zipnerf

**Verification**
Verified that `ns-export pointcloud ...` and `ns-export tsdf ...` correctly produce point clouds and meshes respectively with zipnerf
![Screenshot 2024-09-15 at 10 09 27 AM](https://github.com/user-attachments/assets/53ab6128-3a30-4eca-b9c4-598c9d4411a3)

Resolves #2974 and #3276 