### PR TITLE
Fix splatfacto crash in eval when using viewer

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -300,7 +300,8 @@ class Trainer:
 
                 # Do not perform evaluation if there are no validation images
                 if self.pipeline.datamanager.eval_dataset:
-                    self.eval_iteration(step)
+                    with self.train_lock:
+                        self.eval_iteration(step)
 
                 if step_check(step, self.config.steps_per_save):
                     self.save_checkpoint(step)


### PR DESCRIPTION
This addresses the issue in #3253 where splatfacto training could crash during the evaluation step when interacting with the viewer (e.g., with --vis viewer+wandb). The problem occurs because interacting with the viewer renders a new image in `_render_img()`, where `model.eval()` is called at the start and `model.train()` at the end, regardless of the initial model state (see [nerfstudio/viewer/render_state_machine.py#L151](https://github.com/nerfstudio-project/nerfstudio/blob/7a0b8cbc89c0500984b016e3d73201f372ba8ef3/nerfstudio/viewer/render_state_machine.py#L151)). If this happens during the actual eval step of the model, it flips the mode to training during evaluation, causing errors.

Changes made:
- Modified `eval_iteration()` to use the `train_lock`, ensuring a consistent model state during evaluation

Testing
- Verified that splatfacto no longer crashes during evaluation with viewer interactions.

Closes #3253 