### PR TITLE
Minor update to generate splat files in inference mode

### DIFF
--- a/nerfstudio/scripts/exporter.py
+++ b/nerfstudio/scripts/exporter.py
@@ -547,7 +547,7 @@ class ExportGaussianSplat(Exporter):
         if not self.output_dir.exists():
             self.output_dir.mkdir(parents=True)
 
-        _, pipeline, _, _ = eval_setup(self.load_config)
+        _, pipeline, _, _ = eval_setup(self.load_config, test_mode="inference")
 
         assert isinstance(pipeline.model, SplatfactoModel)
 


### PR DESCRIPTION
Since Gaussian Splat ply generation doesn't require the dataset data it can be generated from inference mode reducing memory and allows the export even if the initial dataset is lost.