### PR TITLE
Keep depth_image on CPU

### DIFF
--- a/nerfstudio/data/datasets/depth_dataset.py
+++ b/nerfstudio/data/datasets/depth_dataset.py
@@ -41,6 +41,8 @@ class DepthDataset(InputDataset):
         scale_factor: The scaling factor for the dataparser outputs.
     """
 
+    exclude_batch_keys_from_device = InputDataset.exclude_batch_keys_from_device + ["depth_image"]
+
     def __init__(self, dataparser_outputs: DataparserOutputs, scale_factor: float = 1.0):
         super().__init__(dataparser_outputs, scale_factor)
         # if there are no depth images than we want to generate them all with zoe depth


### PR DESCRIPTION
This makes the `DepthDataset` consistent with the `SDFDataset` and `SemanticDataset`. From my experiments, this also reduces VRAM for `depth-nerfacto` without affecting training speed.

A step towards #3446.