### PR TITLE
Speed up PairPixelSampler

### DIFF
--- a/nerfstudio/data/pixel_samplers.py
+++ b/nerfstudio/data/pixel_samplers.py
@@ -78,6 +78,61 @@ class PixelSampler:
         """
         self.num_rays_per_batch = num_rays_per_batch
 
+    def rejection_sample_mask(
+        self,
+        mask: Tensor,
+        num_samples: int,
+        num_images: int,
+        image_height: int,
+        image_width: int,
+        device: Union[torch.device, str],
+    ) -> Int[Tensor, "batch_size 3"]:
+        """
+        Samples pixels within a mask using rejection sampling.
+
+        Args:
+            mask: mask of possible pixels in an image to sample from.
+            num_samples: number of samples.
+            num_images: number of images to sample over.
+            image_height: the height of the image.
+            image_width: the width of the image.
+            device: device that the samples should be on.
+        """
+        indices = (
+            torch.rand((num_samples, 3), device=device)
+            * torch.tensor([num_images, image_height, image_width], device=device)
+        ).long()
+
+        num_valid = 0
+        for _ in range(self.config.max_num_iterations):
+            c, y, x = (i.flatten() for i in torch.split(indices, 1, dim=-1))
+            chosen_indices_validity = mask.squeeze()[c, y, x].bool()
+            num_valid = int(torch.sum(chosen_indices_validity).item())
+            if num_valid == num_samples:
+                break
+            else:
+                replacement_indices = (
+                    torch.rand((num_samples - num_valid, 3), device=device)
+                    * torch.tensor([num_images, image_height, image_width], device=device)
+                ).long()
+                indices[~chosen_indices_validity] = replacement_indices
+
+        if num_valid != num_samples:
+            warnings.warn(
+                """
+                Masked sampling failed, mask is either empty or mostly empty.
+                Reverting behavior to non-rejection sampling. Consider setting
+                pipeline.datamanager.pixel-sampler.rejection-sample-mask to False
+                or increasing pipeline.datamanager.pixel-sampler.max-num-iterations
+                """
+            )
+            self.config.rejection_sample_mask = False
+            nonzero_indices = torch.nonzero(mask.squeeze(), as_tuple=False).to(device)
+            chosen_indices = random.sample(range(len(nonzero_indices)), k=num_samples)
+            indices = nonzero_indices[chosen_indices]
+
+        return indices
+
     def sample_method(
         self,
         batch_size: int,
@@ -95,44 +150,25 @@ class PixelSampler:
             num_images: number of images to sample over
             mask: mask of possible pixels in an image to sample from.
         """
-        indices = (
-            torch.rand((batch_size, 3), device=device)
-            * torch.tensor([num_images, image_height, image_width], device=device)
-        ).long()
-
         if isinstance(mask, torch.Tensor) and not self.config.ignore_mask:
             if self.config.rejection_sample_mask:
-                num_valid = 0
-                for _ in range(self.config.max_num_iterations):
-                    c, y, x = (i.flatten() for i in torch.split(indices, 1, dim=-1))
-                    chosen_indices_validity = mask[..., 0][c, y, x].bool()
-                    num_valid = int(torch.sum(chosen_indices_validity).item())
-                    if num_valid == batch_size:
-                        break
-                    else:
-                        replacement_indices = (
-                            torch.rand((batch_size - num_valid, 3), device=device)
-                            * torch.tensor([num_images, image_height, image_width], device=device)
-                        ).long()
-                        indices[~chosen_indices_validity] = replacement_indices
-
-                if num_valid != batch_size:
-                    warnings.warn(
-                        """
-                        Masked sampling failed, mask is either empty or mostly empty.
-                        Reverting behavior to non-rejection sampling. Consider setting
-                        pipeline.datamanager.pixel-sampler.rejection-sample-mask to False
-                        or increasing pipeline.datamanager.pixel-sampler.max-num-iterations
-                        """
-                    )
-                    self.config.rejection_sample_mask = False
-                    nonzero_indices = torch.nonzero(mask[..., 0], as_tuple=False)
-                    chosen_indices = random.sample(range(len(nonzero_indices)), k=batch_size)
-                    indices = nonzero_indices[chosen_indices]
+                indices = self.rejection_sample_mask(
+                    mask=mask,
+                    num_samples=batch_size,
+                    num_images=num_images,
+                    image_height=image_height,
+                    image_width=image_width,
+                    device=device,
+                )
             else:
                 nonzero_indices = torch.nonzero(mask[..., 0], as_tuple=False)
                 chosen_indices = random.sample(range(len(nonzero_indices)), k=batch_size)
                 indices = nonzero_indices[chosen_indices]
+        else:
+            indices = (
+                torch.rand((batch_size, 3), device=device)
+                * torch.tensor([num_images, image_height, image_width], device=device)
+            ).long()
 
         return indices
 
@@ -473,6 +509,10 @@ class PairPixelSamplerConfig(PixelSamplerConfig):
     """Target class to instantiate."""
     radius: int = 2
     """max distance between pairs of pixels."""
+    rejection_sample_mask: bool = True
+    """Whether or not to use rejection sampling when sampling images with masks"""
+    max_num_iterations: int = 100
+    """If rejection sampling masks, the maximum number of times to sample"""
 
 
 class PairPixelSampler(PixelSampler):  # pylint: disable=too-few-public-methods
@@ -508,9 +548,20 @@ class PairPixelSampler(PixelSampler):  # pylint: disable=too-few-public-methods
 
         if isinstance(mask, Tensor) and not self.config.ignore_mask:
             m = erode_mask(mask.permute(0, 3, 1, 2).float(), pixel_radius=self.radius)
-            nonzero_indices = torch.nonzero(m[:, 0], as_tuple=False).to(device)
-            chosen_indices = random.sample(range(len(nonzero_indices)), k=rays_to_sample)
-            indices = nonzero_indices[chosen_indices]
+
+            if self.config.rejection_sample_mask:
+                indices = self.rejection_sample_mask(
+                    mask=m,
+                    num_samples=rays_to_sample,
+                    num_images=num_images,
+                    image_height=image_height,
+                    image_width=image_width,
+                    device=device,
+                )
+            else:
+                nonzero_indices = torch.nonzero(m[:, 0], as_tuple=False).to(device)
+                chosen_indices = random.sample(range(len(nonzero_indices)), k=rays_to_sample)
+                indices = nonzero_indices[chosen_indices]
         else:
             s = (rays_to_sample, 1)
             ns = torch.randint(0, num_images, s, dtype=torch.long, device=device)


### PR DESCRIPTION
This speeds up the extremely slow `PairPixelSampler`. The main issue seems to be with mask erosion being slow. I managed to speed it up a bit but it still isn't great. I also added the functionality from https://github.com/nerfstudio-project/nerfstudio/pull/2585 to `PairPixelSampler`.

Before any of the changes:
![Screenshot from 2024-09-26 19-08-25](https://github.com/user-attachments/assets/4bf0aab8-b356-49a4-893b-931f0f81d3e6)

With only erosion:
![image](https://github.com/user-attachments/assets/a51921ae-fa3b-4018-9b57-7803f5579d09)


With both erosion and rejection sampling:
![image](https://github.com/user-attachments/assets/3feabcd6-37f7-4f12-b57b-fbe9e3937b0a)

This is an initial step towards #3446