### PR TITLE
Change depth from float64 to float32

### DIFF
--- a/nerfstudio/data/utils/data_utils.py
+++ b/nerfstudio/data/utils/data_utils.py
@@ -78,10 +78,10 @@ def get_depth_image_from_path(
         Depth image torch tensor with shape [height, width, 1].
     """
     if filepath.suffix == ".npy":
-        image = np.load(filepath) * scale_factor
+        image = np.load(filepath).astype(np.float32) * scale_factor
         image = cv2.resize(image, (width, height), interpolation=interpolation)
     else:
         image = cv2.imread(str(filepath.absolute()), cv2.IMREAD_ANYDEPTH)
-        image = image.astype(np.float64) * scale_factor
+        image = image.astype(np.float32) * scale_factor
         image = cv2.resize(image, (width, height), interpolation=interpolation)
     return torch.from_numpy(image[:, :, np.newaxis])


### PR DESCRIPTION
It seems weird to me that depth used float64 while everything else used float32. Moreover, we specify that "Filepath points to a 16-bit or 32-bit depth image", so I don't seem a reason behind converting it to float64. Moreover, the depth prediction is also float32 (`ds_nerf_depth_loss`):
```python
loss = -torch.log(weights + EPS) * torch.exp(-((steps - termination_depth[:, None]) ** 2) / (2 * sigma)) * lengths
```
Here `steps` is float32 while `termination_depth` is float64. This PR changes it to also be float32.

Making this change leads to a small speedup.

Before change (float64):
![Screenshot from 2024-09-28 14-39-52](https://github.com/user-attachments/assets/67c6aa3f-d0ce-4555-9b36-5b0a1db4bdf5)

After change (float32):
![Screenshot from 2024-09-28 14-37-58](https://github.com/user-attachments/assets/0964cab2-05b6-4d73-84d7-0a4df6d8e52d)

This is towards #3446.
