### PR TITLE
Make PixelSampler the depth-nerfacto default

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -40,7 +40,6 @@ from nerfstudio.data.dataparsers.sitcoms3d_dataparser import Sitcoms3DDataParser
 from nerfstudio.data.datasets.depth_dataset import DepthDataset
 from nerfstudio.data.datasets.sdf_dataset import SDFDataset
 from nerfstudio.data.datasets.semantic_dataset import SemanticDataset
-from nerfstudio.data.pixel_samplers import PairPixelSamplerConfig
 from nerfstudio.engine.optimizers import AdamOptimizerConfig, RAdamOptimizerConfig
 from nerfstudio.engine.schedulers import (
     CosineDecaySchedulerConfig,
@@ -222,7 +221,6 @@ method_configs["depth-nerfacto"] = TrainerConfig(
     pipeline=VanillaPipelineConfig(
         datamanager=VanillaDataManagerConfig(
             _target=VanillaDataManager[DepthDataset],
-            pixel_sampler=PairPixelSamplerConfig(),
             dataparser=NerfstudioDataParserConfig(),
             train_num_rays_per_batch=4096,
             eval_num_rays_per_batch=4096,

--- a/nerfstudio/models/depth_nerfacto.py
+++ b/nerfstudio/models/depth_nerfacto.py
@@ -49,7 +49,8 @@ class DepthNerfactoModelConfig(NerfactoModelConfig):
     sigma_decay_rate: float = 0.99985
     """Rate of exponential decay."""
     depth_loss_type: DepthLossType = DepthLossType.DS_NERF
-    """Depth loss type."""
+    """Depth loss type. Note that `PairPixelSampler` has to be used for `DepthLossType.SPARSENERF_RANKING`
+    to work as expected."""
 
 
 class DepthNerfactoModel(NerfactoModel):


### PR DESCRIPTION
The default pixel sampler for `depth-nerfacto` is `PairPixelSampler`. However, this is very slow due to mask erosion (so slow that it is basically unusable). I managed to speed it up a little here #3452. However, it is still much more efficient to use `PixelSampler`. Moreover, `PairPixelSampler` is only needed when using `SPARSENERF_RANKING` as the depth loss, but the default value is `DS_NERF`, which doesn't require `PairPixelSampler`. Hence, with the default depth loss, most people will be much better off with `PixelSampler` instead of `PairPixelSampler`.

I tested with both depth and masks using 50 images of resolution 1920x1440. Note, that `PairPixelSampler` is only slow when training with masks due to the need for mask erosion.

With `PairPixelSampler`:
![image](https://github.com/user-attachments/assets/9c92c9bf-452a-40b5-85da-bb3ab52a1819)

With `PixelSampler`:
![image](https://github.com/user-attachments/assets/dd12cb86-aeda-423f-8f12-46d1346a856e)

Closes #3446 
