### PR TITLE
Add option for refining the TSDF using the mesh's AABB

### DIFF
--- a/nerfstudio/exporter/tsdf_utils.py
+++ b/nerfstudio/exporter/tsdf_utils.py
@@ -285,6 +285,8 @@ def export_tsdf_mesh(
     use_bounding_box: bool = True,
     bounding_box_min: Tuple[float, float, float] = (-1.0, -1.0, -1.0),
     bounding_box_max: Tuple[float, float, float] = (1.0, 1.0, 1.0),
+    refine_mesh_using_initial_aabb_estimate: bool = False,
+    refinement_epsilon: float = 1e-2,
 ) -> None:
     """Export a TSDF mesh from a pipeline.
 
@@ -299,6 +301,9 @@ def export_tsdf_mesh(
         use_bounding_box: Whether to use a bounding box for the TSDF volume.
         bounding_box_min: Minimum coordinates of the bounding box.
         bounding_box_max: Maximum coordinates of the bounding box.
+        refine_mesh_using_initial_aabb_estimate: Whether to refine the TSDF using the initial AABB estimate.
+        refinement_epsilon: Epsilon for refining the TSDF. This is the distance in meters that the refined AABB/OBB will
+            be expanded by in each direction.
     """
 
     device = pipeline.device
@@ -356,5 +361,29 @@ def export_tsdf_mesh(
 
     CONSOLE.print("Computing Mesh")
     mesh = tsdf.get_mesh()
+
+    if refine_mesh_using_initial_aabb_estimate:
+        CONSOLE.print("Refining the TSDF based on the Mesh AABB")
+
+        # Compute the AABB of the mesh and use it to initialize a new TSDF
+        vertices_min = torch.min(mesh.vertices, dim=0).values - refinement_epsilon
+        vertices_max = torch.max(mesh.vertices, dim=0).values + refinement_epsilon
+        aabb = torch.stack([vertices_min, vertices_max]).cpu()
+        tsdf = TSDF.from_aabb(aabb, volume_dims=volume_dims)
+        # move TSDF to device
+        tsdf.to(device)
+
+        CONSOLE.print("Integrating the updated TSDF")
+        for i in range(0, len(c2w), batch_size):
+            tsdf.integrate_tsdf(
+                c2w[i : i + batch_size],
+                K[i : i + batch_size],
+                depth_images[i : i + batch_size],
+                color_images=color_images[i : i + batch_size],
+            )
+
+        CONSOLE.print("Computing the updated Mesh")
+        mesh = tsdf.get_mesh()
+
     CONSOLE.print("Saving TSDF Mesh")
     tsdf.export_mesh(mesh, filename=str(output_dir / "tsdf_mesh.ply"))

--- a/nerfstudio/scripts/exporter.py
+++ b/nerfstudio/scripts/exporter.py
@@ -218,6 +218,11 @@ class ExportTSDFMesh(Exporter):
     """If using xatlas for unwrapping, the pixels per side of the texture image."""
     target_num_faces: Optional[int] = 50000
     """Target number of faces for the mesh to texture."""
+    refine_mesh_using_initial_aabb_estimate: bool = False
+    """Refine the mesh using the initial AABB estimate."""
+    refinement_epsilon: float = 1e-2
+    """Refinement epsilon for the mesh. This is the distance in meters that the refined AABB/OBB will be expanded by
+    in each direction."""
 
     def main(self) -> None:
         """Export mesh"""
@@ -238,6 +243,8 @@ class ExportTSDFMesh(Exporter):
             use_bounding_box=self.use_bounding_box,
             bounding_box_min=self.bounding_box_min,
             bounding_box_max=self.bounding_box_max,
+            refine_mesh_using_initial_aabb_estimate=self.refine_mesh_using_initial_aabb_estimate,
+            refinement_epsilon=self.refinement_epsilon,
         )
 
         # possibly


### PR DESCRIPTION
I found the TSDF mesh quality to be highly dependent on the TSDF grid location and resolution. Currently, the user is responsible for providing a tight bounding box around the object to ensure good TSDF grid resolution in the areas of interest. However, this is often inconvenient and slow. It might also be hard to achieve when the NeRF is trained on a server for which the viewer isn't available.

In this PR, I suggest a simple solution for refining a rough bounding box estimate using the computed bounding box of the original mesh. In practice, I found this to lead to big improvements.

Note that this assumes that the density estimates are good enough to prevent floaters far from the object. I set the option to False by default, as this will be an issue if no special care is taken.

I trained `nerfacto` with alpha-transparent training on images of a mustard bottle:
```
ns-train nerfacto \
--pipeline.model.background_color "random" \
--pipeline.model.disable-scene-contraction True \
--data data
```

Exporting with rough estimate + no TSDF refinement:
```
ns-export tsdf --load-config outputs/.../config.yml \
--output-dir exports \
--num-pixels-per-side 2048 \
--resolution 250 250 250 \
--use-bounding-box True \
--bounding-box-min -.5 -.5 -.5 \
--bounding-box-max .5 .5 .5
```
![no_refinement01](https://github.com/user-attachments/assets/7889922e-6c50-4903-b3d9-2ae4b047f3e7)

Exporting with rough estimate + TSDF refinement:
```
ns-export tsdf --load-config outputs/.../config.yml \
--output-dir exports \
--num-pixels-per-side 2048 \
--resolution 250 250 250 \
--use-bounding-box True \
--bounding-box-min -.5 -.5 -.5 \
--bounding-box-max .5 .5 .5 \
--refine-mesh-using-initial-aabb-estimate True
```
![refined00](https://github.com/user-attachments/assets/7b3b1c1a-02e9-4ab9-92de-05372bde64db)

The refined mesh is much smoother.