### PR TITLE
Tag-exported-files

### DIFF
--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -650,8 +650,8 @@ class SplatfactoModel(Model):
         return image
 
     @staticmethod
-    def get_empty_outputs(camera, background):
-        rgb = background.repeat(int(camera.height.item()), int(camera.width.item()), 1)
+    def get_empty_outputs(width: int, height: int, background: torch.Tensor):
+        rgb = background.repeat(height, width, 1)
         depth = background.new_ones(*rgb.shape[:2], 1) * 10
         accumulation = background.new_zeros(*rgb.shape[:2], 1)
         return {"rgb": rgb, "depth": depth, "accumulation": accumulation, "background": background}
@@ -694,7 +694,7 @@ class SplatfactoModel(Model):
         if self.crop_box is not None and not self.training:
             crop_ids = self.crop_box.within(self.means).squeeze()
             if crop_ids.sum() == 0:
-                return self.get_empty_outputs(camera, background)
+                return self.get_empty_outputs(int(camera.width.item()), int(camera.height.item()), background)
         else:
             crop_ids = None
         camera_downscale = self._get_downscale_factor()
@@ -754,7 +754,7 @@ class SplatfactoModel(Model):
         camera.rescale_output_resolution(camera_downscale)
 
         if (self.radii).sum() == 0:
-            return self.get_empty_outputs(camera, background)
+            return self.get_empty_outputs(W, H, background)
 
         if self.config.sh_degree > 0:
             viewdirs = means_crop.detach() - optimized_camera_to_world.detach()[:3, 3]  # (N, 3)

--- a/nerfstudio/models/splatfacto.py
+++ b/nerfstudio/models/splatfacto.py
@@ -650,7 +650,7 @@ class SplatfactoModel(Model):
         return image
 
     @staticmethod
-    def get_empty_outputs(width: int, height: int, background: torch.Tensor):
+    def get_empty_outputs(width: int, height: int, background: torch.Tensor) -> Dict[str, Union[torch.Tensor, List]]:
         rgb = background.repeat(height, width, 1)
         depth = background.new_ones(*rgb.shape[:2], 1) * 10
         accumulation = background.new_zeros(*rgb.shape[:2], 1)

--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -16,12 +16,11 @@
 
 import json
 import xml.etree.ElementTree as ET
-import open3d as o3d
-import numpy as np
 from pathlib import Path
 from typing import Dict, List
 
 import numpy as np
+import open3d as o3d
 
 from nerfstudio.process_data.process_data_utils import CAMERA_MODELS
 from nerfstudio.utils.rich_utils import CONSOLE

--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -37,7 +37,7 @@ def metashape_to_json(
     image_filename_map: Dict[str, Path],
     xml_filename: Path,
     output_dir: Path,
-    ply_filename: Path = None, # type: ignore
+    ply_filename: Path = None,  # type: ignore
     verbose: bool = False,
 ) -> List[str]:
     """Convert Metashape data into a nerfstudio dataset.
@@ -190,7 +190,7 @@ def metashape_to_json(
         frames.append(frame)
 
     data["frames"] = frames
-    
+
     summary = []
 
     if isinstance(ply_filename, Path):

--- a/nerfstudio/process_data/metashape_utils.py
+++ b/nerfstudio/process_data/metashape_utils.py
@@ -200,6 +200,7 @@ def metashape_to_json(
     summary = []
 
     if ply_filename is not None:
+        assert ply_filename.exists()
         pc = o3d.io.read_point_cloud(str(ply_filename))
         points3D = np.asarray(pc.points)
         points3D = np.einsum("ij,bj->bi", applied_transform[:3, :3], points3D) + applied_transform[:3, 3]

--- a/nerfstudio/scripts/exporter.py
+++ b/nerfstudio/scripts/exporter.py
@@ -521,7 +521,7 @@ class ExportGaussianSplat(Exporter):
             # Write PLY header
             ply_file.write(b"ply\n")
             ply_file.write(b"format binary_little_endian 1.0\n")
-
+            ply_file.write(b"comment Written by Nerstudio\n")
             ply_file.write(f"element vertex {count}\n".encode())
 
             # Write properties, in order due to OrderedDict

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -491,7 +491,7 @@ class ProcessODM(BaseConverterToNerfstudioDataset):
 
 @dataclass
 class NotInstalled:
-    def main(self) -> None: 
+    def main(self) -> None:
         ...
 
 

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -347,7 +347,7 @@ class ProcessRealityCapture(BaseConverterToNerfstudioDataset, _NoDefaultProcessR
 
         if self.csv.suffix != ".csv":
             raise ValueError(f"CSV file {self.csv} must have a .csv extension")
-        if not self.csv.exists:
+        if not self.csv.exists():
             raise ValueError(f"CSV file {self.csv} doesn't exist")
         if self.eval_data is not None:
             raise ValueError("Cannot use eval_data since cameras were already aligned with RealityCapture.")
@@ -425,12 +425,12 @@ class ProcessODM(BaseConverterToNerfstudioDataset):
         shots_file = self.data / "odm_report" / "shots.geojson"
         reconstruction_file = self.data / "opensfm" / "reconstruction.json"
 
-        if not shots_file.exists:
+        if not shots_file.exists():
             raise ValueError(f"shots file {shots_file} doesn't exist")
-        if not shots_file.exists:
+        if not shots_file.exists():
             raise ValueError(f"cameras file {cameras_file} doesn't exist")
 
-        if not orig_images_dir.exists:
+        if not orig_images_dir.exists():
             raise ValueError(f"Images dir {orig_images_dir} doesn't exist")
 
         if self.eval_data is not None:

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -19,7 +19,7 @@ import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
 
 import numpy as np
 import tyro
@@ -221,9 +221,6 @@ class _NoDefaultProcessMetashape:
     xml: Path
     """Path to the Metashape xml file."""
 
-    ply: Path
-    """Path to the Metashape point export ply file."""
-
 
 @dataclass
 class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetashape):
@@ -240,6 +237,9 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
     1. Scales images to a specified size.
     2. Converts Metashape poses into the nerfstudio format.
     """
+
+    ply: Optional[Path] = None
+    """Path to the Metashape point export ply file."""
 
     num_downscales: int = 3
     """Number of times to downscale the images. Downscales by 2 each time. For example a value of 3
@@ -258,7 +258,7 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
         if self.eval_data is not None:
             raise ValueError("Cannot use eval_data since cameras were already aligned with Metashape.")
 
-        if isinstance(self.ply, Path):
+        if self.ply is not None:
             if self.ply.suffix != ".ply":
                 raise ValueError(f"PLY file {self.ply} must have a .ply extension")
             if not self.ply.exists:

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -253,7 +253,7 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
 
         if self.xml.suffix != ".xml":
             raise ValueError(f"XML file {self.xml} must have a .xml extension")
-        if not self.xml.exists:
+        if not self.xml.exists():
             raise ValueError(f"XML file {self.xml} doesn't exist")
         if self.eval_data is not None:
             raise ValueError("Cannot use eval_data since cameras were already aligned with Metashape.")
@@ -261,7 +261,7 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
         if self.ply is not None:
             if self.ply.suffix != ".ply":
                 raise ValueError(f"PLY file {self.ply} must have a .ply extension")
-            if not self.ply.exists:
+            if not self.ply.exists():
                 raise ValueError(f"PLY file {self.ply} doesn't exist")
 
         self.output_dir.mkdir(parents=True, exist_ok=True)

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -19,7 +19,7 @@ import sys
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Union, Optional
+from typing import Optional, Union
 
 import numpy as np
 import tyro

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -221,6 +221,9 @@ class _NoDefaultProcessMetashape:
 
     xml: Path
     """Path to the Metashape xml file."""
+    
+    ply: Path
+    """Path to the Metashape point export ply file."""
 
 
 @dataclass
@@ -229,6 +232,9 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
 
     This script assumes that cameras have been aligned using Metashape. After alignment, it is necessary to export the
     camera poses as a `.xml` file. This option can be found under `File > Export > Export Cameras`.
+
+    Additionally, the points can be exported as pointcloud under `File > Export > Export Point Cloud`. Make sure to
+    export the data in non-binary format and exclude the normals.
 
     This script does the following:
 
@@ -252,6 +258,12 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
             raise ValueError(f"XML file {self.xml} doesn't exist")
         if self.eval_data is not None:
             raise ValueError("Cannot use eval_data since cameras were already aligned with Metashape.")
+        
+        if isinstance(self.ply, Path):
+            if self.ply.suffix != ".ply":
+                raise ValueError(f"PLY file {self.ply} must have a .ply extension")
+            if not self.ply.exists:
+                raise ValueError(f"PLY file {self.ply} doesn't exist")
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
         image_dir = self.output_dir / "images"
@@ -291,6 +303,7 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
                 image_filename_map=image_filename_map,
                 xml_filename=self.xml,
                 output_dir=self.output_dir,
+                ply_filename=self.ply,
                 verbose=self.verbose,
             )
         )

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -15,7 +15,6 @@
 #!/usr/bin/env python
 """Processes a video or image sequence to a nerfstudio compatible dataset."""
 
-
 import sys
 import zipfile
 from dataclasses import dataclass
@@ -221,7 +220,7 @@ class _NoDefaultProcessMetashape:
 
     xml: Path
     """Path to the Metashape xml file."""
-    
+
     ply: Path
     """Path to the Metashape point export ply file."""
 
@@ -258,7 +257,7 @@ class ProcessMetashape(BaseConverterToNerfstudioDataset, _NoDefaultProcessMetash
             raise ValueError(f"XML file {self.xml} doesn't exist")
         if self.eval_data is not None:
             raise ValueError("Cannot use eval_data since cameras were already aligned with Metashape.")
-        
+
         if isinstance(self.ply, Path):
             if self.ply.suffix != ".ply":
                 raise ValueError(f"PLY file {self.ply} must have a .ply extension")
@@ -492,8 +491,7 @@ class ProcessODM(BaseConverterToNerfstudioDataset):
 
 @dataclass
 class NotInstalled:
-    def main(self) -> None:
-        ...
+    def main(self) -> None: ...
 
 
 Commands = Union[

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -491,7 +491,8 @@ class ProcessODM(BaseConverterToNerfstudioDataset):
 
 @dataclass
 class NotInstalled:
-    def main(self) -> None: ...
+    def main(self) -> None: 
+        ...
 
 
 Commands = Union[

--- a/nerfstudio/scripts/process_data.py
+++ b/nerfstudio/scripts/process_data.py
@@ -534,7 +534,7 @@ def entrypoint():
     tyro.extras.set_accent_color("bright_yellow")
     try:
         tyro.cli(Commands).main()
-    except RuntimeError as e:
+    except (RuntimeError, ValueError) as e:
         CONSOLE.log("[bold red]" + e.args[0])
 
 


### PR DESCRIPTION
I would like to write the keyword "Nerfstudio" into exported ply files so other software can compensate for the 90° rotation Nerfstudio applies to the data (it doesn't really matter what is the standard and what isn't. I is generally helpful, to have the possibility to know who wrote a file)