### PR TITLE
Load checkpoints with eval_setup from different folder from training

### DIFF
--- a/nerfstudio/utils/eval_utils.py
+++ b/nerfstudio/utils/eval_utils.py
@@ -99,7 +99,8 @@ def eval_setup(
 
     # load checkpoints from wherever they were saved
     # TODO: expose the ability to choose an arbitrary checkpoint
-    config.load_dir = config.get_checkpoint_dir()
+    # By using the parent of config_path, we can call this from any folder even if it wasn't originally trained from there
+    config.load_dir = config_path.parent / config.relative_model_dir
 
     # setup pipeline (which includes the DataManager)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
Previously, if one ran `ns-train` from a directory, then any call to `eval_setup` would have to be called from a directory where the relative layout of the outputs folder had to match training. I changed this to take into account the full path to the config.yml file in eval_setup so that it loads from folders not equivalent to the training folder.

For example, previously running this would fail:
```
ns-train ...
cd ..
ns-viewer --load-config nerfstudio/path/to/config.yml
```

There still needs to be some work to make data path agnostic to the running dir