### PR TITLE
Properly reset train state after render lock in viewer

### DIFF
--- a/nerfstudio/viewer/render_state_machine.py
+++ b/nerfstudio/viewer/render_state_machine.py
@@ -148,6 +148,7 @@ class RenderStateMachine(threading.Thread):
                         device=self.viewer.get_model().device,
                     )
                     self.viewer.get_model().set_background(background_color)
+                was_training = self.viewer.get_model().training
                 self.viewer.get_model().eval()
                 step = self.viewer.step
                 try:
@@ -168,9 +169,11 @@ class RenderStateMachine(threading.Thread):
                         with torch.no_grad(), viewer_utils.SetTrace(self.check_interrupt):
                             outputs = self.viewer.get_model().get_outputs_for_camera(camera, obb_box=obb)
                 except viewer_utils.IOChangeException:
-                    self.viewer.get_model().train()
+                    if was_training:
+                        self.viewer.get_model().train()
                     raise
-                self.viewer.get_model().train()
+                if was_training:
+                    self.viewer.get_model().train()
             num_rays = (camera.height * camera.width).item()
             if self.viewer.control_panel.layer_depth:
                 if isinstance(self.viewer.get_model(), SplatfactoModel):

--- a/nerfstudio/viewer/render_state_machine.py
+++ b/nerfstudio/viewer/render_state_machine.py
@@ -169,11 +169,10 @@ class RenderStateMachine(threading.Thread):
                         with torch.no_grad(), viewer_utils.SetTrace(self.check_interrupt):
                             outputs = self.viewer.get_model().get_outputs_for_camera(camera, obb_box=obb)
                 except viewer_utils.IOChangeException:
+                    raise
+                finally:
                     if was_training:
                         self.viewer.get_model().train()
-                    raise
-                if was_training:
-                    self.viewer.get_model().train()
             num_rays = (camera.height * camera.width).item()
             if self.viewer.control_panel.layer_depth:
                 if isinstance(self.viewer.get_model(), SplatfactoModel):


### PR DESCRIPTION
There were some crashes in the viewer when the training state was set back to train(), instead of keeping the prior state of the model.