### PR TITLE
Selection of the best colmap sparse model

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="nerfstudio" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="nerfstudio" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nerfstudio.iml" filepath="$PROJECT_DIR$/.idea/nerfstudio.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nerfstudio.iml
+++ b/.idea/nerfstudio.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -396,6 +396,7 @@ def colmap_to_json(
     ply_filename="sparse_pc.ply",
     keep_original_world_coordinate: bool = False,
     use_single_camera_mode: bool = True,
+    save_output = True
 ) -> int:
     """Converts COLMAP's cameras.bin and images.bin to a JSON file.
 
@@ -488,8 +489,9 @@ def colmap_to_json(
     )
     out["ply_file_path"] = ply_filename
 
-    with open(output_dir / "transforms.json", "w", encoding="utf-8") as f:
-        json.dump(out, f, indent=4)
+    if save_output:
+        with open(output_dir / "transforms.json", "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=4)
 
     return len(frames)
 


### PR DESCRIPTION
When using the "exhaustive" method to perform matching, COLMAP generates N sparse models, always trying to improve upon the previous result. By default, the original code always selects the first model ("colmap/sparse/0"), which is not always the best one. The modification proposes a scan of the "colmap/sparse" directory to locate all models, analyze the number of frames found in each one, and then save the "transforms.json" file based on the best model.

This PR will resolve some open issues.




