### PR TITLE
Selection of the best colmap sparse model

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="f1d567c2-831a-4cd1-95b7-6af4886f2347" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py" beforeDir="false" afterPath="$PROJECT_DIR$/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/nerfstudio/process_data/colmap_utils.py" beforeDir="false" afterPath="$PROJECT_DIR$/nerfstudio/process_data/colmap_utils.py" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.tslint": "(autodetect)"
+  }
+}]]></component>
+  <component name="TaskManager">
+    <servers />
+  </component>
+</project>

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -396,7 +396,7 @@ def colmap_to_json(
     ply_filename="sparse_pc.ply",
     keep_original_world_coordinate: bool = False,
     use_single_camera_mode: bool = True,
-    save_output: bool = True
+    save_output: bool = True,
 ) -> int:
     """Converts COLMAP's cameras.bin and images.bin to a JSON file.
 
@@ -411,6 +411,7 @@ def colmap_to_json(
                     Colmap optimized world often have y direction of the first camera pointing towards down direction,
                     while nerfstudio world set z direction to be up direction for viewer.
         save_output: If True, the output will be saved as a JSON file in the output directory.
+
     Returns:
         The number of registered images.
     """

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -396,6 +396,7 @@ def colmap_to_json(
     ply_filename="sparse_pc.ply",
     keep_original_world_coordinate: bool = False,
     use_single_camera_mode: bool = True,
+    save_output = True
 ) -> int:
     """Converts COLMAP's cameras.bin and images.bin to a JSON file.
 
@@ -488,8 +489,9 @@ def colmap_to_json(
     )
     out["ply_file_path"] = ply_filename
 
-    with open(output_dir / "transforms.json", "w", encoding="utf-8") as f:
-        json.dump(out, f, indent=4)
+    if save_output:
+        with open(output_dir / "transforms.json", "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=4)
 
     return len(frames)
 

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -396,7 +396,7 @@ def colmap_to_json(
     ply_filename="sparse_pc.ply",
     keep_original_world_coordinate: bool = False,
     use_single_camera_mode: bool = True,
-    save_output = True
+    save_output: bool = True
 ) -> int:
     """Converts COLMAP's cameras.bin and images.bin to a JSON file.
 
@@ -410,6 +410,7 @@ def colmap_to_json(
         keep_original_world_coordinate: If True, no extra transform will be applied to world coordinate.
                     Colmap optimized world often have y direction of the first camera pointing towards down direction,
                     while nerfstudio world set z direction to be up direction for viewer.
+        save_output: If True, the output will be saved as a JSON file in the output directory.
     Returns:
         The number of registered images.
     """


### PR DESCRIPTION
When using the "exhaustive" method to perform matching, COLMAP generates N sparse models, always trying to improve upon the previous result. By default, the original code always selects the best first model ("colmap/sparse/0"), which is not always the best one. The modification proposes a scan of the "colmap/sparse" directory to locate all models, analyze the number of frames found in each one, and then save the "transforms.json" file based on the best model.

This PR will resolve some opened issues.
