### PR TITLE
Selection of the best colmap sparse model

### DIFF
--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -14,12 +14,15 @@
 
 """Base class to processes a video or image sequence to a nerfstudio compatible dataset."""
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple
 
 from nerfstudio.process_data import colmap_utils, hloc_utils, process_data_utils
-from nerfstudio.process_data.base_converter_to_nerfstudio_dataset import BaseConverterToNerfstudioDataset
+from nerfstudio.process_data.base_converter_to_nerfstudio_dataset import (
+    BaseConverterToNerfstudioDataset,
+)
 from nerfstudio.process_data.process_data_utils import CAMERA_MODELS
 from nerfstudio.utils import install_checks
 from nerfstudio.utils.rich_utils import CONSOLE
@@ -29,7 +32,9 @@ from nerfstudio.utils.rich_utils import CONSOLE
 class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     """Base class to process images or video into a nerfstudio dataset using colmap"""
 
-    camera_type: Literal["perspective", "fisheye", "equirectangular", "pinhole", "simple_pinhole"] = "perspective"
+    camera_type: Literal[
+        "perspective", "fisheye", "equirectangular", "pinhole", "simple_pinhole"
+    ] = "perspective"
     """Camera model to use."""
     matching_method: Literal["exhaustive", "sequential", "vocab_tree"] = "vocab_tree"
     """Feature matching method to use. Vocab tree is recommended for a balance of speed
@@ -130,11 +135,35 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
             image_id_to_depth_path: When including sfm-based depth, embed these depth file paths in the exported json
             image_rename_map: Use these image names instead of the names embedded in the COLMAP db
         """
+
         summary_log = []
-        if (self.absolute_colmap_model_path / "cameras.bin").exists():
-            with CONSOLE.status("[bold yellow]Saving results to transforms.json", spinner="balloon"):
+        models_path = self.absolute_colmap_path.joinpath("sparse")
+        if os.path.exists(models_path):
+            matched_frame_counts = []
+            models = os.listdir(str(self.absolute_colmap_path.joinpath("sparse")))
+            for model in models:
+                if (models_path / model / "cameras.bin").exists():
+                    model_path = models_path / model
+                    num_matched_frames = colmap_utils.colmap_to_json(
+                        recon_dir=model_path,
+                        output_dir=self.output_dir,
+                        image_id_to_depth_path=image_id_to_depth_path,
+                        camera_mask_path=camera_mask_path,
+                        image_rename_map=image_rename_map,
+                        use_single_camera_mode=self.use_single_camera_mode,
+                        save_output=False,
+                    )
+                    matched_frame_counts.append(num_matched_frames)
+                else:
+                    matched_frame_counts.append(-1)
+
+            best_model_index = matched_frame_counts.index(max(matched_frame_counts))
+            best_model_path = models_path / models[best_model_index]
+            with CONSOLE.status(
+                "[bold yellow]Saving results to transforms.json", spinner="balloon"
+            ):
                 num_matched_frames = colmap_utils.colmap_to_json(
-                    recon_dir=self.absolute_colmap_model_path,
+                    recon_dir=best_model_path,
                     output_dir=self.output_dir,
                     image_id_to_depth_path=image_id_to_depth_path,
                     camera_mask_path=camera_mask_path,
@@ -142,11 +171,13 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                     use_single_camera_mode=self.use_single_camera_mode,
                 )
                 summary_log.append(f"Colmap matched {num_matched_frames} images")
-            summary_log.append(colmap_utils.get_matching_summary(num_frames, num_matched_frames))
-
+            summary_log.append(
+                colmap_utils.get_matching_summary(num_frames, num_matched_frames)
+            )
         else:
             CONSOLE.log(
-                "[bold yellow]Warning: Could not find existing COLMAP results. " "Not generating transforms.json"
+                "[bold yellow]Warning: Could not find existing COLMAP results. "
+                "Not generating transforms.json"
             )
         return summary_log
 
@@ -202,7 +233,9 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
 
         # check that sfm_tool is hloc if using use_single_camera_mode
         if not self.use_single_camera_mode:
-            assert sfm_tool == "hloc", "not_use_single_camera_mode only works with sfm_tool hloc"
+            assert (
+                sfm_tool == "hloc"
+            ), "not_use_single_camera_mode only works with sfm_tool hloc"
 
         # set the image_dir if didn't copy
         if self.skip_image_processing:
@@ -224,7 +257,10 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
             )
         elif sfm_tool == "hloc":
             if mask_path is not None:
-                raise RuntimeError("Cannot use a mask with hloc. Please remove the cropping options " "and try again.")
+                raise RuntimeError(
+                    "Cannot use a mask with hloc. Please remove the cropping options "
+                    "and try again."
+                )
 
             assert feature_type is not None
             assert matcher_type is not None
@@ -241,7 +277,10 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                 use_single_camera_mode=self.use_single_camera_mode,
             )
         else:
-            raise RuntimeError("Invalid combination of sfm_tool, feature_type, and matcher_type, " "exiting")
+            raise RuntimeError(
+                "Invalid combination of sfm_tool, feature_type, and matcher_type, "
+                "exiting"
+            )
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -60,7 +60,9 @@ def get_colmap_version(colmap_cmd: str, default_version: str = "3.8") -> Version
             version = line.split(" ")[1]
             version = Version(version)
             return version
-    CONSOLE.print(f"[bold red]Could not find COLMAP version. Using default {default_version}")
+    CONSOLE.print(
+        f"[bold red]Could not find COLMAP version. Using default {default_version}"
+    )
     return Version(default_version)
 
 
@@ -73,7 +75,9 @@ def get_vocab_tree() -> Path:
     vocab_tree_filename = Path(appdirs.user_data_dir("nerfstudio")) / "vocab_tree.fbow"
 
     if not vocab_tree_filename.exists():
-        r = requests.get("https://demuc.de/colmap/vocab_tree_flickr100K_words32K.bin", stream=True)
+        r = requests.get(
+            "https://demuc.de/colmap/vocab_tree_flickr100K_words32K.bin", stream=True
+        )
         vocab_tree_filename.parent.mkdir(parents=True, exist_ok=True)
         with open(vocab_tree_filename, "wb") as f:
             total_length = r.headers.get("content-length")
@@ -129,9 +133,15 @@ def run_colmap(
         f"--SiftExtraction.use_gpu {int(gpu)}",
     ]
     if camera_mask_path is not None:
-        feature_extractor_cmd.append(f"--ImageReader.camera_mask_path {camera_mask_path}")
+        feature_extractor_cmd.append(
+            f"--ImageReader.camera_mask_path {camera_mask_path}"
+        )
     feature_extractor_cmd = " ".join(feature_extractor_cmd)
-    with status(msg="[bold yellow]Running COLMAP feature extractor...", spinner="moon", verbose=verbose):
+    with status(
+        msg="[bold yellow]Running COLMAP feature extractor...",
+        spinner="moon",
+        verbose=verbose,
+    ):
         run_command(feature_extractor_cmd, verbose=verbose)
 
     CONSOLE.log("[bold green]:tada: Done extracting COLMAP features.")
@@ -144,9 +154,15 @@ def run_colmap(
     ]
     if matching_method == "vocab_tree":
         vocab_tree_filename = get_vocab_tree()
-        feature_matcher_cmd.append(f'--VocabTreeMatching.vocab_tree_path "{vocab_tree_filename}"')
+        feature_matcher_cmd.append(
+            f'--VocabTreeMatching.vocab_tree_path "{vocab_tree_filename}"'
+        )
     feature_matcher_cmd = " ".join(feature_matcher_cmd)
-    with status(msg="[bold yellow]Running COLMAP feature matcher...", spinner="runner", verbose=verbose):
+    with status(
+        msg="[bold yellow]Running COLMAP feature matcher...",
+        spinner="runner",
+        verbose=verbose,
+    ):
         run_command(feature_matcher_cmd, verbose=verbose)
     CONSOLE.log("[bold green]:tada: Done matching COLMAP features.")
 
@@ -173,7 +189,9 @@ def run_colmap(
     CONSOLE.log("[bold green]:tada: Done COLMAP bundle adjustment.")
 
     if refine_intrinsics:
-        with status(msg="[bold yellow]Refine intrinsics...", spinner="dqpb", verbose=verbose):
+        with status(
+            msg="[bold yellow]Refine intrinsics...", spinner="dqpb", verbose=verbose
+        ):
             bundle_adjuster_cmd = [
                 f"{colmap_cmd} bundle_adjuster",
                 f"--input_path {sparse_dir}/0",
@@ -396,6 +414,7 @@ def colmap_to_json(
     ply_filename="sparse_pc.ply",
     keep_original_world_coordinate: bool = False,
     use_single_camera_mode: bool = True,
+    save_output: bool = True,
 ) -> int:
     """Converts COLMAP's cameras.bin and images.bin to a JSON file.
 
@@ -409,6 +428,8 @@ def colmap_to_json(
         keep_original_world_coordinate: If True, no extra transform will be applied to world coordinate.
                     Colmap optimized world often have y direction of the first camera pointing towards down direction,
                     while nerfstudio world set z direction to be up direction for viewer.
+        save_output: If True, the output will be saved as a JSON file in the output directory.
+
     Returns:
         The number of registered images.
     """
@@ -420,7 +441,9 @@ def colmap_to_json(
     cam_id_to_camera = read_cameras_binary(recon_dir / "cameras.bin")
     im_id_to_image = read_images_binary(recon_dir / "images.bin")
     if set(cam_id_to_camera.keys()) != {1}:
-        CONSOLE.print(f"[bold yellow]Warning: More than one camera is found in {recon_dir}")
+        CONSOLE.print(
+            f"[bold yellow]Warning: More than one camera is found in {recon_dir}"
+        )
         print(cam_id_to_camera)
         use_single_camera_mode = False  # update bool: one camera per frame
         out = {}  # out = {"camera_model": parse_colmap_camera_params(cam_id_to_camera[1])["camera_model"]}
@@ -459,13 +482,19 @@ def colmap_to_json(
             "colmap_im_id": im_id,
         }
         if camera_mask_path is not None:
-            frame["mask_path"] = camera_mask_path.relative_to(camera_mask_path.parent.parent).as_posix()
+            frame["mask_path"] = camera_mask_path.relative_to(
+                camera_mask_path.parent.parent
+            ).as_posix()
         if image_id_to_depth_path is not None:
             depth_path = image_id_to_depth_path[im_id]
-            frame["depth_file_path"] = str(depth_path.relative_to(depth_path.parent.parent))
+            frame["depth_file_path"] = str(
+                depth_path.relative_to(depth_path.parent.parent)
+            )
 
         if not use_single_camera_mode:  # add the camera parameters for this frame
-            frame.update(parse_colmap_camera_params(cam_id_to_camera[im_data.camera_id]))
+            frame.update(
+                parse_colmap_camera_params(cam_id_to_camera[im_data.camera_id])
+            )
 
         frames.append(frame)
 
@@ -479,17 +508,22 @@ def colmap_to_json(
         out["applied_transform"] = applied_transform.tolist()
 
     # create ply from colmap
-    assert ply_filename.endswith(".ply"), f"ply_filename: {ply_filename} does not end with '.ply'"
+    assert ply_filename.endswith(
+        ".ply"
+    ), f"ply_filename: {ply_filename} does not end with '.ply'"
     create_ply_from_colmap(
         ply_filename,
         recon_dir,
         output_dir,
-        torch.from_numpy(applied_transform).float() if applied_transform is not None else None,
+        torch.from_numpy(applied_transform).float()
+        if applied_transform is not None
+        else None,
     )
     out["ply_file_path"] = ply_filename
 
-    with open(output_dir / "transforms.json", "w", encoding="utf-8") as f:
-        json.dump(out, f, indent=4)
+    if save_output:
+        with open(output_dir / "transforms.json", "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=4)
 
     return len(frames)
 
@@ -554,7 +588,9 @@ def create_sfm_depth(
 
     if verbose:
         iter_images = track(
-            im_id_to_image.items(), total=len(im_id_to_image.items()), description="Creating depth maps ..."
+            im_id_to_image.items(),
+            total=len(im_id_to_image.items()),
+            description="Creating depth maps ...",
         )
     else:
         iter_images = iter(im_id_to_image.items())
@@ -568,7 +604,13 @@ def create_sfm_depth(
         z = (rotation @ xyz_world.T)[-1] + im_data.tvec[-1]
         errors = np.array([ptid_to_info[pid].error for pid in pids])
         n_visible = np.array([len(ptid_to_info[pid].image_ids) for pid in pids])
-        uv = np.array([im_data.xys[i] for i in range(len(im_data.xys)) if im_data.point3D_ids[i] != -1])
+        uv = np.array(
+            [
+                im_data.xys[i]
+                for i in range(len(im_data.xys))
+                if im_data.point3D_ids[i] != -1
+            ]
+        )
         # TODO(1480) END delete when abandoning colmap_parsing_utils
 
         # TODO(1480) BEGIN use pycolmap API
@@ -623,11 +665,16 @@ def create_sfm_depth(
         image_id_to_depth_path[im_id] = depth_path
 
         if include_depth_debug:
-            assert input_images_dir is not None, "Need explicit input_images_dir for debug images"
+            assert (
+                input_images_dir is not None
+            ), "Need explicit input_images_dir for debug images"
             assert input_images_dir.exists(), input_images_dir
 
             depth_flat = depth.flatten()[:, None]
-            overlay = 255.0 * colormaps.apply_depth_colormap(torch.from_numpy(depth_flat)).numpy()
+            overlay = (
+                255.0
+                * colormaps.apply_depth_colormap(torch.from_numpy(depth_flat)).numpy()
+            )
             overlay = overlay.reshape([H, W, 3])
             input_image_path = input_images_dir / im_data.name
             input_image = cv2.imread(str(input_image_path))  # type: ignore
@@ -656,7 +703,9 @@ def get_matching_summary(num_initial_frames: int, num_matched_frames: int) -> st
         return "[bold green]COLMAP found poses for all images, CONGRATS!"
     if match_ratio < 0.4:
         result = f"[bold red]COLMAP only found poses for {num_matched_frames / num_initial_frames * 100:.2f}%"
-        result += " of the images. This is low.\nThis can be caused by a variety of reasons,"
+        result += (
+            " of the images. This is low.\nThis can be caused by a variety of reasons,"
+        )
         result += " such poor scene coverage, blurry images, or large exposure changes."
         return result
     if match_ratio < 0.8:
@@ -669,7 +718,10 @@ def get_matching_summary(num_initial_frames: int, num_matched_frames: int) -> st
 
 
 def create_ply_from_colmap(
-    filename: str, recon_dir: Path, output_dir: Path, applied_transform: Union[torch.Tensor, None]
+    filename: str,
+    recon_dir: Path,
+    output_dir: Path,
+    applied_transform: Union[torch.Tensor, None],
 ) -> None:
     """Writes a ply file from colmap.
 
@@ -686,13 +738,20 @@ def create_ply_from_colmap(
         raise ValueError(f"Could not find points3D.txt or points3D.bin in {recon_dir}")
 
     # Load point Positions
-    points3D = torch.from_numpy(np.array([p.xyz for p in colmap_points.values()], dtype=np.float32))
+    points3D = torch.from_numpy(
+        np.array([p.xyz for p in colmap_points.values()], dtype=np.float32)
+    )
     if applied_transform is not None:
         assert applied_transform.shape == (3, 4)
-        points3D = torch.einsum("ij,bj->bi", applied_transform[:3, :3], points3D) + applied_transform[:3, 3]
+        points3D = (
+            torch.einsum("ij,bj->bi", applied_transform[:3, :3], points3D)
+            + applied_transform[:3, 3]
+        )
 
     # Load point colours
-    points3D_rgb = torch.from_numpy(np.array([p.rgb for p in colmap_points.values()], dtype=np.uint8))
+    points3D_rgb = torch.from_numpy(
+        np.array([p.rgb for p in colmap_points.values()], dtype=np.uint8)
+    )
 
     # write ply
     with open(output_dir / filename, "w") as f:


### PR DESCRIPTION
When using the "exhaustive" method to perform matching, COLMAP generates N sparse models, always trying to improve upon the previous result. By default, the original code always selects the best first model ("colmap/sparse/0"), which is not always the best one. The modification proposes a scan of the "colmap/sparse" directory to locate all models, analyze the number of frames found in each one, and then save the "transforms.json" file based on the best model.

This PR will resolve some opened issues.