### PR TITLE
Selection of the best colmap sparse model

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="dfaf6746-5bcc-4bb9-9035-cd9c95061674" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py" beforeDir="false" afterPath="$PROJECT_DIR$/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/nerfstudio/process_data/colmap_utils.py" beforeDir="false" afterPath="$PROJECT_DIR$/nerfstudio/process_data/colmap_utils.py" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 2
+}]]></component>
+  <component name="ProjectId" id="2nvx1iZpW3e2On9h8me48LNpJDT" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "main",
+    "last_opened_file_path": "/home/luis/Documentos/GitHub/nerfstudio",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "yarn",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-5c90d61e3bab-JavaScript-PY-242.23339.19" />
+        <option value="bundled-python-sdk-0029f7779945-399fe30bd8c1-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-242.23339.19" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="dfaf6746-5bcc-4bb9-9035-cd9c95061674" name="Changes" comment="" />
+      <created>1729867137835</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1729867137835</updated>
+      <workItem from="1729867138855" duration="1063000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>


### PR DESCRIPTION
When using the "exhaustive" method to perform matching, COLMAP generates N sparse models, always trying to improve upon the previous result. By default, the original code always selects the best first model ("colmap/sparse/0"), which is not always the best one. The modification proposes a scan of the "colmap/sparse" directory to locate all models, analyze the number of frames found in each one, and then save the "transforms.json" file based on the best model.

This PR will resolve some open issues.