### PR TITLE
Selection of the best colmap sparse model

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="dfaf6746-5bcc-4bb9-9035-cd9c95061674" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py" beforeDir="false" afterPath="$PROJECT_DIR$/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/nerfstudio/process_data/colmap_utils.py" beforeDir="false" afterPath="$PROJECT_DIR$/nerfstudio/process_data/colmap_utils.py" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 2
+}]]></component>
+  <component name="ProjectId" id="2nvx1iZpW3e2On9h8me48LNpJDT" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "main",
+    "last_opened_file_path": "/home/luis/Documentos/GitHub/nerfstudio",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "yarn",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-5c90d61e3bab-JavaScript-PY-242.23339.19" />
+        <option value="bundled-python-sdk-0029f7779945-399fe30bd8c1-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-242.23339.19" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="dfaf6746-5bcc-4bb9-9035-cd9c95061674" name="Changes" comment="" />
+      <created>1729867137835</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1729867137835</updated>
+      <workItem from="1729867138855" duration="1063000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
+++ b/nerfstudio/process_data/colmap_converter_to_nerfstudio_dataset.py
@@ -19,10 +19,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple
 
-from nerfstudio.process_data import (colmap_utils, hloc_utils,
-                                     process_data_utils)
-from nerfstudio.process_data.base_converter_to_nerfstudio_dataset import \
-    BaseConverterToNerfstudioDataset
+from nerfstudio.process_data import colmap_utils, hloc_utils, process_data_utils
+from nerfstudio.process_data.base_converter_to_nerfstudio_dataset import BaseConverterToNerfstudioDataset
 from nerfstudio.process_data.process_data_utils import CAMERA_MODELS
 from nerfstudio.utils import install_checks
 from nerfstudio.utils.rich_utils import CONSOLE
@@ -32,9 +30,7 @@ from nerfstudio.utils.rich_utils import CONSOLE
 class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
     """Base class to process images or video into a nerfstudio dataset using colmap"""
 
-    camera_type: Literal[
-        "perspective", "fisheye", "equirectangular", "pinhole", "simple_pinhole"
-    ] = "perspective"
+    camera_type: Literal["perspective", "fisheye", "equirectangular", "pinhole", "simple_pinhole"] = "perspective"
     """Camera model to use."""
     matching_method: Literal["exhaustive", "sequential", "vocab_tree"] = "vocab_tree"
     """Feature matching method to use. Vocab tree is recommended for a balance of speed
@@ -159,9 +155,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
 
             best_model_index = matched_frame_counts.index(max(matched_frame_counts))
             best_model_path = models_path / models[best_model_index]
-            with CONSOLE.status(
-                "[bold yellow]Saving results to transforms.json", spinner="balloon"
-            ):
+            with CONSOLE.status("[bold yellow]Saving results to transforms.json", spinner="balloon"):
                 num_matched_frames = colmap_utils.colmap_to_json(
                     recon_dir=best_model_path,
                     output_dir=self.output_dir,
@@ -171,13 +165,10 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                     use_single_camera_mode=self.use_single_camera_mode,
                 )
                 summary_log.append(f"Colmap matched {num_matched_frames} images")
-            summary_log.append(
-                colmap_utils.get_matching_summary(num_frames, num_matched_frames)
-            )
+            summary_log.append(colmap_utils.get_matching_summary(num_frames, num_matched_frames))
         else:
             CONSOLE.log(
-                "[bold yellow]Warning: Could not find existing COLMAP results. "
-                "Not generating transforms.json"
+                "[bold yellow]Warning: Could not find existing COLMAP results. " "Not generating transforms.json"
             )
         return summary_log
 
@@ -233,9 +224,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
 
         # check that sfm_tool is hloc if using use_single_camera_mode
         if not self.use_single_camera_mode:
-            assert (
-                sfm_tool == "hloc"
-            ), "not_use_single_camera_mode only works with sfm_tool hloc"
+            assert sfm_tool == "hloc", "not_use_single_camera_mode only works with sfm_tool hloc"
 
         # set the image_dir if didn't copy
         if self.skip_image_processing:
@@ -257,10 +246,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
             )
         elif sfm_tool == "hloc":
             if mask_path is not None:
-                raise RuntimeError(
-                    "Cannot use a mask with hloc. Please remove the cropping options "
-                    "and try again."
-                )
+                raise RuntimeError("Cannot use a mask with hloc. Please remove the cropping options " "and try again.")
 
             assert feature_type is not None
             assert matcher_type is not None
@@ -277,10 +263,7 @@ class ColmapConverterToNerfstudioDataset(BaseConverterToNerfstudioDataset):
                 use_single_camera_mode=self.use_single_camera_mode,
             )
         else:
-            raise RuntimeError(
-                "Invalid combination of sfm_tool, feature_type, and matcher_type, "
-                "exiting"
-            )
+            raise RuntimeError("Invalid combination of sfm_tool, feature_type, and matcher_type, " "exiting")
 
     def __post_init__(self) -> None:
         super().__post_init__()


### PR DESCRIPTION
When using the "exhaustive" method to perform matching, COLMAP generates N sparse models, always trying to improve upon the previous result. By default, the original code always selects the best first model ("colmap/sparse/0"), which is not always the best one. The modification proposes a scan of the "colmap/sparse" directory to locate all models, analyze the number of frames found in each one, and then save the "transforms.json" file based on the best model.

This PR will resolve some open issues.