### PR TITLE
fix: saving ckpt error when ckpt folder has some folder inside

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -478,8 +478,8 @@ class Trainer:
         )
         # possibly delete old checkpoints
         if self.config.save_only_latest_checkpoint:
-            # delete everything else in the checkpoint folder
-            for f in self.checkpoint_dir.glob("*"):
+            # delete every other checkpoint in the checkpoint folder
+            for f in self.checkpoint_dir.glob("*.ckpt"):
                 if f != ckpt_path:
                     f.unlink()
 


### PR DESCRIPTION
When `save_only_latest_checkpoint` is True, it tried to delete everything in the chekpoint folder before saving the latest checkpoint. 

Since it is supposed that the `nerfstudio_models` only has checkpoint **files** inside, when there are some other **customized saved folders** inside, there will be an error.

This change will list `*.ckpt` files only instead of everything (include folder) to be compared with latest checkpoint file before deleting.

Thanks for your consideration