### PR TITLE
Fix: `--crop-bottom` for equirect data

### DIFF
--- a/nerfstudio/process_data/equirect_utils.py
+++ b/nerfstudio/process_data/equirect_utils.py
@@ -158,7 +158,7 @@ def equirect2persp(img: torch.Tensor, fov: int, theta: int, phi: int, hd: int, w
     return remap_cubic(img, lon, lat, border_mode="wrap")
 
 
-def _crop_bottom(bound_arr: list, fov: int, crop_factor: float) -> List[float]:
+def _crop_top(bound_arr: list, fov: int, crop_factor: float) -> List[float]:
     """Returns a list of vertical bounds with the bottom cropped.
 
     Args:
@@ -184,7 +184,7 @@ def _crop_bottom(bound_arr: list, fov: int, crop_factor: float) -> List[float]:
     return bound_arr
 
 
-def _crop_top(bound_arr: list, fov: int, crop_factor: float) -> List[float]:
+def _crop_bottom(bound_arr: list, fov: int, crop_factor: float) -> List[float]:
     """Returns a list of vertical bounds with the top cropped.
 
     Args:


### PR DESCRIPTION
I am trying to process an equirect video using `--crop-bottom=0.2` to remove myself from the bottom portion of the frames.

```bash
ns-process-data video \
    --camera-type equirectangular \
    --images-per-equirect 8 \
    --crop-bottom 0.2 \
    ...
```

Example frame:

![frame_00001](https://github.com/user-attachments/assets/8f6de927-b5df-44f1-a74a-c83b73736055)

However, I get training images that include my body:

![frame_00002_2](https://github.com/user-attachments/assets/081b233c-0aeb-4a9e-b1bd-3e055938fdc5)

I was able to identify an error in this function: https://github.com/nerfstudio-project/nerfstudio/blob/6b60855003011b2ca23c2fe3f8e2ca6314c69924/nerfstudio/process_data/equirect_utils.py#L213-L230
`bound_arr` is initially the array `[-45, 0, 45]`, which means that it will generate perspective training images using 120 deg FoV cameras pointed at altitudes -45, 0, and 45 degrees. However, with `--crop-bottom=0.2` we end up with `bound_arr == [-57.75, -25.5, -6.0]` at the end of the function, which is not what we want.

Doing the math a little bit, I discovered that it is likely that the implementations for `_crop_top()` and `_crop_bottom()` were accidentally swapped, as once i made this change, I ended up with `bound_arr == [6.0, 25.5, 57.75]` which is more correct. Indeed, a +6 degree altitude is the minimum value for excluding the bottom 20% of the equirect for a 120 deg FoV perspective camera. This is the new training image created:

![frame_00003](https://github.com/user-attachments/assets/d69b4218-ace3-431a-892e-143d0e1466fb)

Additional notes:
- Using `--crop-factor 0.2 0 0 0` (i.e. crop top 20%) now correctly gives `bound_arr == [-57.75, -25.5, -6.0]`
- I think the implementation is inherently incorrect, since using `--crop-factor 0.1 0.1 0 0` (i.e. crop top and bottom 10%) gives `bound_arr == [-22.3125, -4.125, 12.0]`, where all altitudes should actually be between -12 and 12 degrees. But that is work for another PR (which I am happy to do!)
