### PR TITLE
Fix: number of iterations wasn't set correctly (num_iterations directly set to equal to max_num_iterations)

### DIFF
--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -240,7 +240,7 @@ class Trainer:
 
         self._init_viewer_state()
         with TimeWriter(writer, EventName.TOTAL_TRAIN_TIME):
-            num_iterations = self.config.max_num_iterations
+            num_iterations = self.config.max_num_iterations - self._start_step
             step = 0
             self.stop_training = False
             for step in range(self._start_step, self._start_step + num_iterations):


### PR DESCRIPTION
The original code causes iteration to go over max_num_iterations, causing the progress tracker to be unable to estimate the time needed to finish, and causing unwanted extra iterations. Issue happens when pre-trained checkpoints are loaded.