### PR TITLE
Drop support for Python 3.8, suggest 3.10 by default

### DIFF
--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -5,16 +5,16 @@
 ::::::{tab-set}
 :::::{tab-item} Linux
 
-Nerfstudio requires `python >= 3.8`. We recommend using conda to manage dependencies. Make sure to install [Conda](https://docs.conda.io/en/latest/miniconda.html) before proceeding.
+Nerfstudio requires `python >= 3.9`. We recommend using conda to manage dependencies. Make sure to install [Conda](https://docs.conda.io/en/latest/miniconda.html) before proceeding.
 
 :::::
 :::::{tab-item} Windows
 
 :::{admonition} Note
 :class: info
-Nerfstudio on Windows is less tested and more fragile, due to way more moving parts outside of Nerfstudio's control.  
-The instructions also tend to break over time as updates to different Windows packages happen.  
-Installing Nerfstudio on Linux instead is recommended if you have the option.  
+Nerfstudio on Windows is less tested and more fragile, due to way more moving parts outside of Nerfstudio's control.
+The instructions also tend to break over time as updates to different Windows packages happen.
+Installing Nerfstudio on Linux instead is recommended if you have the option.
 Alternatively, installing Nerfstudio under WSL2 (temporary unofficial guide [here](https://gist.github.com/SharkWipf/0a3fc1be3ea88b0c9640db6ce15b44b9), not guaranteed to work) is also an option, but this comes with its own set of caveats.
 :::
 
@@ -51,7 +51,7 @@ For example:
 When updating, or if you close your terminal before you finish the installation and run your first `splatfacto`, you have to re-do this environment activation step.
 :::
 
-Nerfstudio requires `python >= 3.8`. We recommend using conda to manage dependencies. Make sure to install [Conda](https://docs.conda.io/en/latest/miniconda.html) before proceeding.
+Nerfstudio requires `python >= 3.9`. We recommend using conda to manage dependencies. Make sure to install [Conda](https://docs.conda.io/en/latest/miniconda.html) before proceeding.
 
 :::::
 ::::::
@@ -59,7 +59,7 @@ Nerfstudio requires `python >= 3.8`. We recommend using conda to manage dependen
 ## Create environment
 
 ```bash
-conda create --name nerfstudio -y python=3.8
+conda create --name nerfstudio -y python=3.10
 conda activate nerfstudio
 python -m pip install --upgrade pip
 
@@ -184,7 +184,7 @@ TLDR for linux:
 curl -fsSL https://pixi.sh/install.sh | bash
 ```
 
-### Install Pixi Environmnent 
+### Install Pixi Environmnent
 After Pixi is installed, you can run
 ```bash
 git clone https://github.com/nerfstudio-project/nerfstudio.git
@@ -192,7 +192,7 @@ cd nerfstudio
 pixi run post-install
 pixi shell
 ```
-This will fetch the latest Nerfstudio code, install all enviroment dependencies including colmap, tinycudann and hloc, and then activate the pixi environment (similar to conda).  
+This will fetch the latest Nerfstudio code, install all enviroment dependencies including colmap, tinycudann and hloc, and then activate the pixi environment (similar to conda).
 From now on, each time you want to run Nerfstudio in a new shell, you have to navigate to the nerfstudio folder and run `pixi shell` again.
 
 You could also run
@@ -435,6 +435,6 @@ export PATH=$PATH:$CUDA_HOME/bin
 
 **Other errors**
 
-(Windows) A lot of errors on Windows can be caused by not having the Visual Studio environment loaded.  
-If you run into errors you can't figure out, please try re-activating the Visual Studio environment (as outlined at the top of the Windows instructions on this page) and try again.  
+(Windows) A lot of errors on Windows can be caused by not having the Visual Studio environment loaded.
+If you run into errors you can't figure out, please try re-activating the Visual Studio environment (as outlined at the top of the Windows instructions on this page) and try again.
 This activation only lasts within your current terminal session and does not extend to other terminals, but this should only be needed on first run and on updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.1.5"
 description = "All-in-one repository for state-of-the-art NeRFs"
 readme = "README.md"
 license = { text="Apache 2.0"}
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
@@ -39,9 +39,7 @@ dependencies = [
     "protobuf<=3.20.3,!=3.20.0",
     # TODO(1480) enable when pycolmap windows wheels are available
     # "pycolmap==0.3.0",
-    # TODO(3461) and external issue cnr-isti-vclab/PyMeshLab/issues/398: Unrestrict Windows version when it isn't broken anymore.
     "pymeshlab>=2022.2.post2; platform_machine != 'arm64' and platform_machine != 'aarch64'",
-    "pymeshlab<2023.12.post2; sys_platform == 'win32' and platform_machine != 'arm64' and platform_machine != 'aarch64'",
     "pyngrok>=5.1.0",
     "python-socketio>=5.7.1",
     "pyquaternion>=0.9.9",
@@ -162,7 +160,7 @@ reportMissingImports = "warning"
 reportMissingTypeStubs = false
 reportPrivateImportUsage = false
 
-pythonVersion = "3.8"
+pythonVersion = "3.10"
 pythonPlatform = "Linux"
 
 [tool.ruff]


### PR DESCRIPTION
Python 3.8 is officially EOL, and at least one Nerfstudio dependency does not work with Python 3.8 anymore (#3461).
I've been running Nerfstudio on Python 3.10 myself without problems (although I've only tested on Linux). I remember having had problems in the past with some dependencies not yet supporting 3.11/3.12, but I don't know if that's been solved already. 3.10 seemed like the safest bet to target.
If you want to target a different python version by default, by all means, I just picked 3.10 because I knew that worked for me.

Reverts #3474 as it is no longer needed after this.