### PR TITLE
Fix cli bug in high version of tyro

### DIFF
--- a/docs/developer_guides/new_methods.md
+++ b/docs/developer_guides/new_methods.md
@@ -83,7 +83,7 @@ The `NERFSTUDIO_METHOD_CONFIGS` environment variable additionally accepts a func
 ```python
 """my_method/my_config.py"""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from nerfstudio.engine.trainer import TrainerConfig
 from nerfstudio.plugins.types import MethodSpecification
 
@@ -95,7 +95,7 @@ def MyMethodFunc():
 
 @dataclass
 class MyMethodClass(MethodSpecification):
-    config: TrainerConfig = TrainerConfig(...)
+    config: TrainerConfig = field(default_factory=lambda: TrainerConfig(...))
     description: str = "Custom description"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
     "pre-commit==3.3.2",
     "pytest==7.1.2",
     "pytest-xdist==2.5.0",
-    "typeguard==2.13.3",
+    "typeguard==4.4.0",
     "ruff>=0.6.1",
     "sshconf==0.2.5",
     "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ dev = [
     "pre-commit==3.3.2",
     "pytest==7.1.2",
     "pytest-xdist==2.5.0",
-    "typeguard==4.4.0",
     "ruff>=0.6.1",
     "sshconf==0.2.5",
     "pycolmap>=0.3.0",  # NOTE: pycolmap==0.3.0 is not available on newer python versions
@@ -146,7 +145,7 @@ include = ["nerfstudio*"]
 "*" = ["*.cu", "*.json", "py.typed", "setup.bash", "setup.zsh"]
 
 [tool.pytest.ini_options]
-addopts = "-n=4 --typeguard-packages=nerfstudio --disable-warnings"
+addopts = "-n=4 --jaxtyping-packages=nerfstudio --disable-warnings"
 testpaths = [
     "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "av>=9.2.0",
     "comet_ml>=3.33.8",
     "cryptography>=38",
-    "tyro>=0.6.6,<=0.9.2",
+    "tyro>=0.9.8",
     "gdown>=4.6.0",
     "ninja>=1.10",
     "h5py>=2.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "av>=9.2.0",
     "comet_ml>=3.33.8",
     "cryptography>=38",
-    "tyro>=0.6.6",
+    "tyro>=0.6.6,<=0.9.2",
     "gdown>=4.6.0",
     "ninja>=1.10",
     "h5py>=2.9.0",

--- a/tests/plugins/test_registry.py
+++ b/tests/plugins/test_registry.py
@@ -20,10 +20,12 @@ else:
 
 @dataclass
 class TestConfigClass(MethodSpecification):
-    config: TrainerConfig = TrainerConfig(
-        method_name="test-method",
-        pipeline=VanillaPipelineConfig(),
-        optimizers={},
+    config: TrainerConfig = field(
+        default_factory=lambda: TrainerConfig(
+            method_name="test-method",
+            pipeline=VanillaPipelineConfig(),
+            optimizers={},
+        )
     )
     description: str = "Test description"
 


### PR DESCRIPTION
In higher version of tyro(>0.9.3), the cli cannot recognize the following config definition:

```python
"""Use the same proposal network. Otherwise use different ones."""
proposal_net_args_list: List[Dict] = field(
    default_factory=lambda: [
        {"hidden_dim": 16, "log2_hashmap_size": 17, "num_levels": 5, "max_res": 128, "use_linear": False},
        {"hidden_dim": 16, "log2_hashmap_size": 17, "num_levels": 5, "max_res": 256, "use_linear": False},
    ]
)
```

## Reproduction:
`ns-train nerfacto --pipeline.model.proposal-net-args-list.0.hidden-dim 1`
1. In `typo==0.9.2`:

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/b3d27c94-94cd-4258-a65e-77f580ae5b13" />

2. In `typo>0.9.2`:

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/00ba4cf5-a24b-4286-a3d0-fc90c4400ac2" />
