### PR TITLE
Fixing Assertion issues when exporting NeRFs to poisson meshes and pointclouds

### DIFF
--- a/nerfstudio/scripts/exporter.py
+++ b/nerfstudio/scripts/exporter.py
@@ -141,8 +141,9 @@ class ExportPointCloud(Exporter):
             pipeline.datamanager,
             (VanillaDataManager, ParallelDataManager),
         )
-        assert pipeline.datamanager.train_pixel_sampler is not None
-        pipeline.datamanager.train_pixel_sampler.num_rays_per_batch = self.num_rays_per_batch
+        if isinstance(pipeline.datamanager, VanillaDataManager):
+            assert pipeline.datamanager.train_pixel_sampler is not None
+            pipeline.datamanager.train_pixel_sampler.num_rays_per_batch = self.num_rays_per_batch
 
         # Whether the normals should be estimated based on the point cloud.
         estimate_normals = self.normal_method == "open3d"
@@ -329,8 +330,9 @@ class ExportPoissonMesh(Exporter):
             pipeline.datamanager,
             (VanillaDataManager, ParallelDataManager),
         )
-        assert pipeline.datamanager.train_pixel_sampler is not None
-        pipeline.datamanager.train_pixel_sampler.num_rays_per_batch = self.num_rays_per_batch
+        if isinstance(pipeline.datamanager, VanillaDataManager):
+            assert pipeline.datamanager.train_pixel_sampler is not None
+            pipeline.datamanager.train_pixel_sampler.num_rays_per_batch = self.num_rays_per_batch
 
         # Whether the normals should be estimated based on the point cloud.
         estimate_normals = self.normal_method == "open3d"


### PR DESCRIPTION
Since the [dataloading PR](https://github.com/nerfstudio-project/nerfstudio/pull/3216) moved the pixel sampling process outside of being a datamanager field and into RayBatchStream, some assertions that test this will fail. This PR double checks the datamanager type before performing assertions when using `ns-export pointcloud` or `ns-export poisson` 

This addresses issues such as https://github.com/nerfstudio-project/nerfstudio/issues/3586