### PR TITLE
Fix seams/gaps when exporting mesh using marching cubes Fixes #2721

### DIFF
--- a/nerfstudio/exporter/marching_cubes.py
+++ b/nerfstudio/exporter/marching_cubes.py
@@ -251,4 +251,5 @@ def generate_mesh_with_multires_marching_cubes(
                     meshes.append(meshcrop)
 
     combined_mesh: trimesh.Trimesh = trimesh.util.concatenate(meshes)  # type: ignore
+    combined_mesh.merge_vertices(merge_tex=True, merge_norm=True)
     return combined_mesh


### PR DESCRIPTION
After concatenating the meshes it is necessary to merge the vertices at the seams so that the following simplification doesn't treat the separately.