### PR TITLE
Clamp values to prevent overshooting artifacts during image extraction with ns-process 

### DIFF
--- a/nerfstudio/process_data/equirect_utils.py
+++ b/nerfstudio/process_data/equirect_utils.py
@@ -80,7 +80,10 @@ def remap_cubic(
 
     grid = torch.stack((grid_x, grid_y), dim=-1).unsqueeze(0).expand(batch_size, -1, -1, -1)
 
-    return torch.nn.functional.grid_sample(img, grid, mode="bicubic", padding_mode="zeros")
+    result = torch.nn.functional.grid_sample(img, grid, mode="bicubic", padding_mode="zeros")
+    
+    # Clamp the output to the valid range [0, 1] to prevent artifacts due to overshooting
+    return torch.clamp(result, 0.0, 1.0)
 
 
 def equirect2persp(img: torch.Tensor, fov: int, theta: int, phi: int, hd: int, wd: int) -> torch.Tensor:


### PR DESCRIPTION
Hello,

I noticed during conversion from equirectangular 360 camera image frames that there would be quite a lot of visible artifacts when inspecting the images. This usually occurs near edges when there's a lot of very high or very low contrast, causing apparent overshoots of the pixels. See image below;

Before code change:
![image](https://github.com/user-attachments/assets/1d48898c-067e-427f-a4c0-c873601c674c)

After code change:
![image](https://github.com/user-attachments/assets/c26432bd-d3fc-412d-b0b3-c6df7622a587)
