### PR TITLE
fix: remove safeguards for parsing colmap data

### DIFF
--- a/nerfstudio/data/dataparsers/colmap_dataparser.py
+++ b/nerfstudio/data/dataparsers/colmap_dataparser.py
@@ -276,12 +276,6 @@ class ColmapDataParser(DataParser):
             cy.append(float(frame["cy"]))
             height.append(int(frame["h"]))
             width.append(int(frame["w"]))
-            if any([k in frame and float(frame[k]) != 0.0 for k in ["k4", "k5", "k6"]]):
-                raise ValueError(
-                    "K4/K5/K6 is non-zero! Note that Nerfstudio camera model's K4 has different meaning than colmap "
-                    "OPENCV camera model K4. Nerfstudio's K4 is the 4-th order of radial distortion coefficient, while "
-                    "colmap/OPENCV's K4 is 4-th coefficient in fractional radial distortion model."
-                )
             distort.append(
                 camera_utils.get_distortion_params(
                     k1=float(frame["k1"]) if "k1" in frame else 0.0,


### PR DESCRIPTION
Fix #3611. The safeguards introduced in #3381 makes datasets with non-zero k4 coefficient such as fisheye unusable. When reading camera distortion coefficients such as [OPENCV camera](https://github.com/nerfstudio-project/nerfstudio/blob/73fe54dda0b743616854fc839889d955522e0e68/nerfstudio/process_data/colmap_utils.py#L262C2-L278C42), k4 is correctly assigned as the fourth-order radial distortion coefficient rather than the fourth coefficient. Therefore, the safeguards can be removed.