### PR TITLE
Fix edit of default values

### DIFF
--- a/nerfstudio/data/datamanagers/base_datamanager.py
+++ b/nerfstudio/data/datamanagers/base_datamanager.py
@@ -381,7 +381,7 @@ class VanillaDataManager(DataManager, Generic[TDataset]):
 
         self.train_dataset = self.create_train_dataset()
         self.eval_dataset = self.create_eval_dataset()
-        self.exclude_batch_keys_from_device = self.train_dataset.exclude_batch_keys_from_device
+        self.exclude_batch_keys_from_device = list(self.train_dataset.exclude_batch_keys_from_device)
         if self.config.masks_on_gpu is True and "mask" in self.exclude_batch_keys_from_device:
             self.exclude_batch_keys_from_device.remove("mask")
         if self.config.images_on_gpu is True and "image" in self.exclude_batch_keys_from_device:

--- a/nerfstudio/data/datamanagers/parallel_datamanager.py
+++ b/nerfstudio/data/datamanagers/parallel_datamanager.py
@@ -108,7 +108,7 @@ class ParallelDataManager(DataManager, Generic[TDataset]):
         self.train_dataparser_outputs: DataparserOutputs = self.dataparser.get_dataparser_outputs(split="train")
         self.train_dataset = self.create_train_dataset()
         self.eval_dataset = self.create_eval_dataset()
-        self.exclude_batch_keys_from_device = self.train_dataset.exclude_batch_keys_from_device
+        self.exclude_batch_keys_from_device = list(self.train_dataset.exclude_batch_keys_from_device)
         if self.config.masks_on_gpu is True and "mask" in self.exclude_batch_keys_from_device:
             self.exclude_batch_keys_from_device.remove("mask")
         if self.config.images_on_gpu is True and "image" in self.exclude_batch_keys_from_device:


### PR DESCRIPTION
Fixed instantiation of VanillaDataManager and ParallelDataManager to avoid modifying the default values of exclude_batch_keys_from_device from InputDataset.

In previous implementation, if masks_on_gpu is true, values are removed from the array. However, the variable contains a reference to the default array in InputDataset. Therefore, the default array is modified, and next instantiations of any InputDataset will have a truncated array without the removed value. Next VanillaDataManager or ParallelDataManager instantiation will then fail to remove the value from the array (because the array does not have it anymore) and will raise an exception aborting everything.

I initially encountered this bug on FullImageDatamanager on the current version of pip package, but the offending code have been removed on master. I have no clue if it was it a quick and dirty fix to this problem or if this code was useless to begin with. This bug is only exhibited when using directly the python API and chaining multiple process. In my case, it happended after calling the train.main method with the splatfacto config, then reloading this config in ExportGaussianSplat to save the ply file.