### PR TITLE
Add Scaffold-GS to methods

### DIFF
--- a/docs/nerfology/methods/index.md
+++ b/docs/nerfology/methods/index.md
@@ -49,6 +49,7 @@ The following methods are supported in nerfstudio:
     BioNeRF<bionerf.md>
     NeRFtoGSandBack<nerf2gs2nerf.md>
     OpenNeRF<opennerf.md>
+    Scaffold-GS<scaffold_gs.md>
 ```
 
 (own_method_docs)=

--- a/docs/nerfology/methods/scaffold_gs.md
+++ b/docs/nerfology/methods/scaffold_gs.md
@@ -1,0 +1,38 @@
+# Scaffold-GS
+
+<h4>Unofficial implementation of "Scaffold-GS: Structured 3D Gaussians for View-Adaptive Rendering"</h4>
+
+```{button-link} https://city-super.github.io/scaffold-gs/
+:color: primary
+:outline:
+Paper Website
+```
+```{button-link} https://github.com/brian-xu/scaffold-gs-nerfstudio
+:color: primary
+:outline:
+Code
+```
+
+<video id="teaser" muted autoplay playsinline loop controls width="100%">
+    <source id="mp4" src="https://www.brian-xu.com/content/scaffold_gs_teaser.mp4" type="video/mp4">
+</video>
+
+
+### Installation
+Ensure that nerfstudio has been installed according to the instructions. Then run the following command:
+```
+pip install git+https://github.com/brian-xu/scaffold-gs-nerfstudio
+```
+You must also install the correct torch_scatter for your environment (https://pytorch-geometric.com/whl/torch-2.1.2%2Bcu118.html).
+
+
+### Running Model
+
+This repository creates a new Nerfstudio method named "scaffold-gs". To train with it, run the command:
+
+```bash
+ns-train scaffold-gs --data [PATH]
+```
+
+## Overview
+Scaffold-GS replaces the Gaussian kernel described in [3D Gaussian Splatting](https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/) with neural Gaussians that are bound to anchor points. During rasterization, the attributes (opacity, color, scale, rotation) of these neural Gaussians are calculated with respect to the viewing direction and distance. This view-adaptive rendering improves results in challenging conditions, such as texture-less areas, insufficient observations, fine-scale details, view-dependent light effects and multi-scale observations.

--- a/nerfstudio/configs/external_methods.py
+++ b/nerfstudio/configs/external_methods.py
@@ -298,6 +298,21 @@ To enable Splatfacto-W, you must install it first by running:
     )
 )
 
+# Scaffold-GS
+external_methods.append(
+    ExternalMethod(
+        """[bold yellow]Scaffold-GS[/bold yellow]
+            For more information visit: https://docs.nerf.studio/nerfology/methods/scaffold_gs.html
+
+            To enable Scaffold-GS, you must install it first by running:
+            [grey]pip install git+https://github.com/brian-xu/scaffold-gs-nerfstudio"[/grey]""",
+        configurations=[
+            ("scaffold-gs", "Scaffold-GS: Structured 3D Gaussians for View-Adaptive Rendering"),
+        ],
+        pip_package="git+https://github.com/brian-xu/scaffold-gs-nerfstudio",
+    )
+)
+
 
 @dataclass
 class ExternalMethodDummyTrainerConfig:


### PR DESCRIPTION
Adds an implementation of [Scaffold-GS](https://github.com/brian-xu/scaffold-gs-nerfstudio) to the docs.

This project is a little ambitious and also includes 2 other methods: GSDF, an extension of Scaffold-GS, and a port of NeuS-acc from SDFStudio. Those two methods aren't completely done yet, but I won't have time to work on them for a while so I figured I should release Scaffold-GS first.