### PR TITLE
Updating github actions cache version

### DIFF
--- a/.github/workflows/core_code_checks.yml
+++ b/.github/workflows/core_code_checks.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8.13'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}


### PR DESCRIPTION
**Background**
- Since February 1st 2025, the github actions for Nerfstudio has been broken as the current version of the cache service has been completely [deprecated](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down). More information here: 
https://github.com/actions/cache/discussions/1510

**Overview of Changes**
- One line change from v2 to v3