### PR TITLE
Add support for setting WandB Entity via experiment config

### DIFF
--- a/nerfstudio/configs/experiment_config.py
+++ b/nerfstudio/configs/experiment_config.py
@@ -75,6 +75,8 @@ class ExperimentConfig(InstantiateConfig):
     """Relative path to save all checkpoints."""
     load_scheduler: bool = True
     """Whether to load the scheduler state_dict to resume training, if it exists."""
+    entity_name: Optional[str] = None
+    """WandB entity name. If None, will use the default entity name set in WandB config."""
 
     def is_viewer_legacy_enabled(self) -> bool:
         """Checks if the legacy viewer is enabled."""

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -213,6 +213,7 @@ class Trainer:
             log_dir=writer_log_path,
             experiment_name=self.config.experiment_name,
             project_name=self.config.project_name,
+            entity_name=self.config.entity_name,
         )
         writer.setup_local_writer(
             self.config.logging, max_iter=self.config.max_num_iterations, banner_messages=banner_messages

--- a/nerfstudio/utils/writer.py
+++ b/nerfstudio/utils/writer.py
@@ -207,6 +207,7 @@ def setup_event_writer(
     log_dir: Path,
     experiment_name: str,
     project_name: str = "nerfstudio-project",
+    entity_name: str = None,
 ) -> None:
     """Initialization of all event writers specified in config
     Args:
@@ -221,7 +222,7 @@ def setup_event_writer(
         EVENT_WRITERS.append(curr_writer)
         using_event_writer = True
     if is_wandb_enabled:
-        curr_writer = WandbWriter(log_dir=log_dir, experiment_name=experiment_name, project_name=project_name)
+        curr_writer = WandbWriter(log_dir=log_dir, experiment_name=experiment_name, project_name=project_name, entity_name=entity_name)
         EVENT_WRITERS.append(curr_writer)
         using_event_writer = True
     if is_tensorboard_enabled:
@@ -305,15 +306,20 @@ class TimeWriter:
 class WandbWriter(Writer):
     """WandDB Writer Class"""
 
-    def __init__(self, log_dir: Path, experiment_name: str, project_name: str = "nerfstudio-project"):
+    def __init__(self, log_dir: Path, experiment_name: str, project_name: str = "nerfstudio-project", entity_name: str = None):
         import wandb  # wandb is slow to import, so we only import it if we need it.
 
-        wandb.init(
-            project=os.environ.get("WANDB_PROJECT", project_name),
-            dir=os.environ.get("WANDB_DIR", str(log_dir)),
-            name=os.environ.get("WANDB_NAME", experiment_name),
-            reinit=True,
-        )
+        opt_args = {
+            "project": os.environ.get("WANDB_PROJECT", project_name),
+            "dir": os.environ.get("WANDB_DIR", str(log_dir)),
+            "name": os.environ.get("WANDB_NAME", experiment_name),
+            "reinit": True,
+        }
+
+        if entity_name is not None:
+            opt_args["entity"] = entity_name
+
+        wandb.init(**opt_args)
 
     def write_image(self, name: str, image: Float[Tensor, "H W C"], step: int) -> None:
         import wandb  # wandb is slow to import, so we only import it if we need it.

--- a/nerfstudio/utils/writer.py
+++ b/nerfstudio/utils/writer.py
@@ -317,7 +317,7 @@ class WandbWriter(Writer):
         }
 
         if entity_name is not None:
-            opt_args["entity"] = entity_name
+            opt_args["entity"] = os.environ.get("WANDB_ENTITY", entity_name)
 
         wandb.init(**opt_args)
 


### PR DESCRIPTION
This PR adds support for specifying the Weights & Biases (WandB) entity (team or organization) directly in the Nerfstudio experiment config.

## Why?
Currently, users must either:
- Rely on their default WandB entity, or
- Move runs manually to the correct entity after they have finished

This can be limiting when working across multiple teams or accounts. With this change, users can now explicitly set the WandB entity in the config, making it easier to log runs under different teams or organizations without needing to modify global environment settings.

## Notes
- The entity must already exist in WandB.
- If not specified, WandB will continue to fall back to the default entity (as it is currently), as defined in the user settings under “Default location to create new projects” > “Default team”.


As this is my first PR to Nerfstudio, so I’m happy to take any suggestions or feedback!