### PR TITLE
Clean | Remove `timm` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ dependencies = [
     "wandb>=0.13.3",
     "xatlas",
     "trimesh>=3.20.2",
-    "timm==0.6.7",
     "gsplat==1.4.0",
     "pytorch-msssim",
     "pathos",


### PR DESCRIPTION
I searched the codebase and found that timm is actually not used. It seems this dependency was introduced in the following PR: https://github.com/nerfstudio-project/nerfstudio/pull/2284. However, I couldn’t find any place where timm is actually referenced 🤔

One reason I’d like to remove this dependency is that I need to install another package that also requires timm, but with a much higher version, which leads to a version conflict.
