### PR TITLE
Update default download behavior for `ns-download-data nerfstudio` cmd

### DIFF
--- a/nerfstudio/scripts/downloads/download_data.py
+++ b/nerfstudio/scripts/downloads/download_data.py
@@ -189,7 +189,7 @@ class NerfstudioDownload(DatasetDownload):
     https://drive.google.com/drive/folders/19TV6kdVGcmg3cGZ1bNIUnBBMD-iQjRbG?usp=drive_link.
     """
 
-    capture_name: NerfstudioCaptureName = "bww_entrance"
+    capture_name: NerfstudioCaptureName = "nerfstudio-dataset"
 
     def download(self, save_dir: Path):
         """Download the nerfstudio dataset."""


### PR DESCRIPTION
Default to downloading the full Nerfstudio dataset rather than "bww_entrance", which isn't part of the official dataset