### PR TITLE
Deployment of issues and environment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN git clone https://github.com/colmap/colmap.git && \
 
 # Upgrade pip and install dependencies.
 # pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118 && \
-RUN pip install --no-cache-dir --upgrade pip 'setuptools<70.0.0' && \
+RUN pip install --no-cache-dir --upgrade pip==25.2 'setuptools<70.0.0' && \
     pip install --no-cache-dir torch==2.1.2+cu118 torchvision==0.16.2+cu118 'numpy<2.0.0' --extra-index-url https://download.pytorch.org/whl/cu118 && \
     git clone --branch master --recursive https://github.com/cvg/Hierarchical-Localization.git /opt/hloc && \
     cd /opt/hloc && git checkout v1.4 && python3.10 -m pip install --no-cache-dir . && cd ~ && \

--- a/nerfstudio/data/datamanagers/parallel_datamanager.py
+++ b/nerfstudio/data/datamanagers/parallel_datamanager.py
@@ -248,7 +248,7 @@ class ParallelDataManager(DataManager, Generic[TDataset]):
     def next_eval(self, step: int) -> Tuple[RayBundle, Dict]:
         """Returns the next batch of data from the eval dataloader."""
         self.eval_count += 1
-        ray_bundle, batch = next(self.iter_train_raybundles)[0]
+        ray_bundle, batch = next(self.iter_eval_raybundles)[0]
         ray_bundle = ray_bundle.to(self.device)
         batch = get_dict_to_torch(batch, self.device)
         return ray_bundle, batch

--- a/nerfstudio/data/utils/dataloaders.py
+++ b/nerfstudio/data/utils/dataloaders.py
@@ -281,6 +281,7 @@ def undistort_view(
         cy=torch.Tensor([[float(K[1, 2])]]),
         width=torch.Tensor([[image.shape[1]]]).to(torch.int32),
         height=torch.Tensor([[image.shape[0]]]).to(torch.int32),
+        metadata=camera.metadata,
     )
     return new_camera, data
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dev = [
     # NOTE: Disabling projectaria-tools because it doesn't have prebuilt windows wheels
     # Syntax comes from here: https://pip.pypa.io/en/stable/reference/requirement-specifiers/
     "projectaria-tools>=1.3.1; sys_platform != 'win32'",
-    "torch==2.7.1",
+    "torch>=2.1.2",
     "awscli==1.33.18"
 ]
 


### PR DESCRIPTION
deployment of issue: #3731 #3721 , correction to setup files
fix: pyporject.toml typo in torch version, undistort_view now passes metadata to new camera instance, paralleldatamanager now uses iter_eval_raybundles instead of iter_train_bundles, add a version specification in dockerfile to pass github tests