### PR TITLE
[Fix] _LazyError reads name-mangled __data via unmangled literal → AttributeError (#3751)

### DIFF
--- a/nerfstudio/utils/external.py
+++ b/nerfstudio/utils/external.py
@@ -17,22 +17,22 @@ import sys
 
 class _LazyError:
     def __init__(self, data):
-        self.__data = data  # pylint: disable=unused-private-member
+        self._data = data  # pylint: disable=unused-private-member
 
     class LazyErrorObj:
         def __init__(self, data):
-            self.__data = data  # pylint: disable=unused-private-member
+            self._data = data  # pylint: disable=unused-private-member
 
         def __call__(self, *args, **kwds):
-            name, exc = object.__getattribute__(self, "__data")
+            name, exc = object.__getattribute__(self, "_data")
             raise RuntimeError(f"Could not load package {name}.") from exc
 
         def __getattr__(self, __name: str):
-            name, exc = object.__getattribute__(self, "__data")
+            name, exc = object.__getattribute__(self, "_data")
             raise RuntimeError(f"Could not load package {name}") from exc
 
     def __getattr__(self, __name: str):
-        return _LazyError.LazyErrorObj(object.__getattribute__(self, "__data"))
+        return _LazyError.LazyErrorObj(object.__getattribute__(self, "_data"))
 
 
 TCNN_EXISTS = False


### PR DESCRIPTION
## Motivation

When an optional dependency such as `tinycudann` is not installed, touching the lazily-errored stand-in raises a confusing `AttributeError: __data` instead of the intended `RuntimeError("Could not load package tinycudann.")` (#3751 — e.g. `neus-facto` on SDFStudio data fails with `_LazyError object has no attribute __data`).

## Root cause

In `nerfstudio/utils/external.py`, `_LazyError` and its inner `LazyErrorObj` store the payload as `self.__data = data`. Inside a class, `self.__data` is name-mangled to `self._LazyError__data` / `self._LazyErrorObj__data`. But the `__call__`/`__getattr__` methods read it back via:

```python
object.__getattribute__(self, "__data")
```

That string literal `"__data"` is **not** name-mangled, so the attribute does not exist — hence `AttributeError` instead of the helpful `RuntimeError`.

## Modifications

`nerfstudio/utils/external.py`: store and read the payload under a consistent, non-mangled name `_data` (replace `self.__data` and the `object.__getattribute__(self, "__data")` lookups). This restores the intended "package not installed" error message.

## Duplicate-check

- Track A — scanned all open PRs (`pulls?state=open&per_page=100 --paginate`) for `3751` / `_LazyError` / `__data` → no references.
- Track B — issue #3751 has 0 comments and no in-progress claim.
