### PR TITLE
fix: coerce numpy scalars in colmap write_next_bytes for NumPy 2.x

### DIFF
--- a/nerfstudio/data/utils/colmap_parsing_utils.py
+++ b/nerfstudio/data/utils/colmap_parsing_utils.py
@@ -96,6 +96,11 @@ def write_next_bytes(fid, data, format_char_sequence, endian_character="<"):
     if isinstance(data, (list, tuple)):
         bytes = struct.pack(endian_character + format_char_sequence, *data)
     else:
+        # NumPy 2.x no longer implicitly converts a size-1 ndarray (or a NumPy
+        # scalar) to a Python scalar inside struct.pack, which raises
+        # "required argument is not a float/integer". Coerce explicitly.
+        if isinstance(data, (np.ndarray, np.generic)):
+            data = data.item()
         bytes = struct.pack(endian_character + format_char_sequence, data)
     fid.write(bytes)
 


### PR DESCRIPTION
## Problem

`build` CI (Core Tests) fails on current dependencies:

```
tests/process_data/test_process_images.py::test_process_images_skip_colmap
tests/process_data/test_process_images.py::test_process_images_recursively_skip_colmap
...
struct.error: required argument is not a float
  nerfstudio/data/utils/colmap_parsing_utils.py:99 in write_next_bytes
```

NumPy 2.x no longer implicitly converts a size-1 `ndarray` (or a NumPy scalar) to a Python scalar inside `struct.pack`. So writing a COLMAP binary model where a field is a NumPy array (e.g. `Point3D.error = np.array([0])`) now raises.

## Fix

Coerce `ndarray`/`np.generic` to a Python scalar via `.item()` in the single-value branch of `write_next_bytes` before packing. One-line, no behavior change on Python scalars/lists/tuples.

## Testing

Reproduced the failing path against the real module and confirmed write + round-trip read now succeed:

```
write_points3D_binary OK -> 67 bytes
read back OK, ids: [1] error: 0.0
write_cameras_binary OK -> 112 bytes
```
