### PR TITLE
ci: build docs on Python 3.11 (fastjsonschema dropped 3.9)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.11.13'
       - name: Install dependencies
         run: |
           pip install uv


### PR DESCRIPTION
The `docs` job pins Python 3.9, but a transitive dep (`fastjsonschema`) now uses PEP 604 `dict | bool` syntax (invalid before 3.10), so `sphinx-build` errors at startup.

Bump the docs workflow to Python 3.11.13, matching `core_code_checks.yml`.
