### PR TITLE
Fix GPU SIFT flag names for COLMAP >=3.13

### DIFF
--- a/nerfstudio/process_data/colmap_utils.py
+++ b/nerfstudio/process_data/colmap_utils.py
@@ -115,6 +115,12 @@ def run_colmap(
     """
 
     colmap_version = get_colmap_version(colmap_cmd)
+    # COLMAP's #3465 (released in 3.13.0) renamed the use_gpu/gpu_index options from
+    # SiftExtraction/SiftMatching to FeatureExtraction/FeatureMatching as part of
+    # generalizing feature extraction beyond SIFT; the old names were dropped, not kept
+    # as aliases, so this must be version-gated rather than always using one or the other.
+    use_gpu_extraction_prefix = "FeatureExtraction" if colmap_version >= Version("3.13") else "SiftExtraction"
+    use_gpu_matching_prefix = "FeatureMatching" if colmap_version >= Version("3.13") else "SiftMatching"
 
     colmap_database_path = colmap_dir / "database.db"
     colmap_database_path.unlink(missing_ok=True)
@@ -126,7 +132,7 @@ def run_colmap(
         f"--image_path {image_dir}",
         "--ImageReader.single_camera 1",
         f"--ImageReader.camera_model {camera_model.value}",
-        f"--SiftExtraction.use_gpu {int(gpu)}",
+        f"--{use_gpu_extraction_prefix}.use_gpu {int(gpu)}",
     ]
     if camera_mask_path is not None:
         feature_extractor_cmd.append(f"--ImageReader.camera_mask_path {camera_mask_path}")
@@ -140,7 +146,7 @@ def run_colmap(
     feature_matcher_cmd = [
         f"{colmap_cmd} {matching_method}_matcher",
         f"--database_path {colmap_dir / 'database.db'}",
-        f"--SiftMatching.use_gpu {int(gpu)}",
+        f"--{use_gpu_matching_prefix}.use_gpu {int(gpu)}",
     ]
     if matching_method == "vocab_tree":
         vocab_tree_filename = get_vocab_tree()


### PR DESCRIPTION
## Summary

COLMAP's [#3465](https://github.com/colmap/colmap/pull/3465) (released in 3.13.0) renamed the `use_gpu`/`gpu_index` options from `SiftExtraction`/`SiftMatching` to `FeatureExtraction`/`FeatureMatching`, as part of generalizing feature extraction beyond SIFT. The old option names were dropped, not kept as aliases.

`nerfstudio/process_data/colmap_utils.py` still uses the old `--SiftExtraction.use_gpu`/`--SiftMatching.use_gpu` flags unconditionally. Against any COLMAP built from a recent enough source (>=3.13.0), `feature_extractor`/`*_matcher` reject these as unrecognized options, so `--gpu` silently has no effect (or the command errors, depending on COLMAP's exact CLI parsing behavior for unknown options).

Not specific to any particular GPU backend — this affects standard CUDA COLMAP builds too, once built from source at 3.13.0+. Found while validating a COLMAP fork built from a recent source tree, not something specific to that fork.

## Fix

Version-gates the flag prefix using the `colmap_version` value this file already computes via `get_colmap_version()`, following the same pattern already used a few lines below for a different version-dependent option (`if colmap_version >= Version("3.7")`).

## Test plan

- [x] Verified the version-gating logic across the 3.13 boundary (3.8 -> `SiftExtraction`, 3.13 -> `FeatureExtraction`, 4.2.0.dev0 -> `FeatureExtraction`)
- [x] Confirmed `--FeatureExtraction.use_gpu`/`--FeatureMatching.use_gpu` against a real COLMAP 4.2.0.dev0 build's `feature_extractor -h`/`*_matcher -h` output